### PR TITLE
Modularize the generation of LSP types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ A framework for writing [Language Server Protocol (LSP)](https://microsoft.githu
 The package currently includes
 
 - [x] [Type definitions](src/LSP/Protocol/Types.curry) for all LSP structures, enumerations and type aliases
-  - These are automatically generated from the [meta model](https://github.com/microsoft/vscode-languageserver-node/blob/main/protocol/metaModel.json)
+  - These are [auto-generated](src/LSP/Generation/Main.curry) from the [meta model](https://github.com/microsoft/vscode-languageserver-node/blob/main/protocol/metaModel.json)
 - [x] Support for encoding and decoding JSON-RPC calls
 - [x] A framework for writing language servers (partially implemented)
 - [ ] A framework for writing language clients
-
-> **Note:** The auto-generated types are currently around 6k lines of Curry code, which compiles to a ~280k line Haskell file. This means that compilation may take considerable time and memory.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "BSD-3-Clause",
   "licenseFile": "LICENSE",
   "dependencies": {
-    "abstract-curry": ">= 3.0.0, < 4.0.0",
     "containers": ">= 3.0.0, < 4.0.0",
     "directory": ">= 3.0.0, < 4.0.0",
     "json": ">= 3.0.0, < 4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "abstract-curry": ">= 3.0.0, < 4.0.0",
     "containers": ">= 3.0.0, < 4.0.0",
+    "directory": ">= 3.0.0, < 4.0.0",
     "json": ">= 3.0.0, < 4.0.0",
     "transformers": ">= 3.0.0, < 4.0.0"
   },

--- a/src/LSP/Generation/AbstractCurry/Build.curry
+++ b/src/LSP/Generation/AbstractCurry/Build.curry
@@ -18,7 +18,7 @@ infixr 9 ~>
 simpleCurryProg :: String -> [String] -> [CTypeDecl] -> [CFuncDecl] -> [COpDecl]
                 -> CurryProg
 simpleCurryProg name imps types funcs ops =
-  CurryProg name imps Nothing [] [] types funcs ops
+  CurryProg name [] imps Nothing [] [] types funcs ops
 
 ------------------------------------------------------------------------
 -- Goodies to construct type declarations

--- a/src/LSP/Generation/AbstractCurry/Build.curry
+++ b/src/LSP/Generation/AbstractCurry/Build.curry
@@ -1,0 +1,287 @@
+------------------------------------------------------------------------
+--- This library provides some useful operations to write programs
+--- that generate AbstractCurry programs in a more compact and readable way.
+---
+--- @version June 2023
+------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Build where
+
+import LSP.Generation.AbstractCurry.Types
+
+infixr 9 ~>
+
+------------------------------------------------------------------------
+-- Goodies to construct type declarations
+
+--- Constructs a simple `CurryProg` without type classes and instances.
+simpleCurryProg :: String -> [String] -> [CTypeDecl] -> [CFuncDecl] -> [COpDecl]
+                -> CurryProg
+simpleCurryProg name imps types funcs ops =
+  CurryProg name imps Nothing [] [] types funcs ops
+
+------------------------------------------------------------------------
+-- Goodies to construct type declarations
+
+--- Constructs a simple constructor declaration without quantified
+--- type variables and type class constraints.
+simpleCCons :: QName -> CVisibility -> [CTypeExpr] -> CConsDecl
+simpleCCons = CCons
+
+------------------------------------------------------------------------
+-- Goodies to construct type expressions
+
+--- A type application of a qualified type constructor name to a list of
+--- argument types.
+applyTC :: QName -> [CTypeExpr] -> CTypeExpr
+applyTC f es = foldl CTApply (CTCons f) es 
+
+--- A function type.
+(~>) :: CTypeExpr -> CTypeExpr -> CTypeExpr
+t1 ~> t2 = CFuncType t1 t2
+
+--- A base type.
+baseType :: QName -> CTypeExpr
+baseType t = CTCons t
+
+--- Constructs a list type from an element type.
+listType :: CTypeExpr -> CTypeExpr
+listType a = CTApply (CTCons (pre "[]")) a
+
+--- Constructs a tuple type from list of component types.
+tupleType :: [CTypeExpr] -> CTypeExpr
+tupleType ts
+ | l==0 = baseType (pre "()")
+ | l==1 = head ts
+ | otherwise = foldl CTApply
+                     (CTCons (pre ('(' : take (l-1) (repeat ',') ++ ")")))
+                     ts
+ where l = length ts
+
+--- Constructs an IO type from a type.
+ioType :: CTypeExpr -> CTypeExpr
+ioType a = CTApply (CTCons (pre "IO")) a
+
+--- Constructs a Maybe type from element type.
+maybeType :: CTypeExpr -> CTypeExpr
+maybeType a = CTApply (CTCons (pre "Maybe")) a
+
+--- The type expression of the String type.
+stringType :: CTypeExpr
+stringType = baseType (pre "String")
+
+--- The type expression of the Int type.
+intType :: CTypeExpr
+intType = baseType (pre "Int")
+
+--- The type expression of the Float type.
+floatType :: CTypeExpr
+floatType = baseType (pre "Float")
+
+--- The type expression of the Bool type.
+boolType :: CTypeExpr
+boolType = baseType (pre "Bool")
+
+--- The type expression of the Char type.
+charType :: CTypeExpr
+charType = baseType (pre "Char")
+
+--- The type expression of the unit type.
+unitType :: CTypeExpr
+unitType = baseType (pre "()")
+
+--- The type expression of the Time.CalendarTime type.
+dateType :: CTypeExpr
+dateType = baseType ("Time", "CalendarTime")
+
+--- A qualified type with empty class constraints.
+emptyClassType :: CTypeExpr -> CQualTypeExpr
+emptyClassType te = CQualType (CContext []) te
+
+------------------------------------------------------------------------
+-- Goodies to construct function declarations
+
+--- Constructs a function declaration from a given qualified function name,
+--- arity, visibility, type expression and list of defining rules.
+cfunc :: QName -> Int -> CVisibility -> CQualTypeExpr -> [CRule] -> CFuncDecl
+cfunc = CFunc
+
+--- Constructs a function declaration from a given comment,
+--- qualified function name,
+--- arity, visibility, type expression and list of defining rules.
+cmtfunc :: String -> QName -> Int -> CVisibility -> CQualTypeExpr -> [CRule]
+        -> CFuncDecl
+cmtfunc = CmtFunc
+
+-- Constructs a `CFunc` with simple (unqualified) type expression.
+stFunc :: QName -> Int -> CVisibility -> CTypeExpr -> [CRule] -> CFuncDecl
+stFunc name arity vis texp rs = cfunc name arity vis (emptyClassType texp) rs
+
+-- Constructs a `CmtFunc` with simple (unqualified) type expression.
+stCmtFunc :: String -> QName -> Int -> CVisibility -> CTypeExpr -> [CRule]
+          -> CFuncDecl
+stCmtFunc cm name arity vis texp rs =
+  cmtfunc cm name arity vis (emptyClassType texp) rs
+
+--- Constructs a simple rule with a pattern list and an
+--- unconditional right-hand side.
+simpleRule :: [CPattern] -> CExpr -> CRule
+simpleRule pats rhs = CRule pats (CSimpleRhs rhs [])
+
+--- Constructs a simple rule with a pattern list, an
+--- unconditional right-hand side, and local declarations.
+simpleRuleWithLocals :: [CPattern] -> CExpr -> [CLocalDecl] -> CRule
+simpleRuleWithLocals pats rhs ldecls = CRule pats (CSimpleRhs rhs ldecls)
+
+--- Constructs a rule with a possibly guarded right-hand side
+--- and local declarations.
+--- A simple right-hand side is constructed if there is only one
+--- `True` condition.
+guardedRule :: [CPattern] -> [(CExpr,CExpr)] -> [CLocalDecl] -> CRule
+guardedRule pats gs ldecls
+  | length gs == 1 && fst (head gs) == CSymbol (pre "True")
+              = CRule pats (CSimpleRhs (snd (head gs)) ldecls)
+  | otherwise = CRule pats (CGuardedRhs gs ldecls)
+
+--- Constructs a guarded expression with the trivial guard.
+noGuard :: CExpr -> (CExpr, CExpr)
+noGuard e = (CSymbol (pre "True"), e)
+
+--- Transforms an expression into a simple unconditional right-hand side.
+simpleRhs :: CExpr -> CRhs
+simpleRhs exp = CSimpleRhs exp []
+
+------------------------------------------------------------------------
+-- Goodies to construct expressions and patterns
+
+--- An application of a qualified function name to a list of arguments.
+applyF :: QName -> [CExpr] -> CExpr
+applyF f es = foldl CApply (CSymbol f) es 
+
+--- An application of an expression to a list of arguments.
+applyE :: CExpr -> [CExpr] -> CExpr
+applyE f args = foldl CApply f args
+
+--- A constant, i.e., an application without arguments.
+constF :: QName -> CExpr
+constF f = applyF f []
+
+--- An application of a variable to a list of arguments.
+applyV :: CVarIName -> [CExpr] -> CExpr
+applyV v es = foldl CApply (CVar v) es 
+
+-- Applies the Just constructor to an AbstractCurry expression.
+applyJust :: CExpr -> CExpr
+applyJust a = applyF (pre "Just") [a]
+
+-- Applies the maybe function to three AbstractCurry expressions.
+applyMaybe :: CExpr -> CExpr -> CExpr -> CExpr
+applyMaybe a1 a2 a3 = applyF (pre "maybe") [a1,a2,a3]
+
+--- Constructs a tuple expression from list of component expressions.
+tupleExpr :: [CExpr] -> CExpr
+tupleExpr es | l==0 = constF (pre "()")
+             | l==1 = head es
+             | otherwise = applyF (pre ('(' : take (l-1) (repeat ',') ++ ")"))
+                                  es
+ where l = length es
+
+--- Constructs an if-then-else expression.
+ifThenElseExp :: CExpr -> CExpr -> CExpr -> CExpr
+ifThenElseExp bexp texp eexp = applyF (pre "if_then_else") [bexp, texp, eexp]
+
+--- Constructs a let declaration (with possibly empty local delcarations).
+letExpr :: [CLocalDecl] -> CExpr -> CExpr
+letExpr locals cexp = if null locals then cexp else CLetDecl locals cexp
+
+--- Constructs a typed expression from an expression and a simple type.
+simpleTyped :: CExpr -> CTypeExpr -> CExpr
+simpleTyped exp texp = CTyped exp (emptyClassType texp)
+
+--- Constructs a do expression. If the list of statements in the do expression
+--- contains a single expression, the do expression is transformed into
+--- a simple expression.
+doExpr :: [CStatement] -> CExpr
+doExpr stats = case stats of [CSExpr exp] -> exp
+                             _            -> CDoExpr stats
+
+--- Constructs from a pattern and an expression a branch for a case expression.
+cBranch :: CPattern -> CExpr -> (CPattern, CRhs)
+cBranch pattern exp = (pattern, CSimpleRhs exp [])
+
+--- Constructs a tuple pattern from list of component patterns.
+tuplePattern :: [CPattern] -> CPattern
+tuplePattern ps
+  | l==0 = CPComb (pre "()") []
+  | l==1 = head ps
+  | otherwise = CPComb (pre ('(' : take (l-1) (repeat ',') ++ ")")) ps
+ where l = length ps
+
+--- Constructs, for given n, a list of n PVars starting from 0.
+pVars :: Int -> [CPattern]
+pVars n = [CPVar (i,"x"++show i) | i<-[0..n-1]] 
+
+--- Converts an integer into an AbstractCurry expression.
+pInt :: Int -> CPattern
+pInt x = CPLit (CIntc x)
+
+--- Converts a float into an AbstractCurry expression.
+pFloat :: Float -> CPattern
+pFloat x = CPLit (CFloatc x)
+
+--- Converts a character into a pattern.
+pChar :: Char -> CPattern
+pChar x = CPLit (CCharc x)
+
+--- Constructs an empty list pattern.
+pNil :: CPattern
+pNil = CPComb (pre "[]") []
+
+--- Constructs a list pattern from list of component patterns.
+listPattern :: [CPattern] -> CPattern
+listPattern []     = pNil
+listPattern (p:ps) = CPComb (pre ":") [p, listPattern ps]
+
+--- Converts a string into a pattern representing this string.
+stringPattern :: String -> CPattern
+stringPattern = CPLit . CStringc
+
+--- Converts a list of AbstractCurry expressions into an
+--- AbstractCurry representation of this list.
+list2ac :: [CExpr] -> CExpr
+list2ac []     = constF (pre "[]")
+list2ac (c:cs) = applyF (pre ":") [c, list2ac cs]
+
+--- Converts an integer into an AbstractCurry expression.
+cInt :: Int -> CExpr
+cInt x = CLit (CIntc x)
+
+--- Converts a float into an AbstractCurry expression.
+cFloat :: Float -> CExpr
+cFloat x = CLit (CFloatc x)
+
+--- Converts a character into an AbstractCurry expression.
+cChar :: Char -> CExpr
+cChar x = CLit (CCharc x)
+
+--- Converts a string into an AbstractCurry represention of this string.  
+string2ac :: String -> CExpr
+string2ac s = CLit (CStringc s)
+
+--- Converts an index i into a variable named xi.
+toVar :: Int -> CExpr
+toVar i = CVar (1,"x"++show i)
+
+--- Converts a string into a variable with index 1.
+cvar :: String -> CExpr
+cvar s = CVar (1,s)
+
+--- Converts a string into a pattern variable with index 1.
+cpvar :: String -> CPattern
+cpvar s = CPVar (1,s)
+
+--- Converts a string into a type variable with index 1.
+ctvar :: String -> CTypeExpr
+ctvar s = CTVar (1,s)
+
+------------------------------------------------------------------------

--- a/src/LSP/Generation/AbstractCurry/Files.curry
+++ b/src/LSP/Generation/AbstractCurry/Files.curry
@@ -1,0 +1,238 @@
+-- ---------------------------------------------------------------------------
+--- This library defines various I/O actions to read Curry programs and
+--- transform them into the AbstractCurry representation and to write
+--- AbstractCurry files.
+---
+--- Assumption: an abstract Curry program is stored in file with
+--- extension `.acy` in the subdirectory `.curry`
+---
+--- @author Michael Hanus, Bjoern Peemoeller, Jan Tikovsky, Finn Teegen
+--- @version December 2018
+-- ---------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Files where
+
+import Data.Char            ( isSpace )
+import System.Directory     ( doesFileExist, getModificationTime
+                            , findFileWithSuffix, getFileWithSuffix )
+import System.FilePath      ( takeFileName, (</>), (<.>) )
+import System.CurryPath     ( getLoadPathForModule, inCurrySubdir
+                            , lookupModuleSourceInLoadPath, stripCurrySuffix )
+import System.FrontendExec
+import ReadShowTerm
+
+import LSP.Generation.AbstractCurry.Select ( imports )
+import LSP.Generation.AbstractCurry.Types
+
+-- ---------------------------------------------------------------------------
+--- I/O action which parses a Curry program and returns the corresponding
+--- typed Abstract Curry program.
+--- Thus, the argument is the file name without suffix ".curry"
+--- or ".lcurry") and the result is a Curry term representing this
+--- program.
+readCurry :: String -> IO CurryProg
+readCurry prog = readCurryWithParseOptions prog (setQuiet True defaultParams)
+
+--- Read an AbstractCurry file with all its imports.
+--- @param modname - Module name or file name of Curry module
+--- @return a list of curry programs, having the AbstractCurry file as head.
+readCurryWithImports :: String -> IO [CurryProg]
+readCurryWithImports modname = collect [] [modname]
+ where
+  collect _        []     = return []
+  collect imported (m:ms)
+    | m `elem` imported   = collect imported ms
+    | otherwise           = do
+      p <- readCurry m
+      ps <- collect (m:imported) (ms ++ imports p)
+      return (p:ps)
+
+tryReadCurryWithImports :: String -> IO (Either [String] [CurryProg])
+tryReadCurryWithImports modname = collect [] [modname]
+ where
+  collect _        []     = return (Right [])
+  collect imported (m:ms)
+    | m `elem` imported   = collect imported ms
+    | otherwise           = do
+      eProg <- tryReadCurryFile m
+      case eProg of
+        Left err                          -> return (Left [err])
+        Right prog@(CurryProg _ is _ _ _ _ _ _) -> do
+          results <- collect (m:imported) (ms ++ is)
+          return (either Left (Right . (prog :)) results)
+
+tryReadCurryFile :: String -> IO (Either String CurryProg)
+tryReadCurryFile m = do
+  mbSrc <- lookupModuleSourceInLoadPath m
+  case mbSrc of
+    Nothing      -> cancel $ "Source module '" ++ m ++ "' not found"
+    Just (_,srcFile) -> do
+      callFrontendWithParams ACY (setQuiet True defaultParams) m
+      mbFn <- getLoadPathForModule m >>=
+              findFileWithSuffix (abstractCurryFileName m) [""]
+      case mbFn of
+        Nothing -> cancel $ "AbstractCurry module '" ++ m ++ "' not found"
+        Just fn -> do
+          ctime <- getModificationTime srcFile
+          ftime <- getModificationTime fn
+          if ctime > ftime
+            then cancel $ "Source file '" ++ srcFile
+                    ++ "' is newer than AbstractCurry file '" ++ fn ++ "'"
+            else do
+              mbProg <- tryParse fn
+              case mbProg of
+                Left  err -> cancel err
+                Right p   -> return (Right p)
+ where cancel str = return (Left str)
+
+--- Try to parse an AbstractCurry file.
+--- @param fn  - file name of AbstractCurry file
+tryParse :: String -> IO (Either String CurryProg)
+tryParse fn = do
+  exists <- doesFileExist fn
+  if not exists
+    then cancel $ "AbstractCurry file '" ++ fn ++ "' does not exist"
+    else do
+      src <- readFile fn
+      let (line1, lines) = break (=='\n') src
+      if line1 /= "{- "++version++" -}"
+        then cancel $ "Could not parse AbstractCurry file '" ++ fn
+                   ++ "': incompatible versions"
+        else
+          case readsUnqualifiedTerm ["AbstractCurry.Types","Prelude"] lines of
+            [(p,tl)]  | all isSpace tl -> return (Right p)
+            _ -> cancel $ "Could not parse AbstractCurry file '" ++ fn
+                          ++ "': no parse"
+ where cancel str = return (Left str)
+
+--- I/O action which parses a Curry program and returns the corresponding
+--- untyped AbstractCurry program.
+--- The argument is the file name without suffix ".curry"
+--- or ".lcurry") and the result is a Curry term representing this
+--- program.
+--- In an untyped AbstractCurry program, the type signatures
+--- of operations are the type signatures provided by the programmer
+--- (and not the type signatures inferred by the front end).
+--- If the programmer has not provided an explicit type signature,
+--- the function declaration contains the type `(CTCons ("Prelude","untyped")`.
+readUntypedCurry :: String -> IO CurryProg
+readUntypedCurry prog =
+  readUntypedCurryWithParseOptions prog (setQuiet True defaultParams)
+
+--- I/O action which reads a typed Curry program from a file (with extension
+--- ".acy") with respect to some parser options.
+--- This I/O action is used by the standard action 'readCurry'.
+--- It is currently predefined only in Curry2Prolog.
+--- @param progfile - the program file name (without suffix ".curry")
+--- @param options - parameters passed to the front end
+
+readCurryWithParseOptions :: String -> FrontendParams -> IO CurryProg
+readCurryWithParseOptions progname options = do
+  let modname = takeFileName progname
+  mbsrc <- lookupModuleSourceInLoadPath progname
+  case mbsrc of
+    Nothing -> do -- no source file, try to find AbstractCurry file in load path:
+      loadpath <- getLoadPathForModule progname
+      filename <- getFileWithSuffix (abstractCurryFileName modname) [""] loadpath
+      readAbstractCurryFile filename
+    Just (dir,_) -> do
+      callFrontendWithParams ACY options progname
+      readAbstractCurryFile (abstractCurryFileName (dir </> modname))
+
+--- I/O action which reads an untyped Curry program from a file (with extension
+--- ".uacy") with respect to some parser options. For more details
+--- see function 'readCurryWithParseOptions'
+--- In an untyped AbstractCurry program, the type signatures
+--- of operations are the type signatures provided by the programmer
+--- (and not the type signatures inferred by the front end).
+--- If the programmer has not provided an explicit type signature,
+--- the function declaration contains the type `(CTCons ("Prelude","untyped")`.
+readUntypedCurryWithParseOptions :: String -> FrontendParams -> IO CurryProg
+readUntypedCurryWithParseOptions progname options = do
+  let modname = takeFileName progname
+  mbsrc <- lookupModuleSourceInLoadPath progname
+  case mbsrc of
+    Nothing -> do -- no source file, try to find AbstractCurry file in load path:
+      loadpath <- getLoadPathForModule progname
+      filename <- getFileWithSuffix (untypedAbstractCurryFileName modname) [""]
+                                loadpath
+      readAbstractCurryFile filename
+    Just (dir,_) -> do
+      callFrontendWithParams UACY options progname
+      readAbstractCurryFile (untypedAbstractCurryFileName (dir </> modname))
+
+--- Transforms a name of a Curry program (with or without suffix ".curry"
+--- or ".lcurry") into the name of the file containing the
+--- corresponding AbstractCurry program.
+abstractCurryFileName :: String -> String
+abstractCurryFileName prog = inCurrySubdir (stripCurrySuffix prog) <.> "acy"
+
+--- Transforms a name of a Curry program (with or without suffix ".curry"
+--- or ".lcurry") into the name of the file containing the
+--- corresponding untyped AbstractCurry program.
+untypedAbstractCurryFileName :: String -> String
+untypedAbstractCurryFileName prog =
+  inCurrySubdir (stripCurrySuffix prog) <.> "uacy"
+
+--- I/O action which reads an AbstractCurry program from a file in ".acy"
+--- format. In contrast to <CODE>readCurry</CODE>, this action does not parse
+--- a source program. Thus, the argument must be the name of an existing
+--- file (with suffix ".acy") containing an AbstractCurry program in ".acy"
+--- format and the result is a Curry term representing this program.
+--- It is currently predefined only in Curry2Prolog.
+readAbstractCurryFile :: String -> IO CurryProg
+readAbstractCurryFile filename = do
+  exacy <- doesFileExist filename
+  if exacy
+   then readExistingACY filename
+   else do let subdirfilename = inCurrySubdir filename
+           exdiracy <- doesFileExist subdirfilename
+           if exdiracy
+            then readExistingACY subdirfilename
+            else error ("EXISTENCE ERROR: AbstractCurry file '"++filename++
+                        "' does not exist")
+ where
+   readExistingACY fname = do
+     filecontents <- readFile fname
+     let (line1,lines) = break (=='\n') filecontents
+     if line1 == "{- "++version++" -}"
+      then return (readUnqualifiedTerm ["AbstractCurry.Types","Prelude"] lines)
+      else error $ "AbstractCurry: incompatible file found: "++fname
+
+--- Tries to read an AbstractCurry file and returns
+---
+---  * Left err  , where err specifies the error occurred
+---  * Right prog, where prog is the AbstractCurry program
+tryReadACYFile :: String -> IO (Maybe CurryProg)
+tryReadACYFile fn = do
+  exists <- doesFileExist fn
+  if exists
+    then tryRead fn
+    else do
+      let fn' = inCurrySubdir fn
+      exists' <- doesFileExist fn'
+      if exists'
+        then tryRead fn'
+        else cancel
+ where
+  tryRead file = do
+    src <- readFile file
+    let (line1,lines) = break (=='\n') src
+    if line1 /= "{- "++version++" -}"
+      then error $ "AbstractCurry: incompatible file found: "++fn
+      else
+        case readsUnqualifiedTerm ["AbstractCurry.Types","Prelude"] lines of
+          []       -> cancel
+          [(p,tl)] -> if all isSpace tl
+                        then return $ Just p
+                        else cancel
+          _        -> cancel
+  cancel = return Nothing
+
+--- Writes an AbstractCurry program into a file in ".acy" format.
+--- The first argument must be the name of the target file
+--- (with suffix ".acy").
+writeAbstractCurryFile :: String -> CurryProg -> IO ()
+writeAbstractCurryFile file prog = writeFile file (showTerm prog)
+
+------------------------------------------------------------------------------

--- a/src/LSP/Generation/AbstractCurry/Pretty.curry
+++ b/src/LSP/Generation/AbstractCurry/Pretty.curry
@@ -1,0 +1,1072 @@
+--- --------------------------------------------------------------------------
+--- Pretty-printing of AbstractCurry.
+---
+--- This library provides a pretty-printer for AbstractCurry modules.
+---
+--- @author  Yannik Potdevin (with changes by Michael Hanus)
+--- @version May 2024
+--- --------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Pretty
+    ( Qualification, Options, LayoutChoice(..)
+
+    , defaultOptions
+    , setPageWith, setIndentWith
+    , setNoQualification, setFullQualification, setImportQualification
+    , setOnDemandQualification, setShowLocalSigs
+    , setModName, setLayoutChoice
+
+    , showCProg, prettyCurryProg, ppCurryProg
+
+    , ppMName, ppExports, ppImports
+
+    , ppCOpDecl, ppCTypeDecl, ppCFuncDecl, ppCFuncDeclWithoutSig, ppCRhs
+    , ppCFuncSignature, ppCQualTypeExpr, ppCTypeExpr, ppCRules, ppCRule
+    , ppCPattern, ppCLiteral, ppCExpr
+    , ppCStatement, ppQFunc, ppFunc, ppQType, ppType)
+    where
+
+import LSP.Generation.AbstractCurry.Select hiding (varsOfLDecl, varsOfFDecl, varsOfStat)
+import LSP.Generation.AbstractCurry.Types
+import LSP.Generation.AbstractCurry.Transform     (typesOfCurryProg, funcsOfCurryProg)
+import Data.Function               (on)
+import Data.List                   (partition, union, scanl, last, nub, (\\))
+import Data.Maybe                  (isJust, fromJust)
+
+import Text.Pretty hiding          ( list, listSpaced, tupled, tupledSpaced
+                                   , set , setSpaced )
+import Prelude     hiding          ( empty )
+
+type Collection a = [a]
+
+data Qualification
+    = Full      -- ^ Fully qualify every identifier, including those of the
+                --   processed module and Prelude.
+    | Imports   -- ^ Fully qualify external identifiers, do not qualify local
+                --   identifiers and those of Prelude.
+    | OnDemand  -- ^ Fully qualify only identifiers which need to be.
+    | None      -- ^ Do not qualify any function.
+ deriving Eq
+
+--- The choice for a generally preferred layout.
+--- @cons PreferNestedLayout - prefer a layout where the arguments of
+---                            long expressions are vertically aligned
+--- @cons PreferFilledLayout - prefer a layout where the arguments of
+---                            long expressions are filled as long as possible
+---                            into one line
+data LayoutChoice = PreferNestedLayout  -- ^ Prefer
+                                        -- a                      f a
+                                        -- + b      respectively    b
+                                        --   + ...                  c
+                                        -- if an expression does not fit the page
+                  | PreferFilledLayout  -- ^ Prefer
+                                        -- a + b                  f a b
+                                        -- + c + d  respectively  c d
+                                        -- if an expression does not fit the page
+
+data Options = Options
+    { pageWidth         :: Int
+    , indentationWidth  :: Int
+    , qualification     :: Qualification
+    , moduleName        :: String
+    {- show signature of local functions or not -}
+    , showLocalSigs     :: Bool
+    , layoutChoice      :: LayoutChoice
+    {- A collection of all to this module visible types (i.e. all imported
+       [prelude too] and self defined types) -- used to determine how to qualify,
+       if Qualification`OnDemand` was chosen. -}
+    , visibleTypes      :: Collection QName
+    {- A collection of all to this module visible functions and constructors
+       (i.e. all imported [prelude too] and self defined ones) -- used to
+       determine how to qualify, if Qualification `OnDemand` was chosen. -}
+    , visibleFunctions  :: Collection QName
+    {- A collection of currently visible (depending on context) variables.
+       Used to determine how to qualify, if Qualification `OnDemand` was chosen.
+    -}
+    , visibleVariables  :: Collection CVarIName
+    }
+
+--- The default options to pretty print a module. These are:
+--- * page width: 78 characters
+--- * indentation width: 2 characters
+--- * qualification method: qualify all imported names (except prelude names)
+--- * layout choice: prefer nested layout (see 'LayoutChoice')
+--- These options can be changed by corresponding setters
+--- ('setPageWith', 'setIndentWith', `set...Qualification`, 'setLayoutChoice').
+---
+--- Note: If these default options are used for pretty-print operations
+--- other than 'prettyCurryProg' or 'ppCurryProg', then one has to set
+--- the current module name explicitly by 'setModName'!
+defaultOptions :: Options
+defaultOptions =
+  Options { pageWidth        = 78
+          , indentationWidth = 2
+          , qualification    = Imports
+          , moduleName       = ""
+          , showLocalSigs    = False
+          , layoutChoice     = PreferNestedLayout
+          , visibleTypes     = emptyCol
+          , visibleFunctions = emptyCol
+          , visibleVariables = emptyCol }
+
+--- Sets the page width of the pretty printer options.
+setPageWith :: Int -> Options -> Options
+setPageWith pw o = o { pageWidth = pw }
+
+--- Sets the indentation width of the pretty printer options.
+setIndentWith :: Int -> Options -> Options
+setIndentWith iw o = o { indentationWidth = iw }
+
+--- Sets the qualification method to be used to print identifiers to
+--- "import qualification" (which is the default).
+--- In this case, all identifiers imported from other modules (except
+--- for the identifiers of the prelude) are fully qualified.
+setImportQualification :: Options -> Options
+setImportQualification o = o { qualification = Imports }
+
+--- Sets the qualification method to be used to print identifiers to
+--- "unqualified".
+--- In this case, no identifiers is printed with its module qualifier.
+--- This might lead to name conflicts or unintended references
+--- if some identifiers in the pretty-printed module are in conflict
+--- with imported identifiers.
+setNoQualification :: Options -> Options
+setNoQualification o = o { qualification = None }
+
+--- Sets the qualification method to be used to print identifiers to
+--- "fully qualified".
+--- In this case, every identifiers, including those of the processed module
+--- and the prelude, are fully qualified.
+setFullQualification :: Options -> Options
+setFullQualification o = o { qualification = Full }
+
+--- Sets the qualification method to be used to print identifiers to
+--- "qualification on demand".
+--- In this case, an identifier is qualified only if it is necessary
+--- to avoid a name conflict, e.g., if a local identifier has the same
+--- names as an imported identifier. Since it is necessary to know
+--- the names of all identifiers defined in the current module (to be pretty
+--- printed) and imported from other modules, the first argument
+--- is the list of modules consisting of the current module and
+--- all imported modules (including the prelude).
+--- The current module must always be the head of this list.
+setOnDemandQualification :: [CurryProg] -> Options -> Options
+setOnDemandQualification mods o =
+  setRelatedMods mods (o { qualification = OnDemand })
+
+--- Sets the name of the current module in the pretty printer options.
+setModName :: MName -> Options -> Options
+setModName m o = o { moduleName = m }
+
+--- Sets the preferred layout in the pretty printer options.
+setLayoutChoice :: LayoutChoice -> Options -> Options
+setLayoutChoice lc o = o { layoutChoice = lc }
+
+--- Sets the flag whether local function signatures should be shown or not.
+setShowLocalSigs :: Bool -> Options -> Options
+setShowLocalSigs b o = o { showLocalSigs = b }
+
+--- Sets the related modules in the pretty printer options. See 'options' to
+--- read a specification of "related modules".
+setRelatedMods :: [CurryProg] -> Options -> Options
+setRelatedMods [] o = o
+setRelatedMods (currentMod:imports) o =
+    o { visibleTypes = vts, visibleFunctions = vfs }
+    where vts = fromList $ map typeName (types currentMod)
+                        ++ collect publicTypeNames
+          vfs = fromList $ concat [ map funcName $ functions currentMod
+                                  , collect publicFuncNames
+                                  , map consName $ constructors currentMod
+                                  , collect publicConsNames ]
+          collect proj = foldr union [] $ map proj imports
+
+--- precedence of top level (pattern or application) context -- lowest
+tlPrec      :: Int
+tlPrec      = 0
+--- precedence of infix (pattern or application) context
+infAppPrec  :: Int
+infAppPrec  = 1
+--- precedence of standard prefix (pattern or application) context
+prefAppPrec :: Int
+prefAppPrec = 2
+--- precedence of atoms (variables, literals, tuples, lists ...)
+highestPrec :: Int
+highestPrec = 3
+
+--- Shows a pretty formatted version of an abstract Curry Program.
+--- The options for pretty-printing are the 'defaultOptions' (and therefore the
+--- restrictions mentioned there apply here too).
+--- @param prog - a curry prog
+--- @return a string, which represents the input program `prog`
+showCProg :: CurryProg -> String
+showCProg = prettyCurryProg defaultOptions
+
+--- Pretty-print the document generated by 'ppCurryProg', using the page width
+--- specified by given options.
+prettyCurryProg :: Options -> CurryProg -> String
+prettyCurryProg opts cprog = showWidth (pageWidth opts) $ ppCurryProg opts cprog
+
+--- Pretty-print a CurryProg (the representation of a program, written in Curry,
+--- using AbstractCurry) according to given options.
+--- This function will overwrite the module name given by options
+--- with the name specified as the first component of `CurryProg`.
+--- The list of imported modules is extended to all modules mentioned
+--- in the program if qualified pretty printing is used.
+--- This is necessary to avoid errors w.r.t. names re-exported by modules.
+ppCurryProg :: Options -> CurryProg -> Doc
+ppCurryProg opts cprog@(CurryProg m ms dfltdecl clsdecls instdecls ts fs os) =
+  vsepBlank
+    [ (nest' opts' $ sep [ text "module" <+> ppMName m,
+                           ppExports opts' clsdecls instdecls ts fs])
+       </> where_
+    , ppImports opts' allImports
+    , vcatMap (ppCOpDecl opts') os
+    , ppCDefaultDecl opts' dfltdecl
+    , vsepBlankMap (ppCClassDecl opts') clsdecls
+    , vsepBlankMap (ppCInstanceDecl opts') instdecls
+    , vsepBlankMap (ppCTypeDecl opts') ts
+    , vsepBlankMap (ppCFuncDecl opts') fs ]
+ where
+   opts' = opts { moduleName = m }
+   allModNames = filter (not . null)
+                   (union (nub (map fst (typesOfCurryProg cprog)))
+                          (nub (map fst (funcsOfCurryProg cprog))))
+   allImports = if qualification opts == None
+                then ms
+                else nub (ms ++ allModNames) \\ [m]
+
+--- Pretty-print a module name (just a string).
+ppMName :: MName -> Doc
+ppMName = text
+
+--- Pretty-print exports, i.e. all type and function declarations which are
+--- public.
+--- extract the type and function declarations which are public and gather their
+--- qualified names in a list.
+ppExports :: Options -> [CClassDecl] -> [CInstanceDecl] -> [CTypeDecl]
+          -> [CFuncDecl] -> Doc
+ppExports opts clsdecls instdecls ts fs
+    | null clsdecls && null instdecls && null pubTs  && null pubFs
+    = parens empty -- nothing is exported
+    | null privTs && null privFs && null privCs
+    = empty        -- everything is exported
+    | otherwise
+    = filledTupledSpaced $ map tDeclToDoc pubTs ++ map fDeclToDoc pubFs
+ where
+  (pubTs, privTs)  = partition isPublicTypeDecl ts
+  (pubFs, privFs)  = partition isPublicFuncDecl fs
+  privCs           = filter ((== Private) . consVis) . concatMap typeCons $ ts
+  isPublicTypeDecl = (== Public) . typeVis
+  isPublicFuncDecl = (== Public) . funcVis
+  tDeclToDoc       = on' (<>) (ppQTypeParsIfInfix opts . typeName)
+                              (ppConsExports opts . typeCons)
+  fDeclToDoc       = ppQFuncParsIfInfix opts . funcName
+
+-- internal use only
+ppConsExports :: Options -> [CConsDecl] -> Doc
+ppConsExports opts cDecls
+    | null pubCs  = empty
+    | null privCs = parens $ dot <> dot
+    | otherwise   = filledTupled $ map cDeclToDoc pubCs
+    where (pubCs, privCs)  = partition isPublicConsDecl cDecls
+          isPublicConsDecl = (== Public) . consVis
+          cDeclToDoc       = ppQFuncParsIfInfix opts . consName
+
+
+--- Pretty-print imports (list of module names) by prepending the word "import"
+--- to the module name. If the qualification mode is 'Imports' or 'Full',
+--- then the imports are declared as `qualified`.
+ppImports :: Options -> [MName] -> Doc
+ppImports opts imps = vcatMap (\m -> text importmode <+> ppMName m)
+                              (filter (/= "Prelude") imps)
+ where
+  importmode = if qualification opts `elem` [Imports,Full]
+                 then "import qualified"
+                 else "import"
+
+--- Pretty-print operator precedence declarations.
+ppCOpDecl :: Options -> COpDecl -> Doc
+ppCOpDecl _ (COp qn fix p) =
+    hsep [ppCFixity fix, int p, genericPPName (bquotesIf . not . isInfixId) qn]
+
+--- Pretty-print the fixity of a function.
+ppCFixity :: CFixity -> Doc
+ppCFixity CInfixOp  = text "infix"
+ppCFixity CInfixlOp = text "infixl"
+ppCFixity CInfixrOp = text "infixr"
+
+--- Pretty-print operator precedence declarations.
+ppCDefaultDecl :: Options -> Maybe CDefaultDecl -> Doc
+ppCDefaultDecl _ Nothing = empty
+ppCDefaultDecl opts (Just (CDefaultDecl texps)) =
+  text "default" <+> filledTupled (map (ppCTypeExpr opts) texps)
+
+--- Pretty-print a class declaration.
+ppCClassDecl :: Options -> CClassDecl -> Doc
+ppCClassDecl opts (CClass qn _ ctxt tvar funcs) =
+  hsep [ text "class", ppCContext opts ctxt, ppType qn, ppCTVarIName opts tvar
+       , text "where"]
+  <$!$> indent' opts (vsepBlankMap (ppCFuncClassDecl opts) funcs)
+
+--- Pretty-print an instance declaration.
+ppCInstanceDecl :: Options -> CInstanceDecl -> Doc
+ppCInstanceDecl opts (CInstance qn ctxt texp funcs) =
+  hsep [ text "instance", ppCContext opts ctxt
+       , ppQType opts qn, ppCTypeExpr' 2 opts texp, text "where"]
+  <$!$> indent' opts (vsepBlankMap (ppCFuncDeclWithoutSig opts) funcs)
+
+--- Pretty-print type declarations, like `data ... = ...`, `type ... = ...` or
+--- `newtype ... = ...`.
+ppCTypeDecl :: Options -> CTypeDecl -> Doc
+ppCTypeDecl opts (CType qn _ tVars cDecls derivings) =
+  hsep [ text "data", ppType qn, ppCTVarINames opts tVars
+       , if null cDecls then empty else ppCConsDecls opts cDecls]
+  <$!$> ppDeriving opts derivings
+ppCTypeDecl opts (CTypeSyn qn _ tVars tExp)
+    = hsep [ text "type", ppType qn, ppCTVarINames opts tVars
+           , align $ equals <+> ppCTypeExpr opts tExp]
+ppCTypeDecl opts (CNewType qn _ tVars cDecl derivings) =
+  hsep [ text "newtype", ppType qn, ppCTVarINames opts tVars, equals
+       , ppCConsDecl opts cDecl]
+  <$!$> ppDeriving opts derivings
+
+--- Pretty-print deriving clause.
+ppDeriving :: Options -> [QName] -> Doc
+ppDeriving _    []   = empty
+ppDeriving opts [cn] = text " deriving" <+> ppQType opts cn
+ppDeriving opts cls@(_:_:_) =
+  text " deriving" <+> alignedTupled (map (ppQType opts) cls)
+
+--- Pretty-print a list of constructor declarations, including the `=` sign.
+ppCConsDecls :: Options -> [CConsDecl] -> Doc
+ppCConsDecls opts cDecls =
+    align . sep $ [equals <+> ppCConsDecl opts (head cDecls)]
+               ++ map ((bar <+>) . (ppCConsDecl opts)) (tail cDecls)
+
+--- Pretty-print a constructor declaration.
+ppCConsDecl :: Options -> CConsDecl -> Doc
+ppCConsDecl opts (CCons   qn _ tExps ) =
+  hsep [ppFunc qn, hsepMap (ppCTypeExpr' 2 opts) tExps]
+ppCConsDecl opts (CRecord qn _ fDecls) =
+  hsep [ppFunc qn <+> alignedSetSpaced (map (ppCFieldDecl opts) fDecls)]
+
+--- Pretty-print a record field declaration (`field :: type`).
+ppCFieldDecl :: Options -> CFieldDecl -> Doc
+ppCFieldDecl opts (CField qn _ tExp) = hsep [ ppFunc qn
+                                            , doubleColon
+                                            , ppCTypeExpr opts tExp ]
+
+--- Pretty-print a document comment.
+ppCDocComment :: String -> Doc
+ppCDocComment cmt = vsepMap (text . ("--- " ++)) (lines cmt)
+
+--- Pretty-print a function declaration occurring in a class declaration.
+ppCFuncClassDecl :: Options -> CFuncDecl -> Doc
+ppCFuncClassDecl opts fDecl@(CFunc qn _ _ tExp rs) =
+    ppCFuncSignature opts qn tExp
+    <$!$> ppCRulesWithoutExternal funcDeclOpts qn rs
+ where funcDeclOpts = addFuncNamesToOpts (funcNamesOfFDecl fDecl) opts
+ppCFuncClassDecl opts (CmtFunc cmt qn a v tExp rs) =
+    ppCDocComment cmt <$!$> ppCFuncClassDecl opts (CFunc qn a v tExp rs)
+
+--- Pretty-print a function declaration.
+ppCFuncDecl :: Options -> CFuncDecl -> Doc
+ppCFuncDecl opts fDecl@(CFunc qn _ _ tExp _) =
+    ppCFuncSignature opts qn tExp <$!$> ppCFuncDeclWithoutSig opts fDecl
+ppCFuncDecl opts (CmtFunc cmt qn a v tExp rs) =
+    ppCDocComment cmt <$!$> ppCFuncDecl opts (CFunc qn a v tExp rs)
+
+--- Pretty-print a function declaration without signature.
+ppCFuncDeclWithoutSig :: Options -> CFuncDecl -> Doc
+ppCFuncDeclWithoutSig opts fDecl@(CFunc qn _ _ _ rs) =
+    ppCRules funcDeclOpts qn rs
+    where funcDeclOpts = addFuncNamesToOpts (funcNamesOfFDecl fDecl) opts
+ppCFuncDeclWithoutSig opts (CmtFunc cmt qn a v tExp rs) =
+    ppCDocComment cmt <$!$> ppCFuncDeclWithoutSig opts (CFunc qn a v tExp rs)
+
+--- Pretty-print a function signature according to given options.
+ppCFuncSignature :: Options -> QName -> CQualTypeExpr -> Doc
+ppCFuncSignature opts qn tExp
+    | isUntyped tExp = empty
+    | otherwise = nest' opts
+                $ sep [ genericPPName parsIfInfix qn
+                      , align $ doubleColon <+> ppCQualTypeExpr opts tExp ]
+ where
+  isUntyped te = te == CQualType (CContext []) (CTCons (pre "untyped"))
+
+--- Pretty-print a qualified type expression.
+ppCQualTypeExpr :: Options -> CQualTypeExpr -> Doc
+ppCQualTypeExpr opts (CQualType clsctxt texp) =
+  ppCContext opts clsctxt <+> ppCTypeExpr opts texp
+
+--- Pretty-print a class context.
+ppCContext :: Options -> CContext -> Doc
+ppCContext _ (CContext []) = empty
+ppCContext opts (CContext [clscon]) =
+  ppCConstraint opts clscon <+> text "=>"
+ppCContext opts (CContext ctxt@(_:_:_)) =
+  alignedTupled (map (ppCConstraint opts) ctxt) <+> text "=>"
+
+--- Pretty-print a single class constraint.
+ppCConstraint :: Options -> CConstraint -> Doc
+ppCConstraint opts (cn,texp) =
+  ppQType opts cn <+> ppCTypeExpr' prefAppPrec opts texp
+
+--- Pretty-print a type expression.
+ppCTypeExpr :: Options -> CTypeExpr -> Doc
+ppCTypeExpr = ppCTypeExpr' tlPrec
+
+-- Internal use only: Pretty-print a type expression and make use of supplied
+-- precedence context. The supplied number represents the precedence of the
+-- enclosing expression. Higher values mean more precedence, so if the nested
+-- expression has lower precedence than the enclosing expression, the nested one
+-- has to be enclosed in parentheses.
+ppCTypeExpr' :: Int -> Options -> CTypeExpr -> Doc
+ppCTypeExpr' _ opts (CTVar     tvar) = ppCTVarIName opts tvar
+ppCTypeExpr' p opts (CFuncType tExp1 tExp2) =
+    parensIf (p > tlPrec)
+  $ sep [ ppCTypeExpr' 1 opts tExp1, rarrow <+> ppCTypeExpr opts tExp2]
+ppCTypeExpr' _ opts (CTCons qn) = ppQType opts qn
+
+ppCTypeExpr' p opts texp@(CTApply tcon targ) =
+  maybe (parensIf (p >= 2) $ ppCTypeExpr' 2 opts tcon
+                         <+> ppCTypeExpr' 2 opts targ)
+        (\qn -> ppCTypeTConApply qn (argsOfApply texp))
+        (funOfApply texp)
+ where
+  ppCTypeTConApply qn targs
+    | isListCons qn  = brackets . ppCTypeExpr opts . head $ targs -- assume singleton
+    | isTupleCons qn = alignedTupled $ map (ppCTypeExpr opts) targs
+    | otherwise      = parensIf (p >= 2)
+                     $ ppQType opts qn
+                   <+> hsepMap (ppCTypeExpr' 2 opts) targs
+
+  funOfApply te = case te of CTApply (CTCons qn) _ -> Just qn
+                             CTApply tc _          -> funOfApply tc
+                             _                     -> Nothing
+
+  argsOfApply te = case te of
+    CTApply (CTCons _) ta -> [ta]
+    CTApply tc         ta -> argsOfApply tc ++ [ta]
+    _                     -> [] -- should not occur
+
+--- Pretty-print a list of type variables horizontally separating them
+--- by `space`.
+ppCTVarINames :: Options -> [CTVarIName] -> Doc
+ppCTVarINames opts = hsepMap (ppCTVarIName opts)
+
+--- Pretty-print a type variable (currently the Int is ignored).
+ppCTVarIName :: Options -> CTVarIName -> Doc
+ppCTVarIName _ (_, tvar) = text tvar
+
+--- Pretty-print a list of function rules, concatenated vertically.
+--- If there are no rules, an external rule is printed.
+ppCRules :: Options -> QName -> [CRule] -> Doc
+ppCRules opts qn rs
+    | null rs   = genericPPName parsIfInfix qn <+> text "external"
+    | otherwise = vcatMap (ppCRule opts qn) rs
+
+--- Pretty-print a list of function rules, concatenated vertically.
+--- If there are no rules, an empty document is returned.
+ppCRulesWithoutExternal :: Options -> QName -> [CRule] -> Doc
+ppCRulesWithoutExternal opts qn rs =
+  if null rs then empty else vcatMap (ppCRule opts qn) rs
+
+--- Pretty-print a rule of a function. Given a function
+--- `f x y = x * y`, then `x y = x * y` is a rule consisting of `x y` as list of
+--- patterns and `x * y` as right hand side.
+ppCRule :: Options -> QName -> CRule -> Doc
+ppCRule opts qn rule@(CRule ps rhs) =
+    (nest' opts $ sep [ ppCPattern opts (CPComb qn ps) {- exploit similarity
+                                                          between left hand side
+                                                          of rule and constructor
+                                                          pattern -}
+                        <+> (case rhs of
+                                  CSimpleRhs  _ _ -> equals
+                                  CGuardedRhs _ _ -> empty )
+                      , ppFuncRhs rhsOpts rhs ] )
+ $$ if null lDecls
+       then empty
+       else indent' opts $ ppWhereDecl whereOpts lDecls
+    where lDecls    = ldeclsOfRule rule
+          whereOpts = addVarsToOpts (concatMap varsOfPat ps) opts
+          rhsOpts   = last $ optsWithIncreasingNamespaces
+                                varsOfLDecl
+                                funcNamesOfLDecl
+                                lDecls
+                                whereOpts
+
+--- Pretty-print a pattern expression.
+ppCPattern :: Options -> CPattern -> Doc
+ppCPattern = ppCPattern' tlPrec
+
+-- Internal use only: Pretty-print a pattern expression and make use of supplied
+-- precedence context. The supplied number represents the precedence of the
+-- enclosing pattern. Higher values mean more precedence, so if the nested
+-- pattern has lower precedence than the enclosing pattern, the nested one has
+-- to be enclosed in parentheses.
+ppCPattern' :: Int -> Options -> CPattern -> Doc
+ppCPattern' _ opts (CPVar  pvar) = ppCVarIName opts pvar
+ppCPattern' _ opts (CPLit  lit ) = ppCLiteral opts lit
+ppCPattern' p opts pat@(CPComb qn ps)
+    | null ps        = parsIfInfix qn qnDoc
+    | isApp qn       = parensIf (p >= prefAppPrec)
+                     $ ppCPattern' infAppPrec opts (ps !! 0)
+                   <+> ppCPattern' prefAppPrec opts (ps !! 1)
+    | isTupleCons qn = filledTupled . map (ppCPattern opts) $ ps
+    | isFinLis pat   = let ps' = fromJust $ extractFiniteListPattern pat
+                       in  alignedList . map (ppCPattern opts) $ ps'
+    | isInfixId qn   =
+        case ps of [l, r] -> parensIf (p >= infAppPrec)
+                           $ hsep [ ppCPattern' p' opts l, qnDoc
+                                  , ppCPattern' p' opts r ]
+                   _      -> prefixApp
+    | otherwise      = prefixApp
+    where qnDoc     = ppQFunc opts qn
+          isApp     = (== ("Prelude", "apply"))
+          p'        = if isInfixId qn then infAppPrec else prefAppPrec
+          prefixApp = parensIf (p >= prefAppPrec) . nest' opts
+                    $ sep [ parsIfInfix qn qnDoc
+                          , align . (case layoutChoice opts of
+                                          PreferFilledLayout -> fillSep
+                                          PreferNestedLayout -> sep)
+                                  . map (ppCPattern' p' opts) $ ps ]
+          isFinLis  = isJust . extractFiniteListPattern
+ppCPattern' _ opts (CPAs pvar p)
+    = hcat [ppCVarIName opts pvar, at, ppCPattern' highestPrec opts p]
+ppCPattern' p opts (CPFuncComb qn ps) = ppCPattern' p opts (CPComb qn ps)
+ppCPattern' _ opts (CPLazy     p     ) = tilde <> ppCPattern' highestPrec opts p
+ppCPattern' _ opts (CPRecord   qn rps) =
+    ppQFunc opts qn <+> alignedSetSpaced (map (ppCFieldPattern opts) rps)
+
+--- Pretty-print a pattern variable (currently the Int is ignored).
+ppCVarIName :: Options -> CVarIName -> Doc
+ppCVarIName _ (_, pvar) = text pvar
+
+--- Pretty-print given literal (Int, Float, ...).
+ppCLiteral :: Options -> CLiteral -> Doc
+ppCLiteral _ (CIntc i)    = int i
+ppCLiteral _ (CFloatc f)  = float f
+ppCLiteral _ (CCharc c)   = text $ show c
+ppCLiteral _ (CStringc s)
+    | null s    = text "\"\"" -- necessary for pakcs
+    | otherwise = text $ show s
+
+--- Pretty-print a record pattern
+ppCFieldPattern :: Options -> CField CPattern -> Doc
+ppCFieldPattern opts (qn, p) = ppQFunc opts qn <+> equals <+> ppCPattern opts p
+
+--- Pretty-print the right hand side of a rule (or case expression), including
+--- the d sign, where `d` is the relation (as doc) between the left hand side
+--- and the right hand side -- usually this is one of `=`, `->`.
+--- If the right hand side contains local declarations, they will be pretty
+--- printed too, further indented.
+ppCRhs :: Doc -> Options -> CRhs -> Doc
+ppCRhs d opts rhs = case rhs of
+        CSimpleRhs  exp   lDecls ->
+            (nest' opts $ sep [d, ppCExpr (expAndGuardOpts lDecls) exp])
+         $$ maybePPlDecls lDecls
+        CGuardedRhs conds lDecls ->
+            ppCGuardedRhs (expAndGuardOpts lDecls) d conds
+         $$ maybePPlDecls lDecls
+    where expAndGuardOpts ls = last $ optsWithIncreasingNamespaces
+                                        varsOfLDecl
+                                        funcNamesOfLDecl
+                                        ls
+                                        opts
+          maybePPlDecls ls   = if null ls
+                                  then empty
+                                  else indent' opts (ppWhereDecl opts ls)
+
+--- Like 'ppCRhs', but do not pretty-print local declarations.
+--- Instead give caller the choice how to handle the declarations. For example
+--- the function 'ppCRule' uses this to prevent local declarations from being
+--- further indented.
+ppFuncRhs :: Options -> CRhs -> Doc
+{- No further enrichment of options necessary -- it was done in 'ppCRule' -}
+ppFuncRhs opts (CSimpleRhs  exp _)   = ppCExpr opts exp
+ppFuncRhs opts (CGuardedRhs conds _) = ppCGuardedRhs opts equals conds
+
+ppCaseRhs :: Options -> CRhs -> Doc
+ppCaseRhs = ppCRhs rarrow
+
+--- Pretty-print guard, i.e. the `| cond d exp` part of a right hand side, where
+--- `d` is the relation (as doc) between `cond` and `exp` -- usually this is
+--- one of `=`, `->`.
+ppCGuardedRhs :: Options -> Doc -> [(CExpr, CExpr)] -> Doc
+ppCGuardedRhs opts d = align . vvsepMap ppCGuard
+    where ppCGuard (e1, e2) = sep [ bar <+> ppCExpr opts e1
+                                  , d   <+> ppCExpr opts e2 ]
+
+--- Pretty-print local declarations . If the second argument is `text "where"`,
+--- pretty-print a `where` block. If the second argument is `text "let"`,
+--- pretty-print a `let` block without `in`.
+ppCLocalDecls :: Options -> Doc -> [CLocalDecl] -> Doc
+ppCLocalDecls opts d lDecls =
+    (d <+>) . align . vvsepMap (ppCLocalDecl lDeclOpts) $ lDecls
+    where lDeclOpts = last $ optsWithIncreasingNamespaces
+                                varsOfLDecl
+                                funcNamesOfLDecl
+                                lDecls
+                                opts
+
+--- Pretty-print local declarations (the part that follows the `where` keyword).
+ppCLocalDecl :: Options -> CLocalDecl -> Doc
+ppCLocalDecl opts (CLocalFunc fDecl) =
+    if showLocalSigs opts
+       then ppCFuncDecl opts fDecl
+       else ppCFuncDeclWithoutSig opts fDecl
+ppCLocalDecl opts (CLocalPat  p rhs) =
+    hsep [ ppCPattern opts p, ppCRhs equals rhsOpts rhs ]
+    where rhsOpts = addVarsToOpts (varsOfPat p) opts
+ppCLocalDecl opts (CLocalVars pvars) =
+    (<+> text "free") $ hsep $ punctuate comma $ map (ppCVarIName opts) pvars
+
+--- Pretty-print a `where` block, in which the word `where` stands alone in a
+--- single line, above the following declarations.
+ppWhereDecl :: Options -> [CLocalDecl] -> Doc
+ppWhereDecl opts lDecls = (where_ $$)
+                        . indent' opts
+                        . vvsepMap (ppCLocalDecl lDeclOpts) $ lDecls
+    where lDeclOpts = last $ optsWithIncreasingNamespaces
+                                varsOfLDecl
+                                funcNamesOfLDecl
+                                lDecls
+                                opts
+
+--- Pretty-print a `let` block without `in`. In contrast to 'ppWhereDecl', the
+--- word `let` is in the same line as the first local declaration.
+ppLetDecl :: Options -> [CLocalDecl] -> Doc
+ppLetDecl opts = ppCLocalDecls opts (text "let")
+
+--- Pretty-print an expression.
+ppCExpr :: Options -> CExpr -> Doc
+ppCExpr = ppCExpr' tlPrec
+
+-- Internal use only: Pretty-print an expression and make use of supplied
+-- precedence context. The supplied number represents the precedence of the
+-- enclosing expression. Higher values mean more precedence, so if the nested
+-- expression has lower precedence than the enclosing expression, the nested one
+-- has to be enclosed in parentheses.
+ppCExpr' :: Int -> Options -> CExpr -> Doc
+ppCExpr' _ opts (CVar     pvar) = ppCVarIName opts pvar
+ppCExpr' _ opts (CLit     lit ) = ppCLiteral opts lit
+ppCExpr' _ opts (CSymbol  qn  ) = ppQFuncParsIfInfix opts qn
+ppCExpr' p opts app@(CApply f exp)
+    | isITE app
+        = parensIf (p > tlPrec)
+        $ let (c, t, e) = fromJust $ extractITE app
+          in  text "if" <+> (align $ sep [ ppCExpr opts c
+                                         , text "then" <+> ppCExpr opts t
+                                         , text "else" <+> ppCExpr opts e])
+    | isTup app = let args = fromJust $ extractTuple app
+                  in  alignedTupled (map (ppCExpr opts) args)
+    | isFinLis app =
+      let elems = fromJust $ extractFiniteListExp app
+      in  (case layoutChoice opts of
+             PreferNestedLayout -> alignedList
+             PreferFilledLayout -> filledList )
+            (map (ppCExpr opts) elems)
+    | isInf app
+        = parensIf (p >= infAppPrec)
+        $ let (op, l, r) = fromJust $ extractInfix app
+          in  (case layoutChoice opts of
+                    PreferNestedLayout -> ppNestedWay
+                    PreferFilledLayout -> ppFilledWay)
+                (ppCExpr' infAppPrec opts l)
+                (ppQFunc opts op)
+                (ppCExpr' infAppPrec opts r)
+    | otherwise = parensIf (p >= prefAppPrec)
+                $ (case layoutChoice opts of
+                        PreferNestedLayout -> ppNestedWay
+                        PreferFilledLayout -> ppFilledWay)
+                    (ppCExpr' infAppPrec opts f)
+                    empty
+                    (ppCExpr' prefAppPrec opts exp)
+    where isITE    = isJust . extractITE
+          isInf    = isJust . extractInfix
+          isTup    = isJust . extractTuple
+          isFinLis = isJust . extractFiniteListExp
+          ppNestedWay l sepa r = align . nest 1 $ sep [l, sepa <+> r]
+          ppFilledWay l sepa r = nest 1 $ fillSep [l, sepa, r]
+ppCExpr' p opts (CLambda ps exp) =
+    parensIf (p > tlPrec) . nest' opts
+  $ sep [ backslash <> hsepMap (ppCPattern' prefAppPrec opts) ps
+                   <+> rarrow
+        , ppCExpr expOpts exp]
+    where expOpts = addVarsToOpts (concatMap varsOfPat ps) opts
+ppCExpr' p opts (CLetDecl lDecls exp) =
+    parensIf (p > tlPrec) . align
+    {- 'ppLetDecl' itself ensures the correct handling of opts -}
+  $ sep [ ppLetDecl opts lDecls, text "in" <+> ppCExpr expOpts exp]
+    where expOpts = last $ optsWithIncreasingNamespaces
+                            varsOfLDecl
+                            funcNamesOfLDecl
+                            lDecls
+                            opts
+ppCExpr' p opts (CDoExpr stms) =
+    parensIf (p > tlPrec)
+  $ text "do" <+> align (vvsep $ zipWith ppCStatement statOptsList stms)
+    where statOptsList = optsWithIncreasingNamespaces
+                            varsOfStat
+                            funcNamesOfStat
+                            stms
+                            opts
+ppCExpr' _ opts (CListComp exp stms) =
+    brackets $ hsep [ ppCExpr expOpts exp, bar
+                    , hsep $ punctuate (comma <> space)
+                                       (zipWith ppCStatement statOptsList stms)]
+    where expOpts      = last statOptsList
+          statOptsList = optsWithIncreasingNamespaces
+                            varsOfStat
+                            funcNamesOfStat
+                            stms
+                            opts
+
+ppCExpr' p opts (CCase cType exp cases) =
+    parensIf (p > tlPrec) . align . nest' opts
+  $ sep [ ppCCaseType cType <+> ppCExpr opts exp <+> text "of"
+        , ppCases opts cases]
+ppCExpr' p opts (CTyped exp tExp) =
+    parensIf (p > tlPrec)
+  $ hsep [ppCExpr opts exp, doubleColon, ppCQualTypeExpr opts tExp]
+ppCExpr' _ opts (CRecConstr qn rFields) =
+    ppQFunc opts qn <+> ppRecordFields opts rFields
+ppCExpr' p opts (CRecUpdate exp rFields) = ppCExpr' p opts exp
+                                       <+> ppRecordFields opts rFields
+
+ppCStatement :: Options -> CStatement -> Doc
+ppCStatement opts (CSExpr exp       ) = ppCExpr opts exp
+ppCStatement opts (CSPat  pat    exp) = ppCPattern opts pat
+                                    <+> larrow
+                                    <+> ppCExpr opts exp
+ppCStatement opts (CSLet  lDecls    ) = ppLetDecl opts lDecls
+
+--- Pretty-print `case`, `fcase` keywords.
+ppCCaseType :: CCaseType -> Doc
+ppCCaseType CRigid = text "case"
+ppCCaseType CFlex  = text "fcase"
+
+--- Pretty-print a list of case expressions, i.e. the `p1 -> e1`,...,`pn -> en`,
+--- transitions, vertically aligned.
+ppCases :: Options -> [(CPattern, CRhs)] -> Doc
+ppCases opts = align . vvsepMap (ppCase opts)
+
+--- Pretty-print a case expression.
+ppCase :: Options -> (CPattern, CRhs) -> Doc
+ppCase opts (p, rhs) = ppCPattern opts p <+> ppCaseRhs rhsOpts rhs
+    where rhsOpts = addVarsToOpts (varsOfPat p) opts
+
+--- Pretty-print record field assignments like this:
+---     { lab1 = exp1, ..., labn expn }
+--- if it fits the page, or
+---     { lab1 = exp1
+---     , ...
+---     , labn = expn }
+--- otherwise.
+ppRecordFields :: Options -> [CField CExpr] -> Doc
+ppRecordFields opts = alignedSetSpaced . map (ppRecordField opts)
+
+--- Pretty-print a record field assignment (`fieldLabel = exp`).
+ppRecordField :: Options -> CField CExpr -> Doc
+ppRecordField opts (qn, exp) = ppQFunc opts qn <+> equals <+> ppCExpr opts exp
+
+--- Pretty-print a QName qualified according to given options.
+--- @param visNames - Depending on call, this is the namespace of visible types
+---                   or of visible functions. Used to determine if `qn` is
+---                   ambiguous, in case the qualification method 'OnDemand' was
+---                   chosen
+--- @param visVars - The in current context visible variables.
+--- @param g - A doc tranformer used to manipulate (f.e. surround with
+---            parentheses) the QName, after it was (maybe) qualified.
+--- @param opts - The options to use.
+--- @param qn - The `QName` to pretty-print.
+--- @return A pretty-printed `QName`, maybe qualified (depending on settings).
+genericPPQName :: Collection QName
+               -> Collection CVarIName
+               -> (QName -> Doc -> Doc)
+               -> Options
+               -> QName
+               -> Doc
+genericPPQName visNames visVars g opts qn@(m, f)
+    | qnIsBuiltIn = name
+    | null m      = name -- assume local declaration
+    | otherwise   =
+        case qualification opts of
+             Full     -> qName
+             Imports  -> if m == moduleName opts || m == "Prelude"
+                            then name
+                            else qName
+             OnDemand -> if m == moduleName opts
+                            then name
+                            else odName -- at this point we know qn is imported
+             None     -> name
+    where qnIsBuiltIn = or (map ($ qn) [ isUnitCons , isListCons
+                                       , isTupleCons, isConsCons ])
+          name        = g qn (text f)
+          qName       = g qn $ ppMName m <> dot <> text f
+          odName      = if isShadowed qn || isAmbiguous qn
+                           then qName
+                           else name
+          isAmbiguous n = anyCol (on' (&&) (sameName n) (diffMod n)) visNames
+          isShadowed n  = anyCol (sameName n) visVars
+          diffMod       = (/=) `on` fst
+          sameName (_,x) (_,y) = x == y
+
+genericPPName :: (QName -> Doc -> Doc) -> QName -> Doc
+genericPPName f qn = f qn $ text . snd $ qn
+
+--- Pretty-print a function name or constructor name qualified according to
+--- given options. Use 'ppQType' or 'ppType' for pretty-printing type names.
+ppQFunc :: Options -> QName -> Doc
+ppQFunc opts = genericPPQName (visibleFunctions opts)
+                              (visibleVariables opts)
+                              (flip const)
+                              opts
+
+--- Like 'ppQFunc', but surround name with parentheses if it is an infix
+--- identifier.
+ppQFuncParsIfInfix :: Options -> QName -> Doc
+ppQFuncParsIfInfix opts = genericPPQName (visibleFunctions opts)
+                                         (visibleVariables opts)
+                                         parsIfInfix
+                                         opts
+
+--- Pretty-print a function name or constructor name non-qualified.
+--- Use 'ppQType' or 'ppType' for pretty-printing type names.
+ppFunc :: QName -> Doc
+ppFunc = genericPPName (flip const)
+
+--- Pretty-print a type (`QName`) qualified according to given options.
+ppQType :: Options -> QName -> Doc
+ppQType opts = genericPPQName (visibleTypes opts) emptyCol (flip const) opts
+
+--- Like 'ppQType', but surround name with parentheses if it is an infix
+--- identifier.
+ppQTypeParsIfInfix :: Options -> QName -> Doc
+ppQTypeParsIfInfix opts =
+    genericPPQName (visibleTypes opts) emptyCol parsIfInfix opts
+
+--- Pretty-print a type (`QName`) non-qualified.
+ppType :: QName -> Doc
+ppType = genericPPName (flip const)
+
+-- Helping function (diagnosis)
+--- Check whether an operator is an infix identifier.
+isInfixId :: QName -> Bool
+isInfixId = all (`elem` "~!@#$%^&*+-=<>:?./|\\") . snd
+
+--- Check whether an identifier represents the unit constructor
+isUnitCons :: QName -> Bool
+isUnitCons (_, i) = i == "()"
+
+--- Check whether an identifier represents the empty list constructor
+isListCons :: QName -> Bool
+isListCons (_, i) = i == "[]"
+
+--- Check whether an identifier represents the list constructor `:`
+isConsCons :: QName -> Bool
+isConsCons (_, i) = i == ":"
+
+--- Check whether an identifier represents a tuple constructor
+isTupleCons :: QName -> Bool
+isTupleCons (_, i) = i == mkTuple (length i)
+  where mkTuple n = '(' : replicate (n - 2) ',' ++ ")"
+
+--- Check if given application tree represents an if then else construct.
+--- If so, return the condition, the "then expression" and the "else expression".
+--- Otherwise, return `Nothing`.
+extractITE :: CExpr -> Maybe (CExpr, CExpr, CExpr)
+extractITE e = case e of
+                    CApply (CApply (CApply (CSymbol ("Prelude","if_then_else"))
+                                            cond)
+                                    tExp)
+                            fExp -> Just (cond, tExp, fExp)
+                    _            -> Nothing
+
+--- Check if given application tree represents an infix operator application.
+--- If so, return the operator, its left and its right argument. Otherwise,
+--- return `Nothing`.
+extractInfix :: CExpr -> Maybe (QName, CExpr, CExpr)
+extractInfix e
+    = case e of CApply (CApply (CSymbol s)
+                                 e1)
+                        e2
+                    | isInfixId s -> Just (s, e1, e2)
+                _                 -> Nothing
+
+--- Check if given application tree represents a tuple contructor application.
+--- If so, return the constructor and its arguments in a list. Otherwise, return
+--- `Nothing`.
+extractTuple :: CExpr -> Maybe [CExpr]
+extractTuple = extractTuple' []
+    where extractTuple' es exp
+            = case exp of
+                   CApply  f e                 -> extractTuple' (e:es) f
+                   CSymbol s   | isTupleCons s -> Just es
+                   _                           -> Nothing
+
+--- Check if given application tree represents a finite list `[x1, ..., xn]`.
+--- If so, return the list elements in a list. Otherwise, return `Nothing`.
+extractFiniteListExp :: CExpr -> Maybe [CExpr]
+extractFiniteListExp = extractFiniteListExp' []
+    where extractFiniteListExp' es exp =
+            case exp of
+                 CApply (CApply (CSymbol f)
+                                 e)
+                         arg | isConsCons f -> extractFiniteListExp' (e:es) arg
+                 CSymbol s   | isListCons s -> Just $ reverse es
+                 _                          -> Nothing
+
+--- Check if given construct pattern represents a finite list `[x1, ..., xn]`.
+--- If so, return the list elements in a list. Otherwise, return `Nothing`.
+extractFiniteListPattern :: CPattern -> Maybe [CPattern]
+extractFiniteListPattern = extractFiniteListPattern' []
+    where extractFiniteListPattern' es pat =
+            case pat of
+                 CPComb qn [e, t] | isConsCons qn
+                                  -> extractFiniteListPattern' (e:es) t
+                 CPComb qn []     | isListCons qn
+                                  -> Just $ reverse es
+                 _                -> Nothing
+
+-- Helping functions (pretty-printing)
+hsepMap :: (a -> Doc) -> [a] -> Doc
+hsepMap f = hsep . map f
+
+vcatMap :: (a -> Doc) -> [a] -> Doc
+vcatMap f = vcat . map f
+
+vsepMap :: (a -> Doc) -> [a] -> Doc
+vsepMap f = vsep . map f
+
+vsepBlankMap :: (a -> Doc) -> [a] -> Doc
+vsepBlankMap f = vsepBlank . map f
+
+vvsep :: [Doc] -> Doc
+vvsep = compose (<$!$>)
+
+vvsepMap :: (a -> Doc) -> [a] -> Doc
+vvsepMap f = vvsep . map f
+
+fillSepMap :: (a -> Doc) -> [a] -> Doc
+fillSepMap f = fillSep . map f
+
+encloseSepSpaced :: Doc -> Doc -> Doc -> [Doc] -> Doc
+encloseSepSpaced l r s = encloseSep (l <> space) (space <> r) (s <> space)
+
+alignedList :: [Doc] -> Doc
+alignedList = encloseSep lbracket rbracket comma
+
+filledList :: [Doc] -> Doc
+filledList = fillEncloseSep lbracket rbracket comma
+
+alignedSetSpaced :: [Doc] -> Doc
+alignedSetSpaced = encloseSepSpaced lbrace rbrace comma
+
+alignedTupled :: [Doc] -> Doc
+alignedTupled = encloseSep lparen rparen comma
+
+filledTupled :: [Doc] -> Doc
+filledTupled = fillEncloseSep lparen rparen comma
+
+filledTupledSpaced :: [Doc] -> Doc
+filledTupledSpaced = fillEncloseSepSpaced lparen rparen comma
+
+nest' :: Options -> Doc -> Doc
+nest' opts = nest (indentationWidth opts)
+
+indent' :: Options -> Doc -> Doc
+indent' opts = indent (indentationWidth opts)
+
+bquotesIf :: Bool -> Doc -> Doc
+bquotesIf b d = if b then bquotes d else d
+
+parsIfInfix :: QName -> Doc -> Doc
+parsIfInfix = parensIf . isInfixId
+
+larrow :: Doc
+larrow = text "<-"
+
+where_ :: Doc
+where_ = text "where"
+
+nil :: Doc
+nil = text "[]"
+
+-- Helping functions (various)
+on' :: (b -> b -> c) -> (a -> b) -> (a -> b) -> a -> c
+on' comb f g x = f x `comb` g x
+
+-- Helping functions (CRUD functions for Collection)
+emptyCol :: Collection a
+emptyCol = []
+
+appendCol :: Collection a -> Collection a -> Collection a
+appendCol = (++)
+
+anyCol :: (a -> Bool) -> Collection a -> Bool
+anyCol = any
+
+fromList :: [a] -> Collection a
+fromList = id
+
+-- Helping functions (management of visible names)
+addVarsToOpts :: [CVarIName] -> Options -> Options
+addVarsToOpts vs o =
+    o { visibleVariables = fromList vs `appendCol` visibleVariables o }
+
+addFuncNamesToOpts :: [QName] -> Options -> Options
+addFuncNamesToOpts ns o =
+    o { visibleFunctions = fromList ns `appendCol` visibleFunctions o }
+
+addVarsAndFuncNamesToOpts :: [CVarIName] -> [QName] -> Options -> Options
+addVarsAndFuncNamesToOpts vs ns = addVarsToOpts vs . addFuncNamesToOpts ns
+
+--- Generates a list of options with increasing numbers of visible variables
+--- and function names. Resulting lists are useful to match the scopes of
+--- do expressions and list comprehensions, where latter statements see previous
+--- variables and functions names, but prior elements do not see subsequent
+--- variables and function names.
+--- Note that `last $ optsWithIncreasingNamespaces varsOf funcNamesOf xs opts`
+--- are options which contain all variables and function names of xs.
+--- @param varsOf - a projection function
+--- @param funcNamesOf - a projection function
+--- @xs - a list [x1, x2, ...] of elements to which the projection functions
+---       will be applied
+--- @param opts - root options
+--- @return a list `[opts0, opts1, opts2, ...]`, where
+---         `opts == opts0`,
+---         `opts1 == opts0` plus vars and funcNames of `x1`,
+---         `opts2 == opts1` plus vars and funcNames of `x2`,
+---         ...
+optsWithIncreasingNamespaces :: (a -> [CVarIName])
+                             -> (a -> [QName])
+                             -> [a]
+                             -> Options
+                             -> [Options]
+optsWithIncreasingNamespaces varsOf funcNamesOf xs opts =
+    scanl (flip . uncurry $ addVarsAndFuncNamesToOpts) opts varsAndFuncNamesOfXs
+    where varsAndFuncNamesOfXs = map varsOf xs `zip` map funcNamesOf xs
+
+-- Helping function (gather variables occurring in argument)
+--- In contrast to `AbstractCurry.Select.varsOfLDecl`, this function does not
+--- include variables of right hand sides.
+varsOfLDecl :: CLocalDecl -> [CVarIName]
+varsOfLDecl (CLocalFunc f      ) = varsOfFDecl f
+varsOfLDecl (CLocalPat  p     _) = varsOfPat p
+varsOfLDecl (CLocalVars lvars  ) = lvars
+
+--- In contrast to `AbstractCurry.Select.varsOfFDecl`, this function does not
+--- include variables of right hand sides.
+varsOfFDecl :: CFuncDecl -> [CVarIName]
+varsOfFDecl (CFunc     _ _ _ _ r) = concatMap varsOfRule r
+varsOfFDecl (CmtFunc _ _ _ _ _ r) = concatMap varsOfRule r
+    where varsOfRule (CRule pats _) = concatMap varsOfPat pats
+
+--- In contrast to `AbstractCurry.Select.varsOfStat`, this function does not
+--- include variables of right hand sides.
+varsOfStat :: CStatement -> [CVarIName]
+varsOfStat (CSExpr _   ) = []
+varsOfStat (CSPat  p  _) = varsOfPat p
+varsOfStat (CSLet  ld  ) = concatMap varsOfLDecl ld

--- a/src/LSP/Generation/AbstractCurry/Select.curry
+++ b/src/LSP/Generation/AbstractCurry/Select.curry
@@ -34,15 +34,19 @@ import Data.List (union)
 
 -- Returns the name of a given Curry program.
 progName :: CurryProg -> String
-progName (CurryProg modname _ _ _ _ _ _ _) = modname
+progName (CurryProg modname _ _ _ _ _ _ _ _) = modname
+
+--- Returns the exports (module names) of a given Curry program.
+exports :: CurryProg -> [MName]
+exports (CurryProg _ ms _ _ _ _ _ _ _) = ms
 
 --- Returns the imports (module names) of a given Curry program.
 imports :: CurryProg -> [MName]
-imports (CurryProg _ ms _ _ _ _ _ _) = ms
+imports (CurryProg _ _ ms _ _ _ _ _ _) = ms
 
 --- Returns the function declarations of a given Curry program.
 functions :: CurryProg -> [CFuncDecl]
-functions (CurryProg _ _ _ _ _ _ fs _) = fs
+functions (CurryProg _ _ _ _ _ _ _ fs _) = fs
 
 --- Returns all constructors of given Curry program.
 constructors :: CurryProg -> [CConsDecl]
@@ -50,7 +54,7 @@ constructors = concatMap typeCons . types
 
 --- Returns the type declarations of a given Curry program.
 types :: CurryProg -> [CTypeDecl]
-types (CurryProg _ _ _ _ _ ts _ _) = ts
+types (CurryProg _ _ _ _ _ _ ts _ _) = ts
 
 --- Returns the names of all visible functions in given Curry program.
 publicFuncNames :: CurryProg -> [QName]

--- a/src/LSP/Generation/AbstractCurry/Select.curry
+++ b/src/LSP/Generation/AbstractCurry/Select.curry
@@ -1,0 +1,325 @@
+------------------------------------------------------------------------
+--- This library provides some useful operations to select components
+--- in AbstractCurry programs, i.e., it provides a collection of
+--- selector functions for AbstractCurry.
+---
+--- @version October 2016
+------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Select
+  ( progName, imports, functions, constructors, types, publicFuncNames
+  , publicConsNames, publicTypeNames
+
+  , typeOfQualType, classConstraintsOfQualType
+  , typeName, typeVis, typeCons
+  , consName, consVis
+  , isBaseType, isPolyType, isFunctionalType, isIOType, isIOReturnType
+  , argTypes, resultType, tvarsOfType, tconsOfType, modsOfType, tconsArgsOfType
+
+  , funcName, funcArity, funcComment, funcVis, funcType, funcRules
+  , ruleRHS, ldeclsOfRule
+
+  , varsOfPat, varsOfExp, varsOfRhs, varsOfStat, varsOfLDecl
+  , varsOfFDecl, varsOfRule
+
+  , funcNamesOfLDecl, funcNamesOfFDecl, funcNamesOfStat
+  , isPrelude
+  ) where
+
+import LSP.Generation.AbstractCurry.Types
+import Data.List (union)
+
+------------------------------------------------------------------------
+-- Selectors for curry programs
+
+-- Returns the name of a given Curry program.
+progName :: CurryProg -> String
+progName (CurryProg modname _ _ _ _ _ _ _) = modname
+
+--- Returns the imports (module names) of a given Curry program.
+imports :: CurryProg -> [MName]
+imports (CurryProg _ ms _ _ _ _ _ _) = ms
+
+--- Returns the function declarations of a given Curry program.
+functions :: CurryProg -> [CFuncDecl]
+functions (CurryProg _ _ _ _ _ _ fs _) = fs
+
+--- Returns all constructors of given Curry program.
+constructors :: CurryProg -> [CConsDecl]
+constructors = concatMap typeCons . types
+
+--- Returns the type declarations of a given Curry program.
+types :: CurryProg -> [CTypeDecl]
+types (CurryProg _ _ _ _ _ ts _ _) = ts
+
+--- Returns the names of all visible functions in given Curry program.
+publicFuncNames :: CurryProg -> [QName]
+publicFuncNames = map funcName . filter ((== Public) . funcVis) . functions
+
+--- Returns the names of all visible constructors in given Curry program.
+publicConsNames :: CurryProg -> [QName]
+publicConsNames = map consName
+                . filter ((== Public) . consVis)
+                . constructors
+
+--- Returns the names of all visible types in given Curry program.
+publicTypeNames :: CurryProg -> [QName]
+publicTypeNames = map typeName . filter ((== Public) . typeVis) . types
+
+------------------------------------------------------------------------
+-- Selectors for type expressions
+
+--- Returns the type expression of a qualified type.
+typeOfQualType :: CQualTypeExpr -> CTypeExpr
+typeOfQualType (CQualType _ te) = te
+
+--- Returns the class constraints of a qualified type.
+classConstraintsOfQualType :: CQualTypeExpr -> [CConstraint]
+classConstraintsOfQualType (CQualType (CContext cc) _) = cc
+
+--- Returns the name of a given type declaration
+typeName :: CTypeDecl -> QName
+typeName (CType    n _ _ _ _) = n
+typeName (CTypeSyn n _ _ _  ) = n
+typeName (CNewType n _ _ _ _) = n
+
+--- Returns the visibility of a given type declaration.
+typeVis :: CTypeDecl -> CVisibility
+typeVis (CType    _ vis _ _ _) = vis
+typeVis (CTypeSyn _ vis _ _  ) = vis
+typeVis (CNewType _ vis _ _ _) = vis
+
+--- Returns the constructors of a given type declaration.
+typeCons :: CTypeDecl -> [CConsDecl]
+typeCons (CType    _ _ _ cs _) = cs
+typeCons (CTypeSyn _ _ _ _   ) = []
+typeCons (CNewType _ _ _ c  _) = [c]
+
+--- Returns the name of a given constructor declaration.
+consName :: CConsDecl -> QName
+consName (CCons   n _ _) = n
+consName (CRecord n _ _) = n
+
+--- Returns the visibility of a given constructor declaration.
+consVis :: CConsDecl -> CVisibility
+consVis (CCons   _ vis _) = vis
+consVis (CRecord _ vis _) = vis
+
+--- Returns true if the type expression is a base type.
+isBaseType :: CTypeExpr -> Bool
+isBaseType texp = case texp of
+  CTCons _ -> True
+  _        -> False
+
+--- Returns true if the type expression contains type variables.
+isPolyType :: CTypeExpr -> Bool
+isPolyType (CTVar                _) = True
+isPolyType (CFuncType domain range) = isPolyType domain || isPolyType range
+isPolyType (CTCons    _)            = False
+isPolyType (CTApply tcon texp)      = isPolyType tcon || isPolyType texp
+
+--- Returns true if the type expression is a functional type.
+isFunctionalType :: CTypeExpr -> Bool
+isFunctionalType texp = case texp of
+  CFuncType _ _ -> True
+  _             -> False
+
+--- Returns true if the type expression is (IO t).
+isIOType :: CTypeExpr -> Bool
+isIOType texp = case texp of
+  CTApply (CTCons tc) _ -> tc == pre "IO"
+  _                     -> False
+
+--- Returns true if the type expression is (IO t) with t/=() and
+--- t is not functional
+isIOReturnType :: CTypeExpr -> Bool
+isIOReturnType (CTVar     _)   = False
+isIOReturnType (CFuncType _ _) = False
+isIOReturnType (CTCons    _)   = False
+isIOReturnType (CTApply tcon targ) =
+  tcon == CTCons (pre "IO") && targ /= CTCons (pre "()")
+  && not (isFunctionalType targ)
+
+--- Returns all argument types from a functional type
+argTypes :: CTypeExpr -> [CTypeExpr]
+argTypes texp = case texp of CFuncType t1 t2 -> t1 : argTypes t2
+                             _               -> []
+
+--- Return the result type from a (nested) functional type
+resultType :: CTypeExpr -> CTypeExpr
+resultType texp = case texp of CFuncType _ t2 -> resultType t2
+                               _              -> texp
+
+--- Returns all type variables occurring in a type expression.
+tvarsOfType :: CTypeExpr -> [CTVarIName]
+tvarsOfType (CTVar v) = [v]
+tvarsOfType (CFuncType t1 t2) = tvarsOfType t1 ++ tvarsOfType t2
+tvarsOfType (CTCons _)        = []
+tvarsOfType (CTApply t1 t2)   = tvarsOfType t1 ++ tvarsOfType t2
+
+--- Returns all type constructors used in the given type.
+tconsOfType :: CTypeExpr -> [QName]
+tconsOfType (CTVar            _) = []
+tconsOfType (CFuncType t1 t2) = tconsOfType t1 `union` tconsOfType t2
+tconsOfType (CTCons tc)       = [tc]
+tconsOfType (CTApply t1 t2)   = tconsOfType t1 `union` tconsOfType t2
+
+--- Returns all modules used in the given type.
+modsOfType :: CTypeExpr -> [String]
+modsOfType = map fst . tconsOfType
+
+--- Transforms a type constructor application into a pair of the type
+--- constructor and the argument types, if possible.
+tconsArgsOfType :: CTypeExpr -> Maybe (QName,[CTypeExpr])
+tconsArgsOfType (CTVar       _) = Nothing
+tconsArgsOfType (CFuncType _ _) = Nothing
+tconsArgsOfType (CTCons tc)     = Just (tc,[])
+tconsArgsOfType (CTApply te ta) =
+  maybe Nothing
+        (\ (tc,targs) -> Just (tc,targs++[ta]))
+        (tconsArgsOfType te)
+
+------------------------------------------------------------------------
+-- Selectors for function definitions
+
+--- Returns the name of a given function declaration.
+funcName :: CFuncDecl -> QName
+funcName (CFunc     n _ _ _ _) = n
+funcName (CmtFunc _ n _ _ _ _) = n
+
+-- Returns the visibility of a given function declaration.
+funcArity :: CFuncDecl -> Int
+funcArity (CFunc     _ a _ _ _) = a
+funcArity (CmtFunc _ _ a _ _ _) = a
+
+--- Returns the documentation comment of a given function declaration.
+funcComment :: CFuncDecl -> String
+funcComment (CFunc       _ _ _ _ _) = ""
+funcComment (CmtFunc cmt _ _ _ _ _) = cmt
+
+--- Returns the visibility of a given function declaration.
+funcVis :: CFuncDecl -> CVisibility
+funcVis (CFunc     _ _ vis _ _) = vis
+funcVis (CmtFunc _ _ _ vis _ _) = vis
+
+--- Returns the type of a given function declaration.
+funcType :: CFuncDecl -> CQualTypeExpr
+funcType (CFunc     _ _ _ texp _) = texp
+funcType (CmtFunc _ _ _ _ texp _) = texp
+
+--- Returns the rules of a given function declaration.
+funcRules :: CFuncDecl -> [CRule]
+funcRules (CFunc     _ _ _ _ rules) = rules
+funcRules (CmtFunc _ _ _ _ _ rules) = rules
+
+------------------------------------------------------------------------
+-- Selectors for rules.
+
+--- Returns the right-hand side of a rules.
+ruleRHS :: CRule -> CRhs
+ruleRHS (CRule _ rhs) = rhs
+
+--- Returns the local declarations of given rule.
+ldeclsOfRule :: CRule -> [CLocalDecl]
+ldeclsOfRule (CRule _ (CSimpleRhs  _ lDecls)) = lDecls
+ldeclsOfRule (CRule _ (CGuardedRhs _ lDecls)) = lDecls
+
+------------------------------------------------------------------------
+-- Operations to compute the variables occurring in a pattern or expression:
+
+--- Returns list of all variables occurring in a pattern.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfPat :: CPattern -> [CVarIName]
+varsOfPat (CPVar v) = [v]
+varsOfPat (CPLit _) = []
+varsOfPat (CPComb _ pats) = concatMap varsOfPat pats
+varsOfPat (CPAs v pat) = v : varsOfPat pat
+varsOfPat (CPFuncComb _ pats) = concatMap varsOfPat pats
+varsOfPat (CPLazy pat) = varsOfPat pat
+varsOfPat (CPRecord _ recpats) = concatMap (varsOfPat . snd) recpats
+
+--- Returns list of all variables occurring in an expression.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfExp :: CExpr -> [CVarIName]
+varsOfExp (CVar v)            = [v]
+varsOfExp (CLit _)            = []
+varsOfExp (CSymbol _)         = []
+varsOfExp (CApply e1 e2)      = varsOfExp e1 ++ varsOfExp e2
+varsOfExp (CLambda pl le)     = concatMap varsOfPat pl ++ varsOfExp le
+varsOfExp (CLetDecl ld le)    = concatMap varsOfLDecl ld ++ varsOfExp le
+varsOfExp (CDoExpr sl)        = concatMap varsOfStat sl
+varsOfExp (CListComp le sl)   = varsOfExp le ++ concatMap varsOfStat sl
+varsOfExp (CCase _ ce bl)     =
+  varsOfExp ce ++ concatMap (\ (p,rhs) -> varsOfPat p ++ varsOfRhs rhs) bl
+varsOfExp (CTyped te _)       = varsOfExp te
+varsOfExp (CRecConstr _ upds) = concatMap (varsOfExp . snd) upds
+varsOfExp (CRecUpdate e upds) = varsOfExp e ++ concatMap (varsOfExp . snd) upds
+
+--- Returns list of all variables occurring in a right-hand side.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfRhs :: CRhs -> [CVarIName]
+varsOfRhs (CSimpleRhs rhs ldecls) =
+  varsOfExp rhs ++ concatMap varsOfLDecl ldecls
+varsOfRhs (CGuardedRhs gs  ldecls) =
+  concatMap (\ (g,e) -> varsOfExp g ++ varsOfExp e) gs  ++
+  concatMap varsOfLDecl ldecls
+
+--- Returns list of all variables occurring in a statement.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfStat :: CStatement -> [CVarIName]
+varsOfStat (CSExpr e)  = varsOfExp e
+varsOfStat (CSPat p e) = varsOfPat p ++ varsOfExp e
+varsOfStat (CSLet ld)  = concatMap varsOfLDecl ld
+
+--- Returns list of all variables occurring in a local declaration.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfLDecl :: CLocalDecl -> [CVarIName]
+varsOfLDecl (CLocalFunc f)     = varsOfFDecl f
+varsOfLDecl (CLocalPat p rhs)  = varsOfPat p ++ varsOfRhs rhs
+varsOfLDecl (CLocalVars lvars) = lvars
+
+--- Returns list of all variables occurring in a function declaration.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfFDecl :: CFuncDecl -> [CVarIName]
+varsOfFDecl (CFunc     _ _ _ _ r) = concatMap varsOfRule r
+varsOfFDecl (CmtFunc _ _ _ _ _ r) = concatMap varsOfRule r
+
+--- Returns list of all variables occurring in a rule.
+--- Each occurrence corresponds to one element, i.e., the list might
+--- contain multiple elements.
+varsOfRule :: CRule -> [CVarIName]
+varsOfRule (CRule pats rhs) = concatMap varsOfPat pats ++ varsOfRhs rhs
+
+------------------------------------------------------------------------
+-- Operations to compute the function names declared in functions, local
+-- declarations and statements:
+
+--- @return The list of declared function names of the given local declaration.
+funcNamesOfLDecl :: CLocalDecl -> [QName]
+funcNamesOfLDecl lDecl =
+    case lDecl of CLocalFunc f -> funcNamesOfFDecl f
+                  _            -> []
+
+--- @return The declared function name of given function declaration in a list.
+funcNamesOfFDecl :: CFuncDecl -> [QName]
+funcNamesOfFDecl (CFunc     qn _ _ _ _) = [qn]
+funcNamesOfFDecl (CmtFunc _ qn _ _ _ _) = [qn]
+
+--- @return The declared function names of given statement in a list.
+funcNamesOfStat :: CStatement -> [QName]
+funcNamesOfStat stms =
+    case stms of CSLet ld -> concatMap funcNamesOfLDecl ld
+                 _        -> []
+
+------------------------------------------------------------------------
+--- Tests whether a module name is the prelude.
+isPrelude :: String -> Bool
+isPrelude m = m == "Prelude"
+
+------------------------------------------------------------------------

--- a/src/LSP/Generation/AbstractCurry/Transform.curry
+++ b/src/LSP/Generation/AbstractCurry/Transform.curry
@@ -1,0 +1,707 @@
+----------------------------------------------------------------------------
+--- This library provides transformation and update operations
+--- on AbstractCurry programs.
+--- Since the transformations are defined recursively on structured types,
+--- they are useful to construct specific transformations on AbstractCurry
+--- programs.
+--- In particular, this library contains the transformation
+--- `renameCurryModule` to rename an AbstractCurry module.
+---
+--- @author Michael Hanus
+--- @version October 2016
+--- @category meta
+----------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Transform where
+
+import LSP.Generation.AbstractCurry.Types
+import LSP.Generation.AbstractCurry.Select
+
+import Data.List (nub, union)
+
+--- This type synonym is useful to denote the type of an update,
+--- where the first argument is the type of values which are updated
+--- by the local update (which acts on types described by the second argument).
+type Update a b = (b -> b) -> a -> a
+
+----------------------------------------------------------------------------
+-- CurryProg
+
+--- Transforms an AbstractCurry program.
+trCProg :: (String -> [String] -> (Maybe CDefaultDecl) -> [CClassDecl]
+        -> [CInstanceDecl] -> [CTypeDecl] -> [CFuncDecl] -> [COpDecl] -> a)
+        -> CurryProg -> a
+trCProg prog (CurryProg name imps dfltdecl clsdecls instdecls types funcs ops) =
+  prog name imps dfltdecl clsdecls instdecls types funcs ops
+
+--- Updates an AbstractCurry program.
+updCProg :: (String      -> String)      ->
+            ([String]    -> [String])    ->
+            (Maybe CDefaultDecl -> Maybe CDefaultDecl) ->
+            ([CClassDecl] -> [CClassDecl]) ->
+            ([CInstanceDecl] -> [CInstanceDecl]) ->
+            ([CTypeDecl] -> [CTypeDecl]) ->
+            ([CFuncDecl] -> [CFuncDecl]) ->
+            ([COpDecl]   -> [COpDecl])   -> CurryProg -> CurryProg
+updCProg fn fi fdft fcl fci ft ff fo = trCProg prog
+ where
+  prog name imps dfltdecl clsdecls instdecls types funcs ops =
+    CurryProg (fn name) (fi imps) (fdft dfltdecl) (fcl clsdecls) (fci instdecls)
+              (ft types) (ff funcs) (fo ops)
+
+--- Updates the name of a Curry program.
+updCProgName :: Update CurryProg String
+updCProgName f = updCProg f id id id id id id id
+
+----------------------------------------------------------------------------
+-- CDefaultDecl
+
+--- Transforms a default declaration.
+trCDefaultDecl :: ([CTypeExpr] -> a) -> CDefaultDecl -> a
+trCDefaultDecl defdecl (CDefaultDecl texps) = defdecl texps
+
+--- Updates a default declaration.
+updCDefaultDecl :: ([CTypeExpr] -> [CTypeExpr])
+                -> CDefaultDecl -> CDefaultDecl
+updCDefaultDecl fts = trCDefaultDecl (\texps -> CDefaultDecl (fts texps))
+
+----------------------------------------------------------------------------
+-- CConstraint
+
+--- Transforms a class context.
+trCContext :: ([CConstraint] -> a) -> CContext -> a
+trCContext ctxt (CContext constrs) = ctxt constrs
+
+--- Updates a class context.
+updCContext :: ([CConstraint] -> [CConstraint])
+            -> CContext -> CContext
+updCContext fc = trCContext (\constrs -> CContext (fc constrs))
+
+----------------------------------------------------------------------------
+-- CClassDecl
+
+--- Transforms a class declaration.
+trCClassDecl ::
+  (QName -> CVisibility -> CContext -> CTVarIName -> [CFuncDecl] -> a)
+  -> CClassDecl -> a
+trCClassDecl cls (CClass name vis ctxt tvar funcs) =
+  cls name vis ctxt tvar funcs
+
+--- Updates an AbstractCurry program.
+updCClassDecl :: (QName       -> QName)
+              -> (CVisibility -> CVisibility)
+              -> (CContext    -> CContext)
+              -> (CTVarIName  -> CTVarIName)
+              -> ([CFuncDecl] -> [CFuncDecl])
+              -> CClassDecl -> CClassDecl
+updCClassDecl fn fv fc ft ff = trCClassDecl cls
+ where
+  cls name vis ctxt tvar funcs =
+    CClass (fn name) (fv vis) (fc ctxt) (ft tvar) (ff funcs)
+
+----------------------------------------------------------------------------
+-- CInstanceDecl
+
+--- Transforms a class declaration.
+trCInstanceDecl :: (QName -> CContext -> CTypeExpr -> [CFuncDecl] -> a)
+                -> CInstanceDecl -> a
+trCInstanceDecl inst (CInstance name ctxt texp funcs) =
+  inst name ctxt texp funcs
+
+--- Updates an AbstractCurry program.
+updCInstanceDecl :: (QName       -> QName)
+                 -> (CContext    -> CContext)
+                 -> (CTypeExpr   -> CTypeExpr)
+                 -> ([CFuncDecl] -> [CFuncDecl])
+                 -> CInstanceDecl -> CInstanceDecl
+updCInstanceDecl fn fc ft ff = trCInstanceDecl inst
+ where
+  inst name ctxt texp funcs =
+    CInstance (fn name) (fc ctxt) (ft texp) (ff funcs)
+
+----------------------------------------------------------------------------
+-- CTypeDecl
+
+--- Transforms a type declaration.
+trCTypeDecl ::
+    (QName -> CVisibility -> [CTVarIName] -> [CConsDecl] -> [QName] -> a)
+ -> (QName -> CVisibility -> [CTVarIName] -> CTypeExpr   -> a)
+ -> (QName -> CVisibility -> [CTVarIName] -> CConsDecl   -> [QName] -> a)
+ -> CTypeDecl -> a
+trCTypeDecl typ _ _   (CType name vis params cs dvs) =
+ typ name vis params cs dvs
+trCTypeDecl _ tsyn _  (CTypeSyn name vis params syn) = tsyn  name vis params syn
+trCTypeDecl _ _ tntyp (CNewType name vis params nt dvs) =
+ tntyp name vis params nt dvs
+
+--- update type declaration
+updCTypeDecl :: (QName -> QName)
+             -> (CVisibility  -> CVisibility)
+             -> ([CTVarIName] -> [CTVarIName])
+             -> ([CConsDecl]  -> [CConsDecl])
+             -> (CTypeExpr    -> CTypeExpr)
+             -> (CConsDecl    -> CConsDecl)
+             -> ([QName]      -> [QName])
+             -> CTypeDecl -> CTypeDecl
+updCTypeDecl fn fv fp fc fs ft fd = trCTypeDecl typ tsyn tntyp
+ where
+  typ   name vis params cs der =
+    CType    (fn name) (fv vis) (fp params) (fc cs) (fd der)
+  tsyn  name vis params syn  = CTypeSyn (fn name) (fv vis) (fp params) (fs syn)
+  tntyp name vis params ntyp der =
+    CNewType (fn name) (fv vis) (fp params) (ft ntyp) (fd der)
+
+--- Updates the name of a type declaration.
+updCTypeDeclName :: Update CTypeDecl QName
+updCTypeDeclName f = updCTypeDecl f id id id id id id
+
+
+----------------------------------------------------------------------------
+-- CConsDecl
+
+--- Transforms a constructor declaration.
+trCConsDecl ::
+     (QName -> CVisibility -> [CTypeExpr]  -> a)
+  -> (QName -> CVisibility -> [CFieldDecl] -> a)
+  -> CConsDecl -> a
+trCConsDecl cons _ (CCons   name vis args) =
+  cons name vis args
+trCConsDecl _ rec  (CRecord name vis args) =
+  rec  name vis args
+
+--- Updates a constructor declaration.
+updCConsDecl :: (QName -> QName)
+             -> (CVisibility  -> CVisibility)
+             -> ([CTypeExpr]  -> [CTypeExpr])
+             -> ([CFieldDecl] -> [CFieldDecl])
+             -> CConsDecl -> CConsDecl
+updCConsDecl fn fv fts ffs = trCConsDecl cons rec
+ where
+  cons name vis args =
+    CCons   (fn name) (fv vis) (fts args)
+  rec  name vis args =
+    CRecord (fn name) (fv vis) (ffs args)
+
+--- Updates the name of a constructor declaration.
+updCConsDeclName :: Update CConsDecl QName
+updCConsDeclName f = updCConsDecl f id id id
+
+----------------------------------------------------------------------------
+-- CFieldDecl
+
+--- Transforms a constructor declaration.
+trCFieldDecl :: (QName -> CVisibility -> CTypeExpr  -> a)
+             -> CFieldDecl -> a
+trCFieldDecl field (CField name vis texp) = field name vis texp
+
+--- update constructor declaration
+updCFieldDecl :: (QName -> QName)
+              -> (CVisibility -> CVisibility)
+              -> (CTypeExpr   -> CTypeExpr)
+              -> CFieldDecl -> CFieldDecl
+updCFieldDecl fn fv ft = trCFieldDecl field
+ where
+  field name vis texp = CField (fn name) (fv vis) (ft texp)
+
+--- Updates the name of a constructor declaration.
+updCFieldDeclName :: Update CFieldDecl QName
+updCFieldDeclName f = updCFieldDecl f id id
+
+----------------------------------------------------------------------------
+-- CQualTypeExpr
+
+--- Transforms a default declaration.
+trCQualTypeExpr :: (CContext -> CTypeExpr -> a) -> CQualTypeExpr -> a
+trCQualTypeExpr qtexp (CQualType ctxt texp) = qtexp ctxt texp
+
+--- Updates a default declaration.
+updCQualTypeExpr :: (CContext  -> CContext)
+                 -> (CTypeExpr -> CTypeExpr)
+                 -> CQualTypeExpr -> CQualTypeExpr
+updCQualTypeExpr fc ft =
+  trCQualTypeExpr (\ctxt texp -> CQualType (fc ctxt) (ft texp))
+
+----------------------------------------------------------------------------
+-- CTypeExpr
+
+--- Transforms a type expression.
+trCTypeExpr :: (CTVarIName -> a)
+            -> (QName -> a)
+            -> (a -> a -> a)
+            -> (a -> a -> a)
+            -> CTypeExpr -> a
+trCTypeExpr tvar tcons functype applytype texp = trTE texp
+ where
+  trTE (CTVar n)           = tvar n
+  trTE (CTCons name)       = tcons name
+  trTE (CFuncType from to) = functype  (trTE from) (trTE to)
+  trTE (CTApply   from to) = applytype (trTE from) (trTE to)
+
+--- Updates all type constructors in a type expression.
+updTConsApp :: (QName -> CTypeExpr) -> CTypeExpr -> CTypeExpr
+updTConsApp tcons = trCTypeExpr CTVar tcons CFuncType CTApply
+
+----------------------------------------------------------------------------
+-- COpDecl
+
+--- Transforms an operator declaration.
+trCOpDecl :: (QName -> CFixity -> Int -> a) -> COpDecl -> a
+trCOpDecl op (COp name fix prec) = op name fix prec
+
+--- Updates an operator declaration.
+updCOpDecl :: (QName -> QName) -> (CFixity -> CFixity) -> (Int -> Int)
+           -> COpDecl -> COpDecl
+updCOpDecl fn ff fp = trCOpDecl op
+ where
+  op name fix prec = COp (fn name) (ff fix) (fp prec)
+
+--- Updates the name of an operator declaration.
+updCOpName :: Update COpDecl QName
+updCOpName f = updCOpDecl f id id
+
+----------------------------------------------------------------------------
+-- CFuncDecl
+
+--- Transforms a function declaration
+trCFuncDecl ::
+    (String -> QName -> Int -> CVisibility -> CQualTypeExpr -> [CRule] -> a)
+    -> CFuncDecl -> a
+trCFuncDecl func (CFunc      name arity vis t rs) = func "" name arity vis t rs
+trCFuncDecl func (CmtFunc cm name arity vis t rs) = func cm name arity vis t rs
+
+--- Updates a function declaration.
+updCFuncDecl :: (String -> String)
+             -> (QName -> QName)
+             -> (Int -> Int)
+             -> (CVisibility -> CVisibility)
+             -> (CQualTypeExpr -> CQualTypeExpr)
+             -> ([CRule] -> [CRule])
+             -> CFuncDecl -> CFuncDecl
+updCFuncDecl fc fn fa fv ft fr = trCFuncDecl func
+ where 
+  func cmt name arity vis t rules =
+    if null cmt
+    then CFunc (fn name) (fa arity) (fv vis) (ft t) (fr rules)
+    else CmtFunc (fc cmt) (fn name) (fa arity) (fv vis) (ft t) (fr rules)
+
+----------------------------------------------------------------------------
+-- CRule
+
+--- Transform a rule.
+trCRule :: ([CPattern] -> CRhs -> a) -> CRule -> a
+trCRule rule (CRule pats rhs) = rule pats rhs
+
+--- Update a rule.
+updCRule :: ([CPattern] -> [CPattern])
+         -> (CRhs -> CRhs)
+         -> CRule -> CRule
+updCRule fp fr = trCRule rule
+ where
+  rule pats rhs = CRule (fp pats) (fr rhs)
+
+----------------------------------------------------------------------------
+-- CRhs
+
+--- Transforms a right-hand side (of a rule or case expression).
+trCRhs :: (CExpr -> [CLocalDecl] -> a)
+       -> ([(CExpr, CExpr)] -> [CLocalDecl] -> a)
+       -> CRhs -> a
+trCRhs srhs _ (CSimpleRhs  exp   locals) = srhs exp locals
+trCRhs _ grhs (CGuardedRhs gexps locals) = grhs gexps locals
+
+--- Updates right-hand side.
+updCRhs :: (CExpr -> CExpr)
+        -> ([(CExpr, CExpr)] -> [(CExpr, CExpr)])
+        -> ([CLocalDecl]     -> [CLocalDecl])
+        -> CRhs -> CRhs
+updCRhs fe fg fl = trCRhs srhs grhs
+ where
+  srhs exp   locals = CSimpleRhs (fe exp) (fl locals)
+  grhs gexps locals = CGuardedRhs (fg gexps) (fl locals)
+
+----------------------------------------------------------------------------
+-- CLocalDecl
+
+--- Transforms a local declaration.
+trCLocalDecl :: (CFuncDecl -> a)
+             -> (CPattern -> CRhs -> a)
+             -> ([CVarIName] -> a)
+             -> CLocalDecl -> a
+trCLocalDecl lfun _ _ (CLocalFunc fdecl)  = lfun fdecl
+trCLocalDecl _ lpat _ (CLocalPat pat rhs) = lpat pat rhs
+trCLocalDecl _ _ vars (CLocalVars vs)     = vars vs
+
+--- Updates a local declaration.
+updCLocalDecl :: (CFuncDecl   -> CFuncDecl)
+              -> (CPattern    -> CPattern)
+              -> (CRhs        -> CRhs)
+              -> ([CVarIName] -> [CVarIName])
+              -> CLocalDecl   -> CLocalDecl
+updCLocalDecl ff fp fr fv = trCLocalDecl lfun lpat lvars
+ where
+  lfun fdecl   = CLocalFunc (ff fdecl)
+  lpat pat rhs = CLocalPat (fp pat) (fr rhs)
+  lvars vars   = CLocalVars (fv vars)
+
+----------------------------------------------------------------------------
+-- CPattern
+
+--- Transforms a pattern.
+trCPattern :: (CVarIName -> a)
+           -> (CLiteral -> a)
+           -> (QName -> [a] -> a)
+           -> (CVarIName -> a -> a)
+           -> (QName -> [a] -> a)
+           -> (QName -> [CField a] -> a)
+           -> CPattern -> a
+trCPattern fv fl fc fa ff fr pattern = trP pattern
+ where
+  trP (CPVar pvar)         = fv pvar
+  trP (CPLit lit)          = fl lit
+  trP (CPComb c pats)      = fc c (map trP pats)
+  trP (CPAs v pat)         = fa v (trP pat)
+  trP (CPFuncComb fn pats) = ff fn (map trP pats)
+  trP (CPLazy pat)         = trP pat
+  trP (CPRecord r fs)      = fr r (map (\(n,p) -> (n,trP p)) fs)
+
+--- Updates a pattern.
+updCPattern :: (CVarIName   -> CVarIName)
+            -> (CLiteral    -> CLiteral)
+            -> (QName       -> QName)
+            -> CPattern   -> CPattern
+updCPattern fv fl fn = trCPattern pvar plit pcomb pas pfcomb prec
+ where
+  pvar var = CPVar (fv var)
+  plit lit = CPLit (fl lit)
+  pcomb c pats = CPComb (fn c) (map (updCPattern fv fl fn) pats)
+  pas v pat = CPAs (fv v) (updCPattern fv fl fn pat)
+  pfcomb f pats = CPFuncComb (fn f) (map (updCPattern fv fl fn) pats)
+  prec r fields = CPRecord (fn r)
+                    (map (\ (n,p) -> (fn n, updCPattern fv fl fn p)) fields)
+
+----------------------------------------------------------------------------
+-- CExpr
+
+--- Transforms an expression.
+trExpr :: (CVarIName -> a)
+       -> (CLiteral -> a)
+       -> (QName -> a)
+       -> (a -> a -> a)
+       -> ([CPattern] -> a -> a)
+       -> ([CLocalDecl] -> a -> a)
+       -> ([CStatement] -> a)
+       -> (a -> [CStatement] -> a)
+       -> (CCaseType -> a -> [(CPattern, CRhs)] -> a)
+       -> (a -> CQualTypeExpr -> a)
+       -> (QName -> [CField a] -> a)
+       -> (a -> [CField a] -> a)
+       -> CExpr -> a
+trExpr var lit sym app lam clet cdo lcomp cas typ rcon rupd exp = trE exp
+ where
+  trE (CVar n) = var n
+  trE (CLit l) = lit l
+  trE (CSymbol n) = sym n
+  trE (CApply e1 e2) = app (trE e1) (trE e2)
+  trE (CLambda pats e) = lam pats (trE e)
+  trE (CLetDecl ls e) = clet ls (trE e)
+  trE (CDoExpr stm) = cdo stm
+  trE (CListComp e stm) = lcomp (trE e) stm
+  trE (CCase ct e branches) = cas ct (trE e) branches
+  trE (CTyped e te) = typ (trE e) te
+  trE (CRecConstr rn fds) = rcon rn (map (\ (lb,e) -> (lb, trE e)) fds)
+  trE (CRecUpdate e  fds) = rupd (trE e) (map (\ (lb,v) -> (lb, trE v)) fds)
+ 
+----------------------------------------------------------------------------
+-- CStatement
+
+--- Transforms a statement (occuring in do expressions or list comprehensions).
+trCStatement :: (CExpr -> a)
+             -> (CPattern -> CExpr -> a)
+             -> ([CLocalDecl] -> a)
+             -> CStatement -> a
+trCStatement sexp _ _ (CSExpr exp)    = sexp exp
+trCStatement _ spat _ (CSPat pat exp) = spat pat exp
+trCStatement _ _ slet (CSLet locals)  = slet locals
+
+--- Updates a statement (occuring in do expressions or list comprehensions).
+updCStatement :: (CExpr      -> CExpr)
+              -> (CPattern   -> CPattern)
+              -> (CLocalDecl -> CLocalDecl)
+              -> CStatement  -> CStatement
+updCStatement fe fp fd = trCStatement sexp spat slet
+ where
+  sexp exp     = CSExpr (fe exp)
+  spat pat exp = CSPat (fp pat) (fe exp)
+  slet locals  = CSLet (map fd locals)
+
+----------------------------------------------------------------------------
+--- Renames a Curry module, i.e., updates the module name and all qualified
+--- names in a program.
+renameCurryModule :: String -> CurryProg -> CurryProg
+renameCurryModule newname prog =
+  updCProgName (const newname) (updQNamesInCProg rnm prog)
+ where
+  rnm mn@(mod,n) | mod == progName prog = (newname,n)
+                 | otherwise            = mn
+
+--- Updates all qualified names in a Curry program.
+updQNamesInCProg :: Update CurryProg QName
+updQNamesInCProg f =
+  updCProg id
+           id 
+           (updQNamesInCDefaultDecl f)
+           (map (updQNamesInCClassDecl f))
+           (map (updQNamesInCInstanceDecl f))
+           (map (updQNamesInCTypeDecl f))
+           (map (updQNamesInCFuncDecl f))
+           (map (updCOpName f))
+
+--- Updates all qualified names in a default declaration.
+updQNamesInCDefaultDecl :: Update (Maybe CDefaultDecl) QName
+updQNamesInCDefaultDecl f = updateDefltDecl
+ where
+   updateDefltDecl Nothing = Nothing
+   updateDefltDecl (Just defdecl) =
+     Just (updCDefaultDecl (map (updQNamesInCTypeExpr f)) defdecl)
+
+--- Updates all qualified names in a class declaration.
+updQNamesInCClassDecl :: Update CClassDecl QName
+updQNamesInCClassDecl f =
+  updCClassDecl f id (updQNamesInCContext f) id
+                (map (updQNamesInCFuncDecl f))
+
+--- Updates all qualified names in an instance declaration.
+updQNamesInCInstanceDecl :: Update CInstanceDecl QName
+updQNamesInCInstanceDecl f =
+  updCInstanceDecl f
+                   (updQNamesInCContext f)
+                   (updQNamesInCTypeExpr f)
+                   (map (updQNamesInCFuncDecl f))
+
+--- Updates all qualified names in a type declaration.
+updQNamesInCTypeDecl :: Update CTypeDecl QName
+updQNamesInCTypeDecl f =
+  updCTypeDecl f id id
+               (map (updQNamesInCConsDecl f))
+               (updQNamesInCTypeExpr f)
+               (updQNamesInCConsDecl f)
+               (map f)
+
+--- Updates all qualified names in a constructor declaration.
+updQNamesInCConsDecl :: Update CConsDecl QName
+updQNamesInCConsDecl f =
+  updCConsDecl f id
+               (map (updQNamesInCTypeExpr f))
+               (map (updQNamesInCFieldDecl f))
+
+--- Updates all qualified names in a constructor declaration.
+updQNamesInCContext :: Update CContext QName
+updQNamesInCContext f = updCContext (map updConstr)
+ where
+  updConstr (n,texp) = (f n, updQNamesInCTypeExpr f texp)
+
+--- Updates all qualified names in a record field declaration.
+updQNamesInCFieldDecl :: Update CFieldDecl QName
+updQNamesInCFieldDecl f = updCFieldDecl f id (updQNamesInCTypeExpr f)
+
+--- Updates all qualified names in a type expression.
+updQNamesInCQualTypeExpr :: Update CQualTypeExpr QName
+updQNamesInCQualTypeExpr f =
+  updCQualTypeExpr (updQNamesInCContext f) (updQNamesInCTypeExpr f)
+
+--- Updates all qualified names in a type expression.
+updQNamesInCTypeExpr :: Update CTypeExpr QName
+updQNamesInCTypeExpr f = updTConsApp (CTCons . f)
+
+--- Updates all qualified names in a function declaration.
+updQNamesInCFuncDecl :: Update CFuncDecl QName
+updQNamesInCFuncDecl f =
+  updCFuncDecl id f id id
+               (updQNamesInCQualTypeExpr f)
+               (map (updQNamesInCRule f))
+
+--- Updates all qualified names in a function declaration.
+updQNamesInCRule :: Update CRule QName
+updQNamesInCRule f =
+  updCRule (map (updQNamesInCPattern f))
+           (updQNamesInCRhs f)
+
+--- Updates all qualified names in a function declaration.
+updQNamesInCRhs :: Update CRhs QName
+updQNamesInCRhs f =
+  updCRhs (updQNamesInCExpr f)
+          (map (\ (g,e) -> (updQNamesInCExpr f g, updQNamesInCExpr f e)))
+          (map (updQNamesInCLocalDecl f))
+
+--- Updates all qualified names in a function declaration.
+updQNamesInCLocalDecl :: Update CLocalDecl QName
+updQNamesInCLocalDecl f =
+  updCLocalDecl (updQNamesInCFuncDecl f)
+                (updQNamesInCPattern f)
+                (updQNamesInCRhs f)
+                id
+
+--- Updates all qualified names in a function declaration.
+updQNamesInCPattern :: Update CPattern QName
+updQNamesInCPattern f = updCPattern id id f
+
+--- Updates all qualified names in a statement.
+updQNamesInCStatement :: Update CStatement QName
+updQNamesInCStatement f =
+  updCStatement (updQNamesInCExpr f)
+                (updQNamesInCPattern f)
+                (updQNamesInCLocalDecl f)
+
+updQNamesInCExpr :: Update CExpr QName
+updQNamesInCExpr f =
+  trExpr CVar CLit (CSymbol . f) CApply lam ldecl doexp lcomp ccase ctyped
+         reccon recupd
+ where
+  lam pats exp = CLambda (map (updQNamesInCPattern f) pats) exp
+  ldecl locals exp = CLetDecl (map (updQNamesInCLocalDecl f) locals) exp
+  doexp stms = CDoExpr (map (updQNamesInCStatement f) stms)
+  lcomp exp stms = CListComp exp (map (updQNamesInCStatement f) stms)
+  ccase ct exp bs = CCase ct exp
+    (map (\ (pat,rhs) -> (updQNamesInCPattern f pat, updQNamesInCRhs f rhs)) bs)
+  ctyped exp texp = CTyped exp (updQNamesInCQualTypeExpr f texp)
+  reccon rec fields = CRecConstr (f rec) (map (\ (l,e) -> (f l,e)) fields)
+  recupd exp fields = CRecUpdate exp (map (\ (l,e) -> (f l,e)) fields)
+  
+-------------------------------------------------------------------------
+--- Extracts all type names occurring in a program.
+typesOfCurryProg :: CurryProg -> [QName]
+typesOfCurryProg =
+  trCProg (\_ _ dfts cls insts types funcs _ ->
+              typesOfDefault dfts ++
+              unionMap typesOfCClassDecl    cls   ++
+              unionMap typesOfCInstanceDecl insts ++
+              unionMap typesOfCTypeDecl     types ++
+              unionMap typesOfCFuncDecl     funcs)
+ where
+  typesOfDefault Nothing = []
+  typesOfDefault (Just (CDefaultDecl texps)) = concatMap typesOfTypeExpr texps
+
+--- Extracts all type names occurring in a class declaration.
+--- Class names are ignored.
+typesOfCClassDecl :: CClassDecl -> [QName]
+typesOfCClassDecl =
+  trCClassDecl (\_ _ ctxt _ funcs -> typesOfContext ctxt ++
+                     unionMap typesOfCFuncDecl funcs)
+
+--- Extracts all type names occurring in a class declaration.
+--- Class names are ignored.
+typesOfCInstanceDecl :: CInstanceDecl -> [QName]
+typesOfCInstanceDecl =
+  trCInstanceDecl (\_ ctxt texp funcs -> typesOfContext ctxt ++
+                     typesOfTypeExpr texp ++
+                     unionMap typesOfCFuncDecl funcs)
+
+--- Extracts all type names occurring in a type declaration.
+--- Class names are ignored.
+typesOfCTypeDecl :: CTypeDecl -> [QName]
+typesOfCTypeDecl =
+  trCTypeDecl (\qn _ _ cdecls _ -> qn : concatMap typesOfConsDecl cdecls)
+              (\qn _ _ texp     -> qn : typesOfTypeExpr texp)
+              (\qn _ _ cdecl  _ -> qn : typesOfConsDecl cdecl)
+
+typesOfConsDecl :: CConsDecl -> [QName]
+typesOfConsDecl =
+  trCConsDecl (\_ _ texps   -> concatMap typesOfTypeExpr texps)
+              (\_ _ fddecls -> concatMap typesOfFieldDecl fddecls)
+
+typesOfFieldDecl :: CFieldDecl -> [QName]
+typesOfFieldDecl = trCFieldDecl (\_ _ texp -> typesOfTypeExpr texp)
+
+typesOfContext :: CContext -> [QName]
+typesOfContext = trCContext (concatMap (typesOfTypeExpr . snd))
+
+typesOfTypeExpr :: CTypeExpr -> [QName]
+typesOfTypeExpr = trCTypeExpr (\_ -> [])
+                              (\qn -> [qn])
+                              (++)
+                              (++)
+
+typesOfQualTypeExpr :: CQualTypeExpr -> [QName]
+typesOfQualTypeExpr =
+  trCQualTypeExpr (\ctxt texp -> typesOfContext ctxt ++ typesOfTypeExpr texp)
+
+typesOfCFuncDecl :: CFuncDecl -> [QName]
+typesOfCFuncDecl =
+  trCFuncDecl (\_ _ _ _ texp _ -> typesOfQualTypeExpr texp)
+  -- type annotations in expressions are currently ignored
+
+-- Map a list-valued function on a list and remove duplicates.
+unionMap :: Eq b => (a -> [b]) -> [a] -> [b]
+unionMap f = foldr union [] . (map (nub . f))
+
+----------------------------------------------------------------------------
+--- Extracts all function (and constructor) names occurring in a program.
+funcsOfCurryProg :: CurryProg -> [QName]
+funcsOfCurryProg =
+  trCProg (\_ _ _ cls insts types funcs _ ->
+              unionMap funcsOfCClassDecl    cls   ++
+              unionMap funcsOfCInstanceDecl insts ++
+              unionMap funcsOfCTypeDecl types ++
+              unionMap funcsOfCFuncDecl funcs)
+
+funcsOfCClassDecl :: CClassDecl -> [QName]
+funcsOfCClassDecl =
+  trCClassDecl (\_ _ _ _ funcs -> unionMap funcsOfCFuncDecl funcs)
+
+funcsOfCInstanceDecl :: CInstanceDecl -> [QName]
+funcsOfCInstanceDecl =
+  trCInstanceDecl (\_ _ _ funcs -> unionMap funcsOfCFuncDecl funcs)
+
+funcsOfCTypeDecl :: CTypeDecl -> [QName]
+funcsOfCTypeDecl =
+  trCTypeDecl (\_ _ _ cdecls _ -> concatMap funcsOfConsDecl cdecls)
+              (\_ _ _ _        -> [])
+              (\_ _ _ cdecl  _ -> funcsOfConsDecl cdecl)
+
+funcsOfConsDecl :: CConsDecl -> [QName]
+funcsOfConsDecl =
+  trCConsDecl (\qn _ _       -> [qn])
+              (\qn _ fddecls -> qn : concatMap funcsOfFieldDecl fddecls)
+
+funcsOfFieldDecl :: CFieldDecl -> [QName]
+funcsOfFieldDecl = trCFieldDecl (\qn _ _ -> [qn])
+
+--- Extracts all function (and constructor) names occurring in a function
+--- declaration.
+funcsOfCFuncDecl :: CFuncDecl -> [QName]
+funcsOfCFuncDecl =
+  trCFuncDecl (\_ _ _ _ _ rules -> concatMap funcsOfCRule rules)
+
+funcsOfCRule :: CRule -> [QName]
+funcsOfCRule = trCRule (\_ rhs -> funcsOfCRhs rhs)
+
+funcsOfCRhs :: CRhs -> [QName]
+funcsOfCRhs =
+  trCRhs (\e  ldecls -> funcsOfExpr e ++ concatMap funcsOfLDecl ldecls)
+         (\gs ldecls -> concatMap (\ (g,e) -> funcsOfExpr g ++ funcsOfExpr e) gs
+                        ++ concatMap funcsOfLDecl ldecls)
+
+funcsOfLDecl :: CLocalDecl -> [QName]
+funcsOfLDecl = trCLocalDecl funcsOfCFuncDecl (const funcsOfCRhs) (const [])
+
+funcsOfExpr :: CExpr -> [QName]
+funcsOfExpr =
+  trExpr (const [])
+         (const [])
+         (\n -> [n])
+         (++)
+         (const id)
+         (\ldecls e -> concatMap funcsOfLDecl ldecls ++ e)
+         (concatMap funcsOfStat)
+         (\e stats -> e ++ concatMap funcsOfStat stats)
+         (\_ e brs -> e ++ concatMap (funcsOfCRhs . snd) brs)
+         (\e _ -> e)
+         (\_ fields -> concatMap snd fields)
+         (\e fields -> e ++ concatMap snd fields)
+         
+funcsOfStat :: CStatement -> [QName]
+funcsOfStat = trCStatement funcsOfExpr
+                           (const funcsOfExpr)
+                           (concatMap funcsOfLDecl)
+
+-------------------------------------------------------------------------

--- a/src/LSP/Generation/AbstractCurry/Types.curry
+++ b/src/LSP/Generation/AbstractCurry/Types.curry
@@ -43,10 +43,11 @@ data CVisibility
 --- Data type for representing a Curry module in the intermediate form.
 --- A value of this data type has the form
 ---
----     (CurryProg modname imports dfltdecl clsdecls instdecls typedecls
+---     (CurryProg modname exports imports dfltdecl clsdecls instdecls typedecls
 ---                funcdecls opdecls)
 ---
 --- where modname: name of this module,
+---       exports: list of modules names that are exported,
 ---       imports: list of modules names that are imported,
 ---       dfltdecl: optional default declaration
 ---       clsdecls:  Class declarations
@@ -54,7 +55,7 @@ data CVisibility
 ---       typedecls: Type declarations
 ---       functions: Function declarations
 ---       opdecls: Operator precedence declarations
-data CurryProg = CurryProg MName [MName] (Maybe CDefaultDecl) [CClassDecl]
+data CurryProg = CurryProg MName [MName] [MName] (Maybe CDefaultDecl) [CClassDecl]
                            [CInstanceDecl] [CTypeDecl] [CFuncDecl] [COpDecl]
   deriving (Eq, Show)
 

--- a/src/LSP/Generation/AbstractCurry/Types.curry
+++ b/src/LSP/Generation/AbstractCurry/Types.curry
@@ -1,0 +1,311 @@
+-- ---------------------------------------------------------------------------
+--- This library contains a definition for representing Curry programs
+--- in Curry.
+---
+--- Note this defines a slightly new format for AbstractCurry
+--- in comparison to the first proposal of 2003.
+---
+--- Assumption: an abstract Curry program is stored in file with
+--- extension .acy
+---
+--- @author Michael Hanus, Bjoern Peemoeller, Finn Teegen
+--- @version November 2020
+-- ---------------------------------------------------------------------------
+
+module LSP.Generation.AbstractCurry.Types where
+
+-- ---------------------------------------------------------------------------
+-- Definition of data types for representing abstract Curry programs:
+-- ---------------------------------------------------------------------------
+
+--- Current version of AbstractCurry
+version :: String
+version = "AbstractCurry 3.0"
+
+--- A module name.
+type MName = String
+
+--- The data type for representing qualified names.
+--- In AbstractCurry all names are qualified to avoid name clashes.
+--- The first component is the module name and the second component the
+--- unqualified name as it occurs in the source program.
+--- An exception are locally defined names where the module name is
+--- the empty string (to avoid name clashes with a globally defined name).
+type QName = (MName, String)
+
+--- Data type to specify the visibility of various entities.
+data CVisibility
+  = Public    -- exported entity
+  | Private   -- private entity
+  deriving (Eq, Show)
+  
+
+--- Data type for representing a Curry module in the intermediate form.
+--- A value of this data type has the form
+---
+---     (CurryProg modname imports dfltdecl clsdecls instdecls typedecls
+---                funcdecls opdecls)
+---
+--- where modname: name of this module,
+---       imports: list of modules names that are imported,
+---       dfltdecl: optional default declaration
+---       clsdecls:  Class declarations
+---       instdecls: Instance declarations
+---       typedecls: Type declarations
+---       functions: Function declarations
+---       opdecls: Operator precedence declarations
+data CurryProg = CurryProg MName [MName] (Maybe CDefaultDecl) [CClassDecl]
+                           [CInstanceDecl] [CTypeDecl] [CFuncDecl] [COpDecl]
+  deriving (Eq, Show)
+
+--- Data type for representing default declarations.
+data CDefaultDecl = CDefaultDecl [CTypeExpr]
+  deriving (Eq, Show)
+
+--- Data type for representing classes declarations.
+---
+--- A type class definition of the form
+---
+---     class cx => c a where { ...;f :: t;... }
+---
+--- is represented by the Curry term
+---
+---     (CClass c v cx tv [...(CFunc f ar v t [...,CRule r,...])...])
+---
+--- where 'tv' is the index of the type variable 'a' and 'v' is the
+--- visibility of the type class resp. method.
+--- Note: The type variable indices are unique inside each class
+---       declaration and are usually numbered from 0.
+---       The methods' types share the type class' type variable index
+---       as the class variable has to occur in a method's type signature.
+---       The list of rules for a method's declaration may be empty if
+---       no default implementation is provided. The arity 'ar' is
+---       determined by a given default implementation or 0.
+---       Regardless of whether typed or untyped abstract curry is generated,
+---       the methods' declarations are always typed.
+data CClassDecl = CClass QName CVisibility CContext CTVarIName [CFuncDecl]
+  deriving (Eq, Show)
+
+--- Data type for representing instance declarations.
+---
+--- An instance definition of the form
+---
+---     instance cx => c ty where { ...;fundecl;... }
+---
+--- is represented by the Curry term
+---
+---     (CInstance c cx ty [...fundecl...])
+---
+--- Note: The type variable indices are unique inside each instance
+---       declaration and are usually numbered from 0.
+---       The methods' types use the instance's type variable indices
+---       (if typed abstract curry is generated).
+data CInstanceDecl = CInstance QName CContext CTypeExpr [CFuncDecl]
+  deriving (Eq, Show)
+
+--- Data type for representing definitions of algebraic data types
+--- and type synonyms.
+---
+--- A data type definition of the form
+---
+---     data t x1...xn = ...| c t1....tkc |...
+---       deriving (d1,...,dp)
+---
+--- is represented by the Curry term
+---
+---     (CType t v [i1,...,in]
+---            [...(CCons c v [t1,...,tkc])...] [d1,...,dp]))
+---
+--- where each `ij` is the index of the type variable `xj` and 'v' is the
+--- visibility of the type resp. constructor.
+---
+--- Note: the type variable indices are unique inside each type declaration
+---       and are usually numbered from 0
+---
+--- Thus, a data type declaration consists of the name of the data type,
+--- a list of type parameters and a list of constructor declarations.
+data CTypeDecl
+  = CType    QName CVisibility [CTVarIName] [CConsDecl] [QName]
+  | CTypeSyn QName CVisibility [CTVarIName] CTypeExpr
+  | CNewType QName CVisibility [CTVarIName] CConsDecl   [QName]
+  deriving (Eq, Show)
+
+--- The type for representing type variables.
+--- They are represented by (i,n) where i is a type variable index
+--- which is unique inside a function and n is a name (if possible,
+--- the name written in the source program).
+type CTVarIName = (Int, String)
+
+--- A constructor declaration consists of the name of the constructor
+--- and a list of the argument types of the constructor.
+--- The arity equals the number of types.
+data CConsDecl
+  = CCons   QName CVisibility [CTypeExpr]
+  | CRecord QName CVisibility [CFieldDecl]
+  deriving (Eq, Show)
+
+--- A record field declaration consists of the name of the
+--- the label, the visibility and its corresponding type.
+data CFieldDecl = CField QName CVisibility CTypeExpr
+  deriving (Eq, Show)
+
+--- Class constraint.
+type CConstraint = (QName, CTypeExpr)
+
+--- Context.
+data CContext = CContext [CConstraint]
+  deriving (Eq, Show)
+
+--- Type expression.
+--- A type expression is either a type variable, a function type,
+--- or a type constructor application.
+---
+--- Note: the names of the predefined type constructors are
+---       "Int", "Float", "Bool", "Char", "IO",
+---       "()" (unit type), "(,...,)" (tuple types), "[]" (list type)
+data CTypeExpr
+  = CTVar CTVarIName               -- type variable
+  | CFuncType CTypeExpr CTypeExpr  -- function type t1->t2
+  | CTCons QName                   -- type constructor
+  | CTApply CTypeExpr CTypeExpr    -- type application
+  deriving (Eq, Show)
+
+--- Qualified type expression.
+data CQualTypeExpr = CQualType CContext CTypeExpr
+  deriving (Eq, Show)
+
+--- Labeled record fields
+type CField a = (QName, a)
+
+--- Data type for operator declarations.
+--- An operator declaration "fix p n" in Curry corresponds to the
+--- AbstractCurry term (COp n fix p).
+data COpDecl = COp QName CFixity Int
+  deriving (Eq, Show)
+
+--- Data type for operator associativity
+data CFixity
+  = CInfixOp   -- non-associative infix operator
+  | CInfixlOp  -- left-associative infix operator
+  | CInfixrOp  -- right-associative infix operator
+  deriving (Eq, Show)
+
+--- Function arity
+type Arity = Int
+
+--- Data type for representing function declarations.
+---
+--- A function declaration in AbstractCurry is a term of the form
+---
+---     (CFunc name arity visibility type (CRules eval [CRule rule1,...,rulek]))
+---
+--- and represents the function `name` defined by the rules
+--- `rule1,...,rulek`.
+---
+--- Note: the variable indices are unique inside each rule
+---
+--- Thus, a function declaration consists of the name, arity, type, and
+--- a list of rules. The type is the function's type inferred by the
+--- type checker. However, if an AbstractCurry program is read with
+--- the operation `AbstractCurry.Files.readUntypedCurry`, the type
+--- is either the type signature provided by the programmer or
+--- the expression `(CTCons ("Prelude","untyped")`
+--- if the programmer has not provided an explicit type signature.
+---
+--- A function declaration with the constructor `CmtFunc`
+--- is similarly to `CFunc` but has a comment
+--- as an additional first argument. This comment could be used
+--- by pretty printers that generate a readable Curry program
+--- containing documentation comments.
+data CFuncDecl
+  = CFunc          QName Arity CVisibility CQualTypeExpr [CRule]
+  | CmtFunc String QName Arity CVisibility CQualTypeExpr [CRule]
+  deriving (Eq, Show)
+
+--- The general form of a function rule. It consists of a list of patterns
+--- (left-hand side) and the right-hand side for these patterns.
+data CRule = CRule [CPattern] CRhs
+  deriving (Eq, Show)
+
+--- Right-hand-side of a 'CRule' or a `case` expression.
+--- It is either a simple unconditional right-hand side or
+--- a list of guards with their corresponding right-hand sides, and
+--- a list of local declarations.
+data CRhs
+  = CSimpleRhs  CExpr            [CLocalDecl] -- expr where decls
+  | CGuardedRhs [(CExpr, CExpr)] [CLocalDecl] -- | cond = expr where decls
+  deriving (Eq, Show)
+
+--- Data type for representing local (let/where) declarations
+data CLocalDecl
+  = CLocalFunc CFuncDecl     -- local function declaration
+  | CLocalPat  CPattern CRhs -- local pattern declaration
+  | CLocalVars [CVarIName]   -- local free variable declaration
+  deriving (Eq, Show)
+
+--- Data types for representing object variables.
+--- Object variables occurring in expressions are represented by (Var i)
+--- where i is a variable index.
+type CVarIName = (Int,String)
+
+--- Data type for representing pattern expressions.
+data CPattern
+  = CPVar      CVarIName               -- pattern variable (unique index / name)
+  | CPLit      CLiteral                -- literal (Integer/Float/Char constant)
+  | CPComb     QName [CPattern]        -- application (m.c e1 ... en) of n-ary
+                                       -- constructor m.c (CPComb (m,c) [e1,...,en])
+  | CPAs       CVarIName CPattern      -- as-pattern (extended Curry)
+  | CPFuncComb QName [CPattern]        -- function pattern (extended Curry)
+  | CPLazy     CPattern                -- lazy pattern (extended Curry)
+  | CPRecord   QName [CField CPattern] -- record pattern (extended Curry)
+  deriving (Eq, Show)
+
+--- Data type for representing Curry expressions.
+data CExpr
+ = CVar       CVarIName                    -- variable (unique index / name)
+ | CLit       CLiteral                     -- literal (Int/Float/Char constant)
+ | CSymbol    QName                        -- a defined symbol (qualified name)
+ | CApply     CExpr CExpr                        -- application (e1 e2)
+ | CLambda    [CPattern] CExpr                   -- lambda abstraction
+ | CLetDecl   [CLocalDecl] CExpr                 -- local let declarations
+ | CDoExpr    [CStatement]                       -- do expression
+ | CListComp  CExpr [CStatement]                 -- list comprehension
+ | CCase      CCaseType CExpr [(CPattern, CRhs)] -- case expression
+ | CTyped     CExpr CQualTypeExpr                -- typed expression
+ | CRecConstr QName [CField CExpr]         -- record construction
+ | CRecUpdate CExpr [CField CExpr]         -- record update
+ deriving (Eq, Show)
+
+--- Data type for representing literals occurring in an expression.
+--- It is either an integer, a float, or a character constant.
+data CLiteral
+  = CIntc   Int
+  | CFloatc Float
+  | CCharc  Char
+  | CStringc String
+ deriving (Eq, Show)
+
+--- Data type for representing statements in do expressions and
+--- list comprehensions.
+data CStatement
+  = CSExpr CExpr         -- an expression (I/O action or boolean)
+  | CSPat CPattern CExpr -- a pattern definition
+  | CSLet [CLocalDecl]   -- a local let declaration
+  deriving (Eq, Show)
+
+--- Type of case expressions
+data CCaseType
+  = CRigid -- rigid case expression
+  | CFlex  -- flexible case expression
+  deriving (Eq, Show)
+
+---------------------------------------------------------------------------
+--- The name of the standard prelude.
+preludeName :: String
+preludeName = "Prelude"
+
+--- Converts a string into a qualified name of the Prelude.
+pre :: String -> QName
+pre f = (preludeName, f)
+
+---------------------------------------------------------------------------

--- a/src/LSP/Generation/AbstractCurry/Types.curry
+++ b/src/LSP/Generation/AbstractCurry/Types.curry
@@ -20,7 +20,7 @@ module LSP.Generation.AbstractCurry.Types where
 
 --- Current version of AbstractCurry
 version :: String
-version = "AbstractCurry 3.0"
+version = "LSP.Generation.AbstractCurry 3.0"
 
 --- A module name.
 type MName = String

--- a/src/LSP/Generation/Dependencies.curry
+++ b/src/LSP/Generation/Dependencies.curry
@@ -7,8 +7,10 @@ import qualified AbstractCurry.Types as AC
 import qualified Data.Set as S
 import LSP.Utils.General ( unions, unionMap )
 
--- TODO: Make this a type class?
--- This would also let us model CField more cleanly without requiring CExpr.
+-- TODO: It would be nice to turn this into a type class, which would also let
+-- us model CField more cleanly without requiring CExpr. Curry doesn't support
+-- instances on type aliases etc. (which would be needed for QName/String), so
+-- we cannot do this without FlexibleInstances etc.
 
 -- | Extracts the required imports from the given type declaration.
 typeDeclToImports :: AC.CTypeDecl -> S.Set String

--- a/src/LSP/Generation/Dependencies.curry
+++ b/src/LSP/Generation/Dependencies.curry
@@ -1,6 +1,6 @@
 module LSP.Generation.Dependencies
-  ( typeDeclToImports
-  , instanceDeclToImports
+  ( typeDeclModuleDeps
+  , instanceDeclModuleDeps
   ) where
 
 import qualified AbstractCurry.Types as AC
@@ -12,111 +12,111 @@ import LSP.Utils.General ( unions, unionMap )
 -- instances on type aliases etc. (which would be needed for QName/String), so
 -- we cannot do this without FlexibleInstances etc.
 
--- | Extracts the required imports from the given type declaration.
-typeDeclToImports :: AC.CTypeDecl -> S.Set String
-typeDeclToImports ty = case ty of
-  AC.CType    _ _ _ cdecls _ -> unionMap consDeclToImports cdecls
-  AC.CTypeSyn _ _ _ texp     -> typeExprToImports texp
-  AC.CNewType _ _ _ cdecl _  -> consDeclToImports cdecl
+-- | Extracts the module dependencies from the given type declaration.
+typeDeclModuleDeps :: AC.CTypeDecl -> S.Set String
+typeDeclModuleDeps ty = case ty of
+  AC.CType    _ _ _ cdecls _ -> unionMap consDeclModuleDeps cdecls
+  AC.CTypeSyn _ _ _ texp     -> typeExprModuleDeps texp
+  AC.CNewType _ _ _ cdecl _  -> consDeclModuleDeps cdecl
 
--- | Extracts the required imports from the given type expression.
-typeExprToImports :: AC.CTypeExpr -> S.Set String
-typeExprToImports texp = case texp of
+-- | Extracts the module dependencies from the given type expression.
+typeExprModuleDeps :: AC.CTypeExpr -> S.Set String
+typeExprModuleDeps texp = case texp of
   AC.CTVar _        -> S.empty
-  AC.CFuncType t t' -> S.union (typeExprToImports t) (typeExprToImports t')
-  AC.CTCons qn      -> qNameToImports qn
-  AC.CTApply t t'   -> S.union (typeExprToImports t) (typeExprToImports t')
+  AC.CFuncType t t' -> S.union (typeExprModuleDeps t) (typeExprModuleDeps t')
+  AC.CTCons qn      -> qNameModuleDeps qn
+  AC.CTApply t t'   -> S.union (typeExprModuleDeps t) (typeExprModuleDeps t')
 
--- | Extracts the required imports from the given constructor declaration.
-consDeclToImports :: AC.CConsDecl -> S.Set String
-consDeclToImports cdecl = case cdecl of
-  AC.CCons _ _ texps    -> unionMap typeExprToImports texps
-  AC.CRecord _ _ fdecls -> unionMap fieldDeclToImports fdecls
+-- | Extracts the module dependencies from the given constructor declaration.
+consDeclModuleDeps :: AC.CConsDecl -> S.Set String
+consDeclModuleDeps cdecl = case cdecl of
+  AC.CCons _ _ texps    -> unionMap typeExprModuleDeps texps
+  AC.CRecord _ _ fdecls -> unionMap fieldDeclModuleDeps fdecls
 
--- | Extracts the required imports from the given field declaration.
-fieldDeclToImports :: AC.CFieldDecl -> S.Set String
-fieldDeclToImports (AC.CField _ _ texp) = typeExprToImports texp
+-- | Extracts the module dependencies from the given field declaration.
+fieldDeclModuleDeps :: AC.CFieldDecl -> S.Set String
+fieldDeclModuleDeps (AC.CField _ _ texp) = typeExprModuleDeps texp
 
--- | Extracts the required imports from the given instance declaration.
-instanceDeclToImports :: AC.CInstanceDecl -> S.Set String
-instanceDeclToImports (AC.CInstance qn ctx texp fdecls) = unions
-  [ qNameToImports qn
-  , contextToImports ctx
-  , typeExprToImports texp
-  , unionMap funcDeclToImports fdecls
+-- | Extracts the module dependencies from the given instance declaration.
+instanceDeclModuleDeps :: AC.CInstanceDecl -> S.Set String
+instanceDeclModuleDeps (AC.CInstance qn ctx texp fdecls) = unions
+  [ qNameModuleDeps qn
+  , contextModuleDeps ctx
+  , typeExprModuleDeps texp
+  , unionMap funcDeclModuleDeps fdecls
   ]
 
--- | Extracts the required imports from the given context.
-contextToImports :: AC.CContext -> S.Set String
-contextToImports (AC.CContext cs) = unionMap constraintToImports cs
+-- | Extracts the module dependencies from the given context.
+contextModuleDeps :: AC.CContext -> S.Set String
+contextModuleDeps (AC.CContext cs) = unionMap constraintModuleDeps cs
 
--- | Extracts the required imports from the given constraint.
-constraintToImports :: AC.CConstraint -> S.Set String
-constraintToImports (qn, texp) = S.union (qNameToImports qn) (typeExprToImports texp)
+-- | Extracts the module dependencies from the given constraint.
+constraintModuleDeps :: AC.CConstraint -> S.Set String
+constraintModuleDeps (qn, texp) = S.union (qNameModuleDeps qn) (typeExprModuleDeps texp)
 
--- | Extracts the required imports from the given function declaration.
-funcDeclToImports :: AC.CFuncDecl -> S.Set String
-funcDeclToImports fdecl = case fdecl of
-  AC.CFunc     qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unionMap ruleToImports rs]
-  AC.CmtFunc _ qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unionMap ruleToImports rs]
+-- | Extracts the module dependencies from the given function declaration.
+funcDeclModuleDeps :: AC.CFuncDecl -> S.Set String
+funcDeclModuleDeps fdecl = case fdecl of
+  AC.CFunc     qn _ _ qty rs -> unions [qNameModuleDeps qn, qualTypeExprModuleDeps qty, unionMap ruleModuleDeps rs]
+  AC.CmtFunc _ qn _ _ qty rs -> unions [qNameModuleDeps qn, qualTypeExprModuleDeps qty, unionMap ruleModuleDeps rs]
 
--- | Extracts the required imports from the given qualified type expression.
-qualTypeExprToImports :: AC.CQualTypeExpr -> S.Set String
-qualTypeExprToImports (AC.CQualType ctx texp) = S.union (contextToImports ctx) (typeExprToImports texp)
+-- | Extracts the module dependencies from the given qualified type expression.
+qualTypeExprModuleDeps :: AC.CQualTypeExpr -> S.Set String
+qualTypeExprModuleDeps (AC.CQualType ctx texp) = S.union (contextModuleDeps ctx) (typeExprModuleDeps texp)
 
--- | Extracts the required imports from the given rule.
-ruleToImports :: AC.CRule -> S.Set String
-ruleToImports (AC.CRule pats rhs) = S.union (unionMap patternToImports pats) (rhsToImports rhs)
+-- | Extracts the module dependencies from the given rule.
+ruleModuleDeps :: AC.CRule -> S.Set String
+ruleModuleDeps (AC.CRule pats rhs) = S.union (unionMap patternModuleDeps pats) (rhsModuleDeps rhs)
 
--- | Extracts the required imports from the given pattern.
-patternToImports :: AC.CPattern -> S.Set String
-patternToImports _ = S.empty -- TODO
+-- | Extracts the module dependencies from the given pattern.
+patternModuleDeps :: AC.CPattern -> S.Set String
+patternModuleDeps _ = S.empty -- TODO
 
--- | Extracts the required imports from the given right-hand side.
-rhsToImports :: AC.CRhs -> S.Set String
-rhsToImports rhs = case rhs of
-  AC.CSimpleRhs expr ldecls    -> S.union (exprToImports expr) (unionMap localDeclToImports ldecls)
-  AC.CGuardedRhs guards ldecls -> S.union (unionMap guardToImports guards) (unionMap localDeclToImports ldecls)
+-- | Extracts the module dependencies from the given right-hand side.
+rhsModuleDeps :: AC.CRhs -> S.Set String
+rhsModuleDeps rhs = case rhs of
+  AC.CSimpleRhs expr ldecls    -> S.union (exprModuleDeps expr) (unionMap localDeclModuleDeps ldecls)
+  AC.CGuardedRhs guards ldecls -> S.union (unionMap guardModuleDeps guards) (unionMap localDeclModuleDeps ldecls)
 
--- | Extracts the required imports from the given expression.
-exprToImports :: AC.CExpr -> S.Set String
-exprToImports expr = case expr of
+-- | Extracts the module dependencies from the given expression.
+exprModuleDeps :: AC.CExpr -> S.Set String
+exprModuleDeps expr = case expr of
   AC.CVar _            -> S.empty
   AC.CLit _            -> S.empty
-  AC.CSymbol qn        -> qNameToImports qn
-  AC.CApply e1 e2      -> S.union (exprToImports e1) (exprToImports e2)
-  AC.CLambda pats e    -> S.union (unionMap patternToImports pats) (exprToImports e)
-  AC.CLetDecl ldecls e -> S.union (unionMap localDeclToImports ldecls) (exprToImports e)
-  AC.CDoExpr stmts     -> unionMap statementToImports stmts
-  AC.CListComp e stmts -> S.union (exprToImports e) (unionMap statementToImports stmts)
-  AC.CCase _ e arms    -> S.union (exprToImports e) (unionMap caseArmToImports arms)
-  AC.CTyped e qty      -> S.union (exprToImports e) (qualTypeExprToImports qty)
-  AC.CRecConstr qn fs  -> S.union (qNameToImports qn) (unionMap fieldToImports fs)
-  AC.CRecUpdate e fs   -> S.union (exprToImports e) (unionMap fieldToImports fs)
+  AC.CSymbol qn        -> qNameModuleDeps qn
+  AC.CApply e1 e2      -> S.union (exprModuleDeps e1) (exprModuleDeps e2)
+  AC.CLambda pats e    -> S.union (unionMap patternModuleDeps pats) (exprModuleDeps e)
+  AC.CLetDecl ldecls e -> S.union (unionMap localDeclModuleDeps ldecls) (exprModuleDeps e)
+  AC.CDoExpr stmts     -> unionMap statementModuleDeps stmts
+  AC.CListComp e stmts -> S.union (exprModuleDeps e) (unionMap statementModuleDeps stmts)
+  AC.CCase _ e arms    -> S.union (exprModuleDeps e) (unionMap caseArmModuleDeps arms)
+  AC.CTyped e qty      -> S.union (exprModuleDeps e) (qualTypeExprModuleDeps qty)
+  AC.CRecConstr qn fs  -> S.union (qNameModuleDeps qn) (unionMap fieldModuleDeps fs)
+  AC.CRecUpdate e fs   -> S.union (exprModuleDeps e) (unionMap fieldModuleDeps fs)
 
--- | Extracts the required imports from the given statement.
-statementToImports :: AC.CStatement -> S.Set String
-statementToImports _ = S.empty -- TODO
+-- | Extracts the module dependencies from the given statement.
+statementModuleDeps :: AC.CStatement -> S.Set String
+statementModuleDeps _ = S.empty -- TODO
 
--- | Extracts the required imports from the given case arm.
-caseArmToImports :: (AC.CPattern, AC.CRhs) -> S.Set String
-caseArmToImports (pat, rhs) = S.union (patternToImports pat) (rhsToImports rhs)
+-- | Extracts the module dependencies from the given case arm.
+caseArmModuleDeps :: (AC.CPattern, AC.CRhs) -> S.Set String
+caseArmModuleDeps (pat, rhs) = S.union (patternModuleDeps pat) (rhsModuleDeps rhs)
 
--- | Extracts the required imports from the given field.
-fieldToImports :: AC.CField AC.CExpr -> S.Set String
-fieldToImports _ = S.empty
+-- | Extracts the module dependencies from the given field.
+fieldModuleDeps :: AC.CField AC.CExpr -> S.Set String
+fieldModuleDeps _ = S.empty
 
--- | Extracts the required imports from the given guard.
-guardToImports :: (AC.CExpr, AC.CExpr) -> S.Set String
-guardToImports (e1, e2) = S.union (exprToImports e1) (exprToImports e2)
+-- | Extracts the module dependencies from the given guard.
+guardModuleDeps :: (AC.CExpr, AC.CExpr) -> S.Set String
+guardModuleDeps (e1, e2) = S.union (exprModuleDeps e1) (exprModuleDeps e2)
 
--- | Extracts the required imports from the given local declaration.
-localDeclToImports :: AC.CLocalDecl -> S.Set String
-localDeclToImports ldecl = case ldecl of
-  AC.CLocalFunc fdecl  -> funcDeclToImports fdecl
-  AC.CLocalPat pat rhs -> S.union (patternToImports pat) (rhsToImports rhs)
+-- | Extracts the module dependencies from the given local declaration.
+localDeclModuleDeps :: AC.CLocalDecl -> S.Set String
+localDeclModuleDeps ldecl = case ldecl of
+  AC.CLocalFunc fdecl  -> funcDeclModuleDeps fdecl
+  AC.CLocalPat pat rhs -> S.union (patternModuleDeps pat) (rhsModuleDeps rhs)
   AC.CLocalVars _      -> S.empty
 
--- | Extracts the required imports from the given qualified name.
-qNameToImports :: AC.QName -> S.Set String
-qNameToImports (mname, _) = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged
+-- | Extracts the module dependencies from the given qualified name.
+qNameModuleDeps :: AC.QName -> S.Set String
+qNameModuleDeps (mname, _) = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged

--- a/src/LSP/Generation/Dependencies.curry
+++ b/src/LSP/Generation/Dependencies.curry
@@ -1,4 +1,4 @@
-module LSP.Generation.Imports
+module LSP.Generation.Dependencies
   ( typeDeclToImports
   , instanceDeclToImports
   ) where

--- a/src/LSP/Generation/Deps.curry
+++ b/src/LSP/Generation/Deps.curry
@@ -1,4 +1,4 @@
-module LSP.Generation.Dependencies
+module LSP.Generation.Deps
   ( typeDeclModuleDeps
   , instanceDeclModuleDeps
   ) where

--- a/src/LSP/Generation/Deps.curry
+++ b/src/LSP/Generation/Deps.curry
@@ -3,8 +3,8 @@ module LSP.Generation.Deps
   , instanceDeclModuleDeps
   ) where
 
-import qualified AbstractCurry.Types as AC
 import qualified Data.Set as S
+import qualified LSP.Generation.AbstractCurry.Types as AC
 import LSP.Utils.General ( unions, unionMap )
 
 -- TODO: It would be nice to turn this into a type class, which would also let

--- a/src/LSP/Generation/Deps.curry
+++ b/src/LSP/Generation/Deps.curry
@@ -96,7 +96,10 @@ exprModuleDeps expr = case expr of
 
 -- | Extracts the module dependencies from the given statement.
 statementModuleDeps :: AC.CStatement -> S.Set String
-statementModuleDeps _ = S.empty -- TODO
+statementModuleDeps stmt = case stmt of
+  AC.CSExpr e     -> exprModuleDeps e
+  AC.CSPat pat e  -> S.union (patternModuleDeps pat) (exprModuleDeps e)
+  AC.CSLet ldecls -> unionMap localDeclModuleDeps ldecls
 
 -- | Extracts the module dependencies from the given case arm.
 caseArmModuleDeps :: (AC.CPattern, AC.CRhs) -> S.Set String
@@ -104,7 +107,7 @@ caseArmModuleDeps (pat, rhs) = S.union (patternModuleDeps pat) (rhsModuleDeps rh
 
 -- | Extracts the module dependencies from the given field.
 fieldModuleDeps :: AC.CField AC.CExpr -> S.Set String
-fieldModuleDeps _ = S.empty
+fieldModuleDeps (qn, e) = S.union (qNameModuleDeps qn) (exprModuleDeps e)
 
 -- | Extracts the module dependencies from the given guard.
 guardModuleDeps :: (AC.CExpr, AC.CExpr) -> S.Set String

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -349,7 +349,7 @@ lookupMaybeFromJSONQName = ("LSP.Utils.JSON", "lookupMaybeFromJSON")
 ppJSONQName :: AC.QName
 ppJSONQName = ("JSON.Pretty", "ppJSON")
 
--- | a prefixed enum value name.
+-- | Generates a prefixed enum value name.
 enumValueName :: String -> String -> String
 enumValueName prefix name = capitalize prefix ++ capitalize name
 
@@ -364,3 +364,7 @@ escapeName = replaceSingle '_' "Base"
 -- | Qualifies the given name with the given prefix.
 qualWith :: String -> String -> String
 qualWith prefix name = prefix ++ "." ++ name
+
+-- | Creates a QName with the derived module name.
+mkQName :: String -> String -> AC.QName
+mkQName mprefix n = (qualWith mprefix n, n)

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -56,7 +56,7 @@ metaModelToPrettyProgs :: String -> MetaModel -> [(String, String)]
 metaModelToPrettyProgs mprefix m = prettyWithModuleName <$> progs
   where
     progs = runGM (metaModelToProgs m) mprefix
-    prettyWithModuleName prog@(AC.CurryProg name _ _ _ _ _ _ _) = (name, unlines [pragmas, body])
+    prettyWithModuleName prog = (progName prog, unlines [pragmas, body])
       where
         -- Disable qualification since instances are not generated correctly
         -- when using qualified identifiers. We just have to make sure to include
@@ -278,6 +278,10 @@ typeName ty = snd $ case ty of
   AC.CType    n _ _ _ _ -> n
   AC.CTypeSyn n _ _ _   -> n
   AC.CNewType n _ _ _ _ -> n
+
+-- | Extracts the module name from the given program.
+progName :: AC.CurryProg -> String
+progName (AC.CurryProg name _ _ _ _ _ _ _) = name
 
 -- | An identifier from the LSP.Protocol.Support module.
 support :: String -> AC.QName

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -94,7 +94,7 @@ metaStructureToProg s = do
   let cdecl = AC.CRecord qn vis fs
       ty = AC.CType qn vis [] [cdecl] derivs
       insts = [fromJSONInst]
-      imps = requiredImports mname $ typeDeclToImports ty -- TODO: Standard imports?
+      imps = requiredImports mname $ typeDeclModuleDeps ty
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta enumeration to a Curry program.
@@ -115,7 +115,7 @@ metaEnumerationToProg e = do
   let derivs = stdDerivs ++ enumDerivs
       ty = AC.CType qn vis [] cdecls derivs
       insts = [fromJSONInst]
-      imps = requiredImports mname $ typeDeclToImports ty -- TODO: Standard imports?
+      imps = requiredImports mname $ typeDeclModuleDeps ty
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta structure to a FromJSON instance.
@@ -220,7 +220,7 @@ metaAliasToProg a = do
   let maybeTy = case M.lookup name btas of
         Just _  -> Nothing -- Skip built-in type aliases (e.g. LSPAny)
         Nothing -> Just $ AC.CTypeSyn qn vis [] texp
-      imps = requiredImports mname $ unions $ typeDeclToImports <$> maybeToList maybeTy
+      imps = requiredImports mname $ unions $ typeDeclModuleDeps <$> maybeToList maybeTy
   return $ (\ty -> AC.CurryProg mname imps Nothing [] [] [ty] [] []) <$> maybeTy
 
 -- | Converts a meta property to a Curry record field declaration.

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -86,7 +86,7 @@ metaModelToProgs m = do
 
 -- | Generates an umbrella module that reexports the given modules.
 mkUmbrellaProg :: String -> [String] -> AC.CurryProg
-mkUmbrellaProg mname mods = AC.CurryProg mname mods [] Nothing [] [] [] [] []
+mkUmbrellaProg mname mods = AC.CurryProg mname mods mods Nothing [] [] [] [] []
 
 -- | Converts a meta structure to a Curry program.
 metaStructureToProg :: MetaStructure -> GM AC.CurryProg

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -23,7 +23,6 @@ import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unio
 data GeneratorEnv = GeneratorEnv
   { geModulePrefix :: String
   , geBuiltInTypeAliases :: M.Map String AC.QName
-  , geStandardImports :: [String]
   , geStandardDerivings :: [AC.QName]
   , geStandardEnumDerivings :: [AC.QName]
   }
@@ -36,14 +35,6 @@ generatorEnv mprefix = GeneratorEnv
   { geModulePrefix = mprefix
   , geBuiltInTypeAliases = M.fromList
     [ ("LSPAny", support "LSPAny")
-    ]
-    -- TODO: Remove these since if we can generate the needed imports?
-  , geStandardImports =
-    [ "LSP.Utils.JSON"
-    , "LSP.Protocol.Support"
-    , "Data.Map"
-    , "JSON.Data"
-    , "JSON.Pretty"
     ]
   , geStandardDerivings =
     [ AC.pre "Show"
@@ -229,7 +220,7 @@ metaAliasToProg a = do
   let maybeTy = case M.lookup name btas of
         Just _  -> Nothing -- Skip built-in type aliases (e.g. LSPAny)
         Nothing -> Just $ AC.CTypeSyn qn vis [] texp
-  imps <- asks geStandardImports
+      imps = requiredImports mname $ unions $ typeDeclToImports <$> maybeToList maybeTy
   return $ (\ty -> AC.CurryProg mname imps Nothing [] [] [ty] [] []) <$> maybeTy
 
 -- | Converts a meta property to a Curry record field declaration.

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -12,6 +12,7 @@ import qualified Data.Set as S
 import Data.Maybe ( fromMaybe, maybeToList, catMaybes )
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
+import LSP.Generation.Imports
 import LSP.Generation.Model
 import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions )
 
@@ -279,91 +280,6 @@ metaBaseTypeToTypeExpr b = case b of
 requiredImports :: String -> S.Set String -> [String]
 requiredImports mname = filter isRequired . S.toList
   where isRequired m = m /= AC.preludeName && m /= mname
-
--- | Extracts the required imports from the given type declaration.
-typeDeclToImports :: AC.CTypeDecl -> S.Set String
-typeDeclToImports ty = case ty of
-  AC.CType    _ _ _ cdecls _ -> unions $ consDeclToImports <$> cdecls
-  AC.CTypeSyn _ _ _ texp     -> typeExprToImports texp
-  AC.CNewType _ _ _ cdecl _  -> consDeclToImports cdecl
-
--- | Extracts the required imports from the given type expression.
-typeExprToImports :: AC.CTypeExpr -> S.Set String
-typeExprToImports texp = case texp of
-  AC.CTVar _        -> S.empty
-  AC.CFuncType t t' -> S.union (typeExprToImports t) (typeExprToImports t')
-  AC.CTCons qn      -> qNameToImports qn
-  AC.CTApply t t'   -> S.union (typeExprToImports t) (typeExprToImports t')
-
--- | Extracts the required imports from the given constructor declaration.
-consDeclToImports :: AC.CConsDecl -> S.Set String
-consDeclToImports cdecl = case cdecl of
-  AC.CCons _ _ texps    -> unions $ typeExprToImports <$> texps
-  AC.CRecord _ _ fdecls -> unions $ fieldDeclToImports <$> fdecls
-
--- | Extracts the required imports from the given field declaration.
-fieldDeclToImports :: AC.CFieldDecl -> S.Set String
-fieldDeclToImports (AC.CField _ _ texp) = typeExprToImports texp
-
--- | Extracts the required imports from the given instance declaration.
-instanceDeclToImports :: AC.CInstanceDecl -> S.Set String
-instanceDeclToImports (AC.CInstance qn ctx texp fdecls) = unions
-  [ qNameToImports qn
-  , contextToImports ctx
-  , typeExprToImports texp
-  , unions $ funcDeclToImports <$> fdecls
-  ]
-
--- | Extracts the required imports from the given context.
-contextToImports :: AC.CContext -> S.Set String
-contextToImports (AC.CContext cs) = unions $ constraintToImports <$> cs
-
--- | Extracts the required imports from the given constraint.
-constraintToImports :: AC.CConstraint -> S.Set String
-constraintToImports (qn, texp) = S.union (qNameToImports qn) (typeExprToImports texp)
-
--- | Extracts the required imports from the given function declaration.
-funcDeclToImports :: AC.CFuncDecl -> S.Set String
-funcDeclToImports fdecl = case fdecl of
-  AC.CFunc     qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unions $ ruleToImports <$> rs]
-  AC.CmtFunc _ qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unions $ ruleToImports <$> rs]
-
--- | Extracts the required imports from the given qualified type expression.
-qualTypeExprToImports :: AC.CQualTypeExpr -> S.Set String
-qualTypeExprToImports (AC.CQualType ctx texp) = S.union (contextToImports ctx) (typeExprToImports texp)
-
--- | Extracts the required imports from the given rule.
-ruleToImports :: AC.CRule -> S.Set String
-ruleToImports (AC.CRule pats rhs) = S.union (unions $ patternToImports <$> pats) (rhsToImports rhs)
-
--- | Extracts the required imports from the given pattern.
-patternToImports :: AC.CPattern -> S.Set String
-patternToImports _ = S.empty -- TODO
-
--- | Extracts the required imports from the given right-hand side.
-rhsToImports :: AC.CRhs -> S.Set String
-rhsToImports rhs = case rhs of
-  AC.CSimpleRhs expr ldecls    -> S.union (exprToImports expr) (unions $ localDeclToImports <$> ldecls)
-  AC.CGuardedRhs guards ldecls -> S.union (unions $ guardToImports <$> guards) (unions $ localDeclToImports <$> ldecls)
-
--- | Extracts the required imports from the given expression.
-exprToImports :: AC.CExpr -> S.Set String
-exprToImports _ = S.empty -- TODO
-
--- | Extracts the required imports from the given guard.
-guardToImports :: (AC.CExpr, AC.CExpr) -> S.Set String
-guardToImports (e1, e2) = S.union (exprToImports e1) (exprToImports e2)
-
--- | Extracts the required imports from the given local declaration.
-localDeclToImports :: AC.CLocalDecl -> S.Set String
-localDeclToImports ldecl = case ldecl of
-  AC.CLocalFunc fdecl  -> funcDeclToImports fdecl
-  AC.CLocalPat pat rhs -> S.union (patternToImports pat) (rhsToImports rhs)
-  AC.CLocalVars _      -> S.empty
-
--- | Extracts the required imports from the given qualified name.
-qNameToImports :: AC.QName -> S.Set String
-qNameToImports (mname, _) = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged
 
 -- | Extracts the name from a type declaration.
 typeName :: AC.CTypeDecl -> String

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -11,6 +11,7 @@ import Data.Maybe ( fromMaybe, maybeToList, catMaybes )
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
 import qualified LSP.Generation.AbstractCurry.Types as AC
+import qualified LSP.Generation.AbstractCurry.Select as ACS
 import qualified LSP.Generation.AbstractCurry.Build as ACB
 import qualified LSP.Generation.AbstractCurry.Pretty as ACP
 import LSP.Generation.Deps
@@ -80,8 +81,8 @@ metaModelToProgs m = do
   aliases <- catMaybes <$> mapM metaAliasToProg (mmTypeAliases m)
   mprefix <- asks geModulePrefix
   let progs = structs ++ enums ++ aliases
-      umbrella = mkUmbrellaProg mprefix (progName <$> progs)
-  return $ keyBy progName <$> (umbrella : progs)
+      umbrella = mkUmbrellaProg mprefix (ACS.progName <$> progs)
+  return $ keyBy ACS.progName <$> (umbrella : progs)
 
 -- | Generates an umbrella module that reexports the given modules.
 mkUmbrellaProg :: String -> [String] -> AC.CurryProg
@@ -286,10 +287,6 @@ typeName ty = snd $ case ty of
   AC.CType    n _ _ _ _ -> n
   AC.CTypeSyn n _ _ _   -> n
   AC.CNewType n _ _ _ _ -> n
-
--- | Extracts the module name from the given program.
-progName :: AC.CurryProg -> String
-progName (AC.CurryProg name _ _ _ _ _ _ _) = name
 
 -- | An identifier from the LSP.Protocol.Support module.
 support :: String -> AC.QName

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -102,7 +102,7 @@ metaStructureToProg s = do
   let cdecl = AC.CRecord qn vis fs
       ty = AC.CType qn vis [] [cdecl] derivs
       insts = [fromJSONInst]
-      imps = S.toList $ typeDeclToImports ty -- TODO: Standard imports?
+      imps = requiredImports mname $ typeDeclToImports ty -- TODO: Standard imports?
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta enumeration to a Curry program.
@@ -123,7 +123,7 @@ metaEnumerationToProg e = do
   let derivs = stdDerivs ++ enumDerivs
       ty = AC.CType qn vis [] cdecls derivs
       insts = [fromJSONInst]
-      imps = S.toList $ typeDeclToImports ty -- TODO: Standard imports?
+      imps = requiredImports mname $ typeDeclToImports ty -- TODO: Standard imports?
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta structure to a FromJSON instance.
@@ -274,6 +274,11 @@ metaBaseTypeToTypeExpr b = case b of
   MetaBaseTypeNull        -> ACB.unitType
   MetaBaseTypeDocumentUri -> ACB.baseType $ support "DocumentUri"
   MetaBaseTypeUri         -> ACB.baseType $ support "Uri"
+
+-- | Orders and filters out the required imports for the given module.
+requiredImports :: String -> S.Set String -> [String]
+requiredImports mname = filter isRequired . S.toList
+  where isRequired m = m /= AC.preludeName && m /= mname
 
 -- | Extracts the required imports from the given type declaration.
 typeDeclToImports :: AC.CTypeDecl -> S.Set String

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -12,7 +12,7 @@ import qualified Data.Set as S
 import Data.Maybe ( fromMaybe, maybeToList, catMaybes )
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
-import LSP.Generation.Imports
+import LSP.Generation.Dependencies
 import LSP.Generation.Model
 import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions )
 

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -2,9 +2,6 @@ module LSP.Generation.Generator
   ( metaModelToPrettyProgs
   ) where
 
-import qualified AbstractCurry.Types as AC
-import qualified AbstractCurry.Build as ACB
-import qualified AbstractCurry.Pretty as ACP
 import Control.Monad ( join )
 import Control.Monad.Trans.Reader ( Reader, runReader, asks )
 import qualified Data.Map as M
@@ -13,6 +10,9 @@ import Data.List ( intercalate )
 import Data.Maybe ( fromMaybe, maybeToList, catMaybes )
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
+import qualified LSP.Generation.AbstractCurry.Types as AC
+import qualified LSP.Generation.AbstractCurry.Build as ACB
+import qualified LSP.Generation.AbstractCurry.Pretty as ACP
 import LSP.Generation.Deps
 import LSP.Generation.Model
 import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions, unionMap, keyBy )

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -301,10 +301,27 @@ fieldDeclToImports :: AC.CFieldDecl -> S.Set String
 fieldDeclToImports fdecl = case fdecl of
   AC.CField _ _ texp -> typeExprToImports texp
 
+-- | Extracts the required imports from the given instance declaration.
+instanceDeclToImports :: AC.CInstanceDecl -> S.Set String
+instanceDeclToImports idecl = case idecl of
+  AC.CInstance qn ctx texp fdecls -> unions
+    [ qNameToImports qn
+    , contextToImports ctx
+    , typeExprToImports texp
+    , unions $ funcDeclToImports <$> fdecls
+    ]
+
+-- | Extracts the required imports from the given context.
+contextToImports :: AC.CContext -> S.Set String
+contextToImports ctx = S.empty -- TODO
+
+-- | Extracts the required imports from the given function declaration.
+funcDeclToImports :: AC.CFuncDecl -> S.Set String
+funcDeclToImports ctx = S.empty -- TODO
+
 -- | Extracts the required imports from the given qualified name.
 qNameToImports :: AC.QName -> S.Set String
-qNameToImports (mname, _) | mname == AC.preludeName = S.empty
-                          | otherwise               = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged
+qNameToImports (mname, _) = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged
 
 -- | Extracts the name from a type declaration.
 typeName :: AC.CTypeDecl -> String

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -14,7 +14,7 @@ import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
 import LSP.Generation.Dependencies
 import LSP.Generation.Model
-import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions )
+import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions, unionMap )
 
 -- TODO: Generate documentation
 -- See https://git.ps.informatik.uni-kiel.de/curry-packages/abstract-curry/-/issues/1
@@ -94,7 +94,7 @@ metaStructureToProg s = do
   let cdecl = AC.CRecord qn vis fs
       ty = AC.CType qn vis [] [cdecl] derivs
       insts = [fromJSONInst]
-      imps = requiredImports mname $ typeDeclModuleDeps ty
+      imps = requiredImports mname $ S.union (typeDeclModuleDeps ty) (unionMap instanceDeclModuleDeps insts)
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta enumeration to a Curry program.
@@ -115,7 +115,7 @@ metaEnumerationToProg e = do
   let derivs = stdDerivs ++ enumDerivs
       ty = AC.CType qn vis [] cdecls derivs
       insts = [fromJSONInst]
-      imps = requiredImports mname $ typeDeclModuleDeps ty
+      imps = requiredImports mname $ S.union (typeDeclModuleDeps ty) (unionMap instanceDeclModuleDeps insts)
   return $ AC.CurryProg mname imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta structure to a FromJSON instance.

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -12,7 +12,7 @@ import qualified Data.Set as S
 import Data.Maybe ( fromMaybe, maybeToList, catMaybes )
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
-import LSP.Generation.Dependencies
+import LSP.Generation.Deps
 import LSP.Generation.Model
 import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), unions, unionMap )
 

--- a/src/LSP/Generation/Imports.curry
+++ b/src/LSP/Generation/Imports.curry
@@ -1,0 +1,93 @@
+module LSP.Generation.Imports
+  ( typeDeclToImports
+  , instanceDeclToImports
+  ) where
+
+import qualified AbstractCurry.Types as AC
+import qualified Data.Set as S
+import LSP.Utils.General ( unions )
+
+-- | Extracts the required imports from the given type declaration.
+typeDeclToImports :: AC.CTypeDecl -> S.Set String
+typeDeclToImports ty = case ty of
+  AC.CType    _ _ _ cdecls _ -> unions $ consDeclToImports <$> cdecls
+  AC.CTypeSyn _ _ _ texp     -> typeExprToImports texp
+  AC.CNewType _ _ _ cdecl _  -> consDeclToImports cdecl
+
+-- | Extracts the required imports from the given type expression.
+typeExprToImports :: AC.CTypeExpr -> S.Set String
+typeExprToImports texp = case texp of
+  AC.CTVar _        -> S.empty
+  AC.CFuncType t t' -> S.union (typeExprToImports t) (typeExprToImports t')
+  AC.CTCons qn      -> qNameToImports qn
+  AC.CTApply t t'   -> S.union (typeExprToImports t) (typeExprToImports t')
+
+-- | Extracts the required imports from the given constructor declaration.
+consDeclToImports :: AC.CConsDecl -> S.Set String
+consDeclToImports cdecl = case cdecl of
+  AC.CCons _ _ texps    -> unions $ typeExprToImports <$> texps
+  AC.CRecord _ _ fdecls -> unions $ fieldDeclToImports <$> fdecls
+
+-- | Extracts the required imports from the given field declaration.
+fieldDeclToImports :: AC.CFieldDecl -> S.Set String
+fieldDeclToImports (AC.CField _ _ texp) = typeExprToImports texp
+
+-- | Extracts the required imports from the given instance declaration.
+instanceDeclToImports :: AC.CInstanceDecl -> S.Set String
+instanceDeclToImports (AC.CInstance qn ctx texp fdecls) = unions
+  [ qNameToImports qn
+  , contextToImports ctx
+  , typeExprToImports texp
+  , unions $ funcDeclToImports <$> fdecls
+  ]
+
+-- | Extracts the required imports from the given context.
+contextToImports :: AC.CContext -> S.Set String
+contextToImports (AC.CContext cs) = unions $ constraintToImports <$> cs
+
+-- | Extracts the required imports from the given constraint.
+constraintToImports :: AC.CConstraint -> S.Set String
+constraintToImports (qn, texp) = S.union (qNameToImports qn) (typeExprToImports texp)
+
+-- | Extracts the required imports from the given function declaration.
+funcDeclToImports :: AC.CFuncDecl -> S.Set String
+funcDeclToImports fdecl = case fdecl of
+  AC.CFunc     qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unions $ ruleToImports <$> rs]
+  AC.CmtFunc _ qn _ _ qty rs -> unions [qNameToImports qn, qualTypeExprToImports qty, unions $ ruleToImports <$> rs]
+
+-- | Extracts the required imports from the given qualified type expression.
+qualTypeExprToImports :: AC.CQualTypeExpr -> S.Set String
+qualTypeExprToImports (AC.CQualType ctx texp) = S.union (contextToImports ctx) (typeExprToImports texp)
+
+-- | Extracts the required imports from the given rule.
+ruleToImports :: AC.CRule -> S.Set String
+ruleToImports (AC.CRule pats rhs) = S.union (unions $ patternToImports <$> pats) (rhsToImports rhs)
+
+-- | Extracts the required imports from the given pattern.
+patternToImports :: AC.CPattern -> S.Set String
+patternToImports _ = S.empty -- TODO
+
+-- | Extracts the required imports from the given right-hand side.
+rhsToImports :: AC.CRhs -> S.Set String
+rhsToImports rhs = case rhs of
+  AC.CSimpleRhs expr ldecls    -> S.union (exprToImports expr) (unions $ localDeclToImports <$> ldecls)
+  AC.CGuardedRhs guards ldecls -> S.union (unions $ guardToImports <$> guards) (unions $ localDeclToImports <$> ldecls)
+
+-- | Extracts the required imports from the given expression.
+exprToImports :: AC.CExpr -> S.Set String
+exprToImports _ = S.empty -- TODO
+
+-- | Extracts the required imports from the given guard.
+guardToImports :: (AC.CExpr, AC.CExpr) -> S.Set String
+guardToImports (e1, e2) = S.union (exprToImports e1) (exprToImports e2)
+
+-- | Extracts the required imports from the given local declaration.
+localDeclToImports :: AC.CLocalDecl -> S.Set String
+localDeclToImports ldecl = case ldecl of
+  AC.CLocalFunc fdecl  -> funcDeclToImports fdecl
+  AC.CLocalPat pat rhs -> S.union (patternToImports pat) (rhsToImports rhs)
+  AC.CLocalVars _      -> S.empty
+
+-- | Extracts the required imports from the given qualified name.
+qNameToImports :: AC.QName -> S.Set String
+qNameToImports (mname, _) = S.fromList [mname] -- TODO: Use S.singleton once https://github.com/curry-packages/containers/pull/1 is merged

--- a/src/LSP/Generation/Main.curry
+++ b/src/LSP/Generation/Main.curry
@@ -6,16 +6,24 @@ import LSP.Generation.Generator ( metaModelToPrettyProgs )
 import LSP.Generation.Model ( MetaModel (..) )
 import LSP.Utils.General ( fromRight', forM_, replace )
 import LSP.Utils.JSON ( FromJSON (..) )
+import System.Directory ( createDirectoryIfMissing )
 
 main :: IO ()
 main = do
-  putStrLn "==> Reading meta model..."
-  rawMetaModel <- readFile "resources/metaModel.json"
+  let metaModelPath = "resources/metaModel.json"
+      modulePrefix = "LSP.Protocol.Types"
+
+  putStrLn $ "==> Reading meta model from " ++ metaModelPath ++ "..."
+  rawMetaModel <- readFile metaModelPath
   let metaModel = (fromRight' $ fromJSONString rawMetaModel) :: MetaModel
 
-  putStrLn "==> Generating Curry from meta model..."
-  forM_ (metaModelToPrettyProgs "LSP.Protocol.Types" metaModel) $ \(name, prettyProg) -> do
-    let path = moduleNameToPath name
+  let dirPath = moduleNameToPath modulePrefix
+  putStrLn $ "==> Preparing " ++ dirPath ++ "..."
+  createDirectoryIfMissing True dirPath
+
+  putStrLn $ "==> Generating source code from meta model..."
+  forM_ (metaModelToPrettyProgs modulePrefix metaModel) $ \(name, prettyProg) -> do
+    let path = moduleNameToPath name ++ ".curry"
     putStrLn $ "==> Writing " ++ path ++ "..."
     writeFile path $ unlines [autogenNote, prettyProg]
 
@@ -23,4 +31,4 @@ autogenNote :: String
 autogenNote = "-- NOTE: This file is generated automatically and should not be edited manually!"
 
 moduleNameToPath :: String -> FilePath
-moduleNameToPath name = "src/" ++ replace '.' '/' name ++ ".curry"
+moduleNameToPath name = "src/" ++ replace '.' '/' name

--- a/src/LSP/Generation/Main.curry
+++ b/src/LSP/Generation/Main.curry
@@ -2,18 +2,25 @@ module LSP.Generation.Main
   ( main
   ) where
 
-import LSP.Generation.Generator ( metaModelToPrettyCurry )
+import LSP.Generation.Generator ( metaModelToPrettyProgs )
 import LSP.Generation.Model ( MetaModel (..) )
-import LSP.Utils.General ( fromRight' )
+import LSP.Utils.General ( fromRight', forM_, replace )
 import LSP.Utils.JSON ( FromJSON (..) )
-
-autogenNote :: String
-autogenNote = unlines ["-- NOTE: This file is generated automatically and should not be edited manually!"]
 
 main :: IO ()
 main = do
+  putStrLn "==> Reading meta model..."
   rawMetaModel <- readFile "resources/metaModel.json"
   let metaModel = (fromRight' $ fromJSONString rawMetaModel) :: MetaModel
 
-  putStrLn "==> Generating Curry from meta-model..."
-  writeFile "src/LSP/Protocol/Types.curry" $ autogenNote ++ metaModelToPrettyCurry "LSP.Protocol.Types" metaModel
+  putStrLn "==> Generating Curry from meta model..."
+  forM_ (metaModelToPrettyProgs "LSP.Protocol.Types" metaModel) $ \(name, prettyProg) -> do
+    let path = moduleNameToPath name
+    putStrLn $ "==> Writing " ++ path ++ "..."
+    writeFile path $ unlines [autogenNote, prettyProg]
+
+autogenNote :: String
+autogenNote = "-- NOTE: This file is generated automatically and should not be edited manually!"
+
+moduleNameToPath :: String -> FilePath
+moduleNameToPath name = "src/" ++ replace '.' '/' name ++ ".curry"

--- a/src/LSP/Protocol/Types.curry
+++ b/src/LSP/Protocol/Types.curry
@@ -7224,3 +7224,4 @@ type NotebookDocumentFilter = Either (Either NotebookDocumentFilterNotebookType 
 type Pattern = String
 
 type RegularExpressionEngineKind = String
+

--- a/src/LSP/Protocol/Types.curry
+++ b/src/LSP/Protocol/Types.curry
@@ -1,7227 +1,868 @@
 -- NOTE: This file is generated automatically and should not be edited manually!
 {-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
-module LSP.Protocol.Types where
-
-import LSP.Utils.JSON
-import LSP.Protocol.Support
-import Data.Map
-import JSON.Data
-import JSON.Pretty
-
-instance FromJSON ImplementationParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ImplementationParams {  }
-      _ -> Left ("Unrecognized ImplementationParams value: " ++ ppJSON j)
-
-instance FromJSON Location where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedRange <- lookupFromJSON "range" vs
-           return
-            Location { locationUri = parsedUri, locationRange = parsedRange }
-      _ -> Left ("Unrecognized Location value: " ++ ppJSON j)
-
-instance FromJSON ImplementationRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ImplementationRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized ImplementationRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON TypeDefinitionParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeDefinitionParams {  }
-      _ -> Left ("Unrecognized TypeDefinitionParams value: " ++ ppJSON j)
-
-instance FromJSON TypeDefinitionRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeDefinitionRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized TypeDefinitionRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON WorkspaceFolder where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedName <- lookupFromJSON "name" vs
-           return
-            WorkspaceFolder { workspaceFolderUri = parsedUri
-                            , workspaceFolderName = parsedName }
-      _ -> Left ("Unrecognized WorkspaceFolder value: " ++ ppJSON j)
-
-instance FromJSON DidChangeWorkspaceFoldersParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedEvent <- lookupFromJSON "event" vs
-           return
-            DidChangeWorkspaceFoldersParams { didChangeWorkspaceFoldersParamsEvent = parsedEvent }
-      _ ->
-        Left
-         ("Unrecognized DidChangeWorkspaceFoldersParams value: " ++ ppJSON j)
-
-instance FromJSON ConfigurationParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItems <- lookupFromJSON "items" vs
-           return
-            ConfigurationParams { configurationParamsItems = parsedItems }
-      _ -> Left ("Unrecognized ConfigurationParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentColorParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            DocumentColorParams { documentColorParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized DocumentColorParams value: " ++ ppJSON j)
-
-instance FromJSON ColorInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedColor <- lookupFromJSON "color" vs
-           return
-            ColorInformation { colorInformationRange = parsedRange
-                             , colorInformationColor = parsedColor }
-      _ -> Left ("Unrecognized ColorInformation value: " ++ ppJSON j)
-
-instance FromJSON DocumentColorRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentColorRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentColorRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON ColorPresentationParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedColor <- lookupFromJSON "color" vs
-           parsedRange <- lookupFromJSON "range" vs
-           return
-            ColorPresentationParams { colorPresentationParamsTextDocument = parsedTextDocument
-                                    , colorPresentationParamsColor = parsedColor
-                                    , colorPresentationParamsRange = parsedRange }
-      _ -> Left ("Unrecognized ColorPresentationParams value: " ++ ppJSON j)
-
-instance FromJSON ColorPresentation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupFromJSON "label" vs
-           parsedTextEdit <- lookupMaybeFromJSON "textEdit" vs
-           parsedAdditionalTextEdits <- lookupMaybeFromJSON
-                                         "additionalTextEdits"
-                                         vs
-           return
-            ColorPresentation { colorPresentationLabel = parsedLabel
-                              , colorPresentationTextEdit = parsedTextEdit
-                              , colorPresentationAdditionalTextEdits = parsedAdditionalTextEdits }
-      _ -> Left ("Unrecognized ColorPresentation value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
-           return
-            WorkDoneProgressOptions { workDoneProgressOptionsWorkDoneProgress = parsedWorkDoneProgress }
-      _ -> Left ("Unrecognized WorkDoneProgressOptions value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
-           return
-            TextDocumentRegistrationOptions { textDocumentRegistrationOptionsDocumentSelector = parsedDocumentSelector }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON FoldingRangeParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            FoldingRangeParams { foldingRangeParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized FoldingRangeParams value: " ++ ppJSON j)
-
-instance FromJSON FoldingRange where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStartLine <- lookupFromJSON "startLine" vs
-           parsedStartCharacter <- lookupMaybeFromJSON "startCharacter" vs
-           parsedEndLine <- lookupFromJSON "endLine" vs
-           parsedEndCharacter <- lookupMaybeFromJSON "endCharacter" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           parsedCollapsedText <- lookupMaybeFromJSON "collapsedText" vs
-           return
-            FoldingRange { foldingRangeStartLine = parsedStartLine
-                         , foldingRangeStartCharacter = parsedStartCharacter
-                         , foldingRangeEndLine = parsedEndLine
-                         , foldingRangeEndCharacter = parsedEndCharacter
-                         , foldingRangeKind = parsedKind
-                         , foldingRangeCollapsedText = parsedCollapsedText }
-      _ -> Left ("Unrecognized FoldingRange value: " ++ ppJSON j)
-
-instance FromJSON FoldingRangeRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return FoldingRangeRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized FoldingRangeRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DeclarationParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DeclarationParams {  }
-      _ -> Left ("Unrecognized DeclarationParams value: " ++ ppJSON j)
-
-instance FromJSON DeclarationRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DeclarationRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DeclarationRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON SelectionRangeParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedPositions <- lookupFromJSON "positions" vs
-           return
-            SelectionRangeParams { selectionRangeParamsTextDocument = parsedTextDocument
-                                 , selectionRangeParamsPositions = parsedPositions }
-      _ -> Left ("Unrecognized SelectionRangeParams value: " ++ ppJSON j)
-
-instance FromJSON SelectionRange where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedParent <- lookupMaybeFromJSON "parent" vs
-           return
-            SelectionRange { selectionRangeRange = parsedRange
-                           , selectionRangeParent = parsedParent }
-      _ -> Left ("Unrecognized SelectionRange value: " ++ ppJSON j)
-
-instance FromJSON SelectionRangeRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return SelectionRangeRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized SelectionRangeRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressCreateParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedToken <- lookupFromJSON "token" vs
-           return
-            WorkDoneProgressCreateParams { workDoneProgressCreateParamsToken = parsedToken }
-      _ ->
-        Left ("Unrecognized WorkDoneProgressCreateParams value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressCancelParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedToken <- lookupFromJSON "token" vs
-           return
-            WorkDoneProgressCancelParams { workDoneProgressCancelParamsToken = parsedToken }
-      _ ->
-        Left ("Unrecognized WorkDoneProgressCancelParams value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyPrepareParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CallHierarchyPrepareParams {  }
-      _ ->
-        Left ("Unrecognized CallHierarchyPrepareParams value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedKind <- lookupFromJSON "kind" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedDetail <- lookupMaybeFromJSON "detail" vs
-           parsedUri <- lookupFromJSON "uri" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            CallHierarchyItem { callHierarchyItemName = parsedName
-                              , callHierarchyItemKind = parsedKind
-                              , callHierarchyItemTags = parsedTags
-                              , callHierarchyItemDetail = parsedDetail
-                              , callHierarchyItemUri = parsedUri
-                              , callHierarchyItemRange = parsedRange
-                              , callHierarchyItemSelectionRange = parsedSelectionRange
-                              , callHierarchyItemData = parsedData }
-      _ -> Left ("Unrecognized CallHierarchyItem value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CallHierarchyRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized CallHierarchyRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyIncomingCallsParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
-           return
-            CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem = parsedItem }
-      _ ->
-        Left
-         ("Unrecognized CallHierarchyIncomingCallsParams value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyIncomingCall where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFrom <- lookupFromJSON "from" vs
-           parsedFromRanges <- lookupFromJSON "fromRanges" vs
-           return
-            CallHierarchyIncomingCall { callHierarchyIncomingCallFrom = parsedFrom
-                                      , callHierarchyIncomingCallFromRanges = parsedFromRanges }
-      _ -> Left ("Unrecognized CallHierarchyIncomingCall value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyOutgoingCallsParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
-           return
-            CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem = parsedItem }
-      _ ->
-        Left
-         ("Unrecognized CallHierarchyOutgoingCallsParams value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyOutgoingCall where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTo <- lookupFromJSON "to" vs
-           parsedFromRanges <- lookupFromJSON "fromRanges" vs
-           return
-            CallHierarchyOutgoingCall { callHierarchyOutgoingCallTo = parsedTo
-                                      , callHierarchyOutgoingCallFromRanges = parsedFromRanges }
-      _ -> Left ("Unrecognized CallHierarchyOutgoingCall value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            SemanticTokensParams { semanticTokensParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized SemanticTokensParams value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokens where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResultId <- lookupMaybeFromJSON "resultId" vs
-           parsedData <- lookupFromJSON "data" vs
-           return
-            SemanticTokens { semanticTokensResultId = parsedResultId
-                           , semanticTokensData = parsedData }
-      _ -> Left ("Unrecognized SemanticTokens value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensPartialResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedData <- lookupFromJSON "data" vs
-           return
-            SemanticTokensPartialResult { semanticTokensPartialResultData = parsedData }
-      _ ->
-        Left ("Unrecognized SemanticTokensPartialResult value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return SemanticTokensRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized SemanticTokensRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON SemanticTokensDeltaParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedPreviousResultId <- lookupFromJSON "previousResultId" vs
-           return
-            SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument = parsedTextDocument
-                                      , semanticTokensDeltaParamsPreviousResultId = parsedPreviousResultId }
-      _ -> Left ("Unrecognized SemanticTokensDeltaParams value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensDelta where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResultId <- lookupMaybeFromJSON "resultId" vs
-           parsedEdits <- lookupFromJSON "edits" vs
-           return
-            SemanticTokensDelta { semanticTokensDeltaResultId = parsedResultId
-                                , semanticTokensDeltaEdits = parsedEdits }
-      _ -> Left ("Unrecognized SemanticTokensDelta value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensDeltaPartialResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedEdits <- lookupFromJSON "edits" vs
-           return
-            SemanticTokensDeltaPartialResult { semanticTokensDeltaPartialResultEdits = parsedEdits }
-      _ ->
-        Left
-         ("Unrecognized SemanticTokensDeltaPartialResult value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensRangeParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRange <- lookupFromJSON "range" vs
-           return
-            SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument = parsedTextDocument
-                                      , semanticTokensRangeParamsRange = parsedRange }
-      _ -> Left ("Unrecognized SemanticTokensRangeParams value: " ++ ppJSON j)
-
-instance FromJSON ShowDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedExternal <- lookupMaybeFromJSON "external" vs
-           parsedTakeFocus <- lookupMaybeFromJSON "takeFocus" vs
-           parsedSelection <- lookupMaybeFromJSON "selection" vs
-           return
-            ShowDocumentParams { showDocumentParamsUri = parsedUri
-                               , showDocumentParamsExternal = parsedExternal
-                               , showDocumentParamsTakeFocus = parsedTakeFocus
-                               , showDocumentParamsSelection = parsedSelection }
-      _ -> Left ("Unrecognized ShowDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON ShowDocumentResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSuccess <- lookupFromJSON "success" vs
-           return
-            ShowDocumentResult { showDocumentResultSuccess = parsedSuccess }
-      _ -> Left ("Unrecognized ShowDocumentResult value: " ++ ppJSON j)
-
-instance FromJSON LinkedEditingRangeParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return LinkedEditingRangeParams {  }
-      _ -> Left ("Unrecognized LinkedEditingRangeParams value: " ++ ppJSON j)
-
-instance FromJSON LinkedEditingRanges where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRanges <- lookupFromJSON "ranges" vs
-           parsedWordPattern <- lookupMaybeFromJSON "wordPattern" vs
-           return
-            LinkedEditingRanges { linkedEditingRangesRanges = parsedRanges
-                                , linkedEditingRangesWordPattern = parsedWordPattern }
-      _ -> Left ("Unrecognized LinkedEditingRanges value: " ++ ppJSON j)
-
-instance FromJSON LinkedEditingRangeRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return LinkedEditingRangeRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized LinkedEditingRangeRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON CreateFilesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFiles <- lookupFromJSON "files" vs
-           return CreateFilesParams { createFilesParamsFiles = parsedFiles }
-      _ -> Left ("Unrecognized CreateFilesParams value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedChanges <- lookupMaybeFromJSON "changes" vs
-           parsedDocumentChanges <- lookupMaybeFromJSON "documentChanges" vs
-           parsedChangeAnnotations <- lookupMaybeFromJSON "changeAnnotations"
-                                       vs
-           return
-            WorkspaceEdit { workspaceEditChanges = parsedChanges
-                          , workspaceEditDocumentChanges = parsedDocumentChanges
-                          , workspaceEditChangeAnnotations = parsedChangeAnnotations }
-      _ -> Left ("Unrecognized WorkspaceEdit value: " ++ ppJSON j)
-
-instance FromJSON FileOperationRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFilters <- lookupFromJSON "filters" vs
-           return
-            FileOperationRegistrationOptions { fileOperationRegistrationOptionsFilters = parsedFilters }
-      _ ->
-        Left
-         ("Unrecognized FileOperationRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON RenameFilesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFiles <- lookupFromJSON "files" vs
-           return RenameFilesParams { renameFilesParamsFiles = parsedFiles }
-      _ -> Left ("Unrecognized RenameFilesParams value: " ++ ppJSON j)
-
-instance FromJSON DeleteFilesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFiles <- lookupFromJSON "files" vs
-           return DeleteFilesParams { deleteFilesParamsFiles = parsedFiles }
-      _ -> Left ("Unrecognized DeleteFilesParams value: " ++ ppJSON j)
-
-instance FromJSON MonikerParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return MonikerParams {  }
-      _ -> Left ("Unrecognized MonikerParams value: " ++ ppJSON j)
-
-instance FromJSON Moniker where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedScheme <- lookupFromJSON "scheme" vs
-           parsedIdentifier <- lookupFromJSON "identifier" vs
-           parsedUnique <- lookupFromJSON "unique" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           return
-            Moniker { monikerScheme = parsedScheme
-                    , monikerIdentifier = parsedIdentifier
-                    , monikerUnique = parsedUnique
-                    , monikerKind = parsedKind }
-      _ -> Left ("Unrecognized Moniker value: " ++ ppJSON j)
-
-instance FromJSON MonikerRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return MonikerRegistrationOptions {  }
-      _ ->
-        Left ("Unrecognized MonikerRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchyPrepareParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeHierarchyPrepareParams {  }
-      _ ->
-        Left ("Unrecognized TypeHierarchyPrepareParams value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchyItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedKind <- lookupFromJSON "kind" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedDetail <- lookupMaybeFromJSON "detail" vs
-           parsedUri <- lookupFromJSON "uri" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            TypeHierarchyItem { typeHierarchyItemName = parsedName
-                              , typeHierarchyItemKind = parsedKind
-                              , typeHierarchyItemTags = parsedTags
-                              , typeHierarchyItemDetail = parsedDetail
-                              , typeHierarchyItemUri = parsedUri
-                              , typeHierarchyItemRange = parsedRange
-                              , typeHierarchyItemSelectionRange = parsedSelectionRange
-                              , typeHierarchyItemData = parsedData }
-      _ -> Left ("Unrecognized TypeHierarchyItem value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchyRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeHierarchyRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized TypeHierarchyRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchySupertypesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
-           return
-            TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem = parsedItem }
-      _ ->
-        Left
-         ("Unrecognized TypeHierarchySupertypesParams value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchySubtypesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
-           return
-            TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem = parsedItem }
-      _ ->
-        Left ("Unrecognized TypeHierarchySubtypesParams value: " ++ ppJSON j)
-
-instance FromJSON InlineValueParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedContext <- lookupFromJSON "context" vs
-           return
-            InlineValueParams { inlineValueParamsTextDocument = parsedTextDocument
-                              , inlineValueParamsRange = parsedRange
-                              , inlineValueParamsContext = parsedContext }
-      _ -> Left ("Unrecognized InlineValueParams value: " ++ ppJSON j)
-
-instance FromJSON InlineValueRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InlineValueRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized InlineValueRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON InlayHintParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRange <- lookupFromJSON "range" vs
-           return
-            InlayHintParams { inlayHintParamsTextDocument = parsedTextDocument
-                            , inlayHintParamsRange = parsedRange }
-      _ -> Left ("Unrecognized InlayHintParams value: " ++ ppJSON j)
-
-instance FromJSON InlayHint where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedPosition <- lookupFromJSON "position" vs
-           parsedLabel <- lookupFromJSON "label" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           parsedTextEdits <- lookupMaybeFromJSON "textEdits" vs
-           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
-           parsedPaddingLeft <- lookupMaybeFromJSON "paddingLeft" vs
-           parsedPaddingRight <- lookupMaybeFromJSON "paddingRight" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            InlayHint { inlayHintPosition = parsedPosition
-                      , inlayHintLabel = parsedLabel
-                      , inlayHintKind = parsedKind
-                      , inlayHintTextEdits = parsedTextEdits
-                      , inlayHintTooltip = parsedTooltip
-                      , inlayHintPaddingLeft = parsedPaddingLeft
-                      , inlayHintPaddingRight = parsedPaddingRight
-                      , inlayHintData = parsedData }
-      _ -> Left ("Unrecognized InlayHint value: " ++ ppJSON j)
-
-instance FromJSON InlayHintRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InlayHintRegistrationOptions {  }
-      _ ->
-        Left ("Unrecognized InlayHintRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentDiagnosticParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
-           parsedPreviousResultId <- lookupMaybeFromJSON "previousResultId" vs
-           return
-            DocumentDiagnosticParams { documentDiagnosticParamsTextDocument = parsedTextDocument
-                                     , documentDiagnosticParamsIdentifier = parsedIdentifier
-                                     , documentDiagnosticParamsPreviousResultId = parsedPreviousResultId }
-      _ -> Left ("Unrecognized DocumentDiagnosticParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentDiagnosticReportPartialResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRelatedDocuments <- lookupFromJSON "relatedDocuments" vs
-           return
-            DocumentDiagnosticReportPartialResult { documentDiagnosticReportPartialResultRelatedDocuments = parsedRelatedDocuments }
-      _ ->
-        Left
-         ("Unrecognized DocumentDiagnosticReportPartialResult value: "
-           ++ ppJSON j)
-
-instance FromJSON DiagnosticServerCancellationData where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRetriggerRequest <- lookupFromJSON "retriggerRequest" vs
-           return
-            DiagnosticServerCancellationData { diagnosticServerCancellationDataRetriggerRequest = parsedRetriggerRequest }
-      _ ->
-        Left
-         ("Unrecognized DiagnosticServerCancellationData value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DiagnosticRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DiagnosticRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceDiagnosticParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
-           parsedPreviousResultIds <- lookupFromJSON "previousResultIds" vs
-           return
-            WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier = parsedIdentifier
-                                      , workspaceDiagnosticParamsPreviousResultIds = parsedPreviousResultIds }
-      _ -> Left ("Unrecognized WorkspaceDiagnosticParams value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItems <- lookupFromJSON "items" vs
-           return
-            WorkspaceDiagnosticReport { workspaceDiagnosticReportItems = parsedItems }
-      _ -> Left ("Unrecognized WorkspaceDiagnosticReport value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceDiagnosticReportPartialResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItems <- lookupFromJSON "items" vs
-           return
-            WorkspaceDiagnosticReportPartialResult { workspaceDiagnosticReportPartialResultItems = parsedItems }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceDiagnosticReportPartialResult value: "
-           ++ ppJSON j)
-
-instance FromJSON DidOpenNotebookDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
-           parsedCellTextDocuments <- lookupFromJSON "cellTextDocuments" vs
-           return
-            DidOpenNotebookDocumentParams { didOpenNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
-                                          , didOpenNotebookDocumentParamsCellTextDocuments = parsedCellTextDocuments }
-      _ ->
-        Left
-         ("Unrecognized DidOpenNotebookDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentSyncRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return NotebookDocumentSyncRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentSyncRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON DidChangeNotebookDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
-           parsedChange <- lookupFromJSON "change" vs
-           return
-            DidChangeNotebookDocumentParams { didChangeNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
-                                            , didChangeNotebookDocumentParamsChange = parsedChange }
-      _ ->
-        Left
-         ("Unrecognized DidChangeNotebookDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON DidSaveNotebookDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
-           return
-            DidSaveNotebookDocumentParams { didSaveNotebookDocumentParamsNotebookDocument = parsedNotebookDocument }
-      _ ->
-        Left
-         ("Unrecognized DidSaveNotebookDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON DidCloseNotebookDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
-           parsedCellTextDocuments <- lookupFromJSON "cellTextDocuments" vs
-           return
-            DidCloseNotebookDocumentParams { didCloseNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
-                                           , didCloseNotebookDocumentParamsCellTextDocuments = parsedCellTextDocuments }
-      _ ->
-        Left
-         ("Unrecognized DidCloseNotebookDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedContext <- lookupFromJSON "context" vs
-           return
-            InlineCompletionParams { inlineCompletionParamsContext = parsedContext }
-      _ -> Left ("Unrecognized InlineCompletionParams value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionList where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItems <- lookupFromJSON "items" vs
-           return
-            InlineCompletionList { inlineCompletionListItems = parsedItems }
-      _ -> Left ("Unrecognized InlineCompletionList value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedInsertText <- lookupFromJSON "insertText" vs
-           parsedFilterText <- lookupMaybeFromJSON "filterText" vs
-           parsedRange <- lookupMaybeFromJSON "range" vs
-           parsedCommand <- lookupMaybeFromJSON "command" vs
-           return
-            InlineCompletionItem { inlineCompletionItemInsertText = parsedInsertText
-                                 , inlineCompletionItemFilterText = parsedFilterText
-                                 , inlineCompletionItemRange = parsedRange
-                                 , inlineCompletionItemCommand = parsedCommand }
-      _ -> Left ("Unrecognized InlineCompletionItem value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InlineCompletionRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized InlineCompletionRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON RegistrationParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRegistrations <- lookupFromJSON "registrations" vs
-           return
-            RegistrationParams { registrationParamsRegistrations = parsedRegistrations }
-      _ -> Left ("Unrecognized RegistrationParams value: " ++ ppJSON j)
-
-instance FromJSON UnregistrationParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUnregisterations <- lookupFromJSON "unregisterations" vs
-           return
-            UnregistrationParams { unregistrationParamsUnregisterations = parsedUnregisterations }
-      _ -> Left ("Unrecognized UnregistrationParams value: " ++ ppJSON j)
-
-instance FromJSON InitializeParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InitializeParams {  }
-      _ -> Left ("Unrecognized InitializeParams value: " ++ ppJSON j)
-
-instance FromJSON InitializeResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCapabilities <- lookupFromJSON "capabilities" vs
-           parsedServerInfo <- lookupMaybeFromJSON "serverInfo" vs
-           return
-            InitializeResult { initializeResultCapabilities = parsedCapabilities
-                             , initializeResultServerInfo = parsedServerInfo }
-      _ -> Left ("Unrecognized InitializeResult value: " ++ ppJSON j)
-
-instance FromJSON InitializeError where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRetry <- lookupFromJSON "retry" vs
-           return InitializeError { initializeErrorRetry = parsedRetry }
-      _ -> Left ("Unrecognized InitializeError value: " ++ ppJSON j)
-
-instance FromJSON InitializedParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InitializedParams {  }
-      _ -> Left ("Unrecognized InitializedParams value: " ++ ppJSON j)
-
-instance FromJSON DidChangeConfigurationParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSettings <- lookupFromJSON "settings" vs
-           return
-            DidChangeConfigurationParams { didChangeConfigurationParamsSettings = parsedSettings }
-      _ ->
-        Left ("Unrecognized DidChangeConfigurationParams value: " ++ ppJSON j)
-
-instance FromJSON DidChangeConfigurationRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSection <- lookupMaybeFromJSON "section" vs
-           return
-            DidChangeConfigurationRegistrationOptions { didChangeConfigurationRegistrationOptionsSection = parsedSection }
-      _ ->
-        Left
-         ("Unrecognized DidChangeConfigurationRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ShowMessageParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedType <- lookupFromJSON "type" vs
-           parsedMessage <- lookupFromJSON "message" vs
-           return
-            ShowMessageParams { showMessageParamsType = parsedType
-                              , showMessageParamsMessage = parsedMessage }
-      _ -> Left ("Unrecognized ShowMessageParams value: " ++ ppJSON j)
-
-instance FromJSON ShowMessageRequestParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedType <- lookupFromJSON "type" vs
-           parsedMessage <- lookupFromJSON "message" vs
-           parsedActions <- lookupMaybeFromJSON "actions" vs
-           return
-            ShowMessageRequestParams { showMessageRequestParamsType = parsedType
-                                     , showMessageRequestParamsMessage = parsedMessage
-                                     , showMessageRequestParamsActions = parsedActions }
-      _ -> Left ("Unrecognized ShowMessageRequestParams value: " ++ ppJSON j)
-
-instance FromJSON MessageActionItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTitle <- lookupFromJSON "title" vs
-           return MessageActionItem { messageActionItemTitle = parsedTitle }
-      _ -> Left ("Unrecognized MessageActionItem value: " ++ ppJSON j)
-
-instance FromJSON LogMessageParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedType <- lookupFromJSON "type" vs
-           parsedMessage <- lookupFromJSON "message" vs
-           return
-            LogMessageParams { logMessageParamsType = parsedType
-                             , logMessageParamsMessage = parsedMessage }
-      _ -> Left ("Unrecognized LogMessageParams value: " ++ ppJSON j)
-
-instance FromJSON DidOpenTextDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            DidOpenTextDocumentParams { didOpenTextDocumentParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized DidOpenTextDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON DidChangeTextDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedContentChanges <- lookupFromJSON "contentChanges" vs
-           return
-            DidChangeTextDocumentParams { didChangeTextDocumentParamsTextDocument = parsedTextDocument
-                                        , didChangeTextDocumentParamsContentChanges = parsedContentChanges }
-      _ ->
-        Left ("Unrecognized DidChangeTextDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentChangeRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSyncKind <- lookupFromJSON "syncKind" vs
-           return
-            TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind = parsedSyncKind }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentChangeRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON DidCloseTextDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            DidCloseTextDocumentParams { didCloseTextDocumentParamsTextDocument = parsedTextDocument }
-      _ ->
-        Left ("Unrecognized DidCloseTextDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON DidSaveTextDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedText <- lookupMaybeFromJSON "text" vs
-           return
-            DidSaveTextDocumentParams { didSaveTextDocumentParamsTextDocument = parsedTextDocument
-                                      , didSaveTextDocumentParamsText = parsedText }
-      _ -> Left ("Unrecognized DidSaveTextDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentSaveRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TextDocumentSaveRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentSaveRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON WillSaveTextDocumentParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedReason <- lookupFromJSON "reason" vs
-           return
-            WillSaveTextDocumentParams { willSaveTextDocumentParamsTextDocument = parsedTextDocument
-                                       , willSaveTextDocumentParamsReason = parsedReason }
-      _ ->
-        Left ("Unrecognized WillSaveTextDocumentParams value: " ++ ppJSON j)
-
-instance FromJSON TextEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedNewText <- lookupFromJSON "newText" vs
-           return
-            TextEdit { textEditRange = parsedRange
-                     , textEditNewText = parsedNewText }
-      _ -> Left ("Unrecognized TextEdit value: " ++ ppJSON j)
-
-instance FromJSON DidChangeWatchedFilesParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedChanges <- lookupFromJSON "changes" vs
-           return
-            DidChangeWatchedFilesParams { didChangeWatchedFilesParamsChanges = parsedChanges }
-      _ ->
-        Left ("Unrecognized DidChangeWatchedFilesParams value: " ++ ppJSON j)
-
-instance FromJSON DidChangeWatchedFilesRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWatchers <- lookupFromJSON "watchers" vs
-           return
-            DidChangeWatchedFilesRegistrationOptions { didChangeWatchedFilesRegistrationOptionsWatchers = parsedWatchers }
-      _ ->
-        Left
-         ("Unrecognized DidChangeWatchedFilesRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON PublishDiagnosticsParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedVersion <- lookupMaybeFromJSON "version" vs
-           parsedDiagnostics <- lookupFromJSON "diagnostics" vs
-           return
-            PublishDiagnosticsParams { publishDiagnosticsParamsUri = parsedUri
-                                     , publishDiagnosticsParamsVersion = parsedVersion
-                                     , publishDiagnosticsParamsDiagnostics = parsedDiagnostics }
-      _ -> Left ("Unrecognized PublishDiagnosticsParams value: " ++ ppJSON j)
-
-instance FromJSON CompletionParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedContext <- lookupMaybeFromJSON "context" vs
-           return CompletionParams { completionParamsContext = parsedContext }
-      _ -> Left ("Unrecognized CompletionParams value: " ++ ppJSON j)
-
-instance FromJSON CompletionItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupFromJSON "label" vs
-           parsedLabelDetails <- lookupMaybeFromJSON "labelDetails" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedDetail <- lookupMaybeFromJSON "detail" vs
-           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
-           parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
-           parsedPreselect <- lookupMaybeFromJSON "preselect" vs
-           parsedSortText <- lookupMaybeFromJSON "sortText" vs
-           parsedFilterText <- lookupMaybeFromJSON "filterText" vs
-           parsedInsertText <- lookupMaybeFromJSON "insertText" vs
-           parsedInsertTextFormat <- lookupMaybeFromJSON "insertTextFormat" vs
-           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
-           parsedTextEdit <- lookupMaybeFromJSON "textEdit" vs
-           parsedTextEditText <- lookupMaybeFromJSON "textEditText" vs
-           parsedAdditionalTextEdits <- lookupMaybeFromJSON
-                                         "additionalTextEdits"
-                                         vs
-           parsedCommitCharacters <- lookupMaybeFromJSON "commitCharacters" vs
-           parsedCommand <- lookupMaybeFromJSON "command" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            CompletionItem { completionItemLabel = parsedLabel
-                           , completionItemLabelDetails = parsedLabelDetails
-                           , completionItemKind = parsedKind
-                           , completionItemTags = parsedTags
-                           , completionItemDetail = parsedDetail
-                           , completionItemDocumentation = parsedDocumentation
-                           , completionItemDeprecated = parsedDeprecated
-                           , completionItemPreselect = parsedPreselect
-                           , completionItemSortText = parsedSortText
-                           , completionItemFilterText = parsedFilterText
-                           , completionItemInsertText = parsedInsertText
-                           , completionItemInsertTextFormat = parsedInsertTextFormat
-                           , completionItemInsertTextMode = parsedInsertTextMode
-                           , completionItemTextEdit = parsedTextEdit
-                           , completionItemTextEditText = parsedTextEditText
-                           , completionItemAdditionalTextEdits = parsedAdditionalTextEdits
-                           , completionItemCommitCharacters = parsedCommitCharacters
-                           , completionItemCommand = parsedCommand
-                           , completionItemData = parsedData }
-      _ -> Left ("Unrecognized CompletionItem value: " ++ ppJSON j)
-
-instance FromJSON CompletionList where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIsIncomplete <- lookupFromJSON "isIncomplete" vs
-           parsedItemDefaults <- lookupMaybeFromJSON "itemDefaults" vs
-           parsedItems <- lookupFromJSON "items" vs
-           return
-            CompletionList { completionListIsIncomplete = parsedIsIncomplete
-                           , completionListItemDefaults = parsedItemDefaults
-                           , completionListItems = parsedItems }
-      _ -> Left ("Unrecognized CompletionList value: " ++ ppJSON j)
-
-instance FromJSON CompletionRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CompletionRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized CompletionRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON HoverParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return HoverParams {  }
-      _ -> Left ("Unrecognized HoverParams value: " ++ ppJSON j)
-
-instance FromJSON Hover where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedContents <- lookupFromJSON "contents" vs
-           parsedRange <- lookupMaybeFromJSON "range" vs
-           return
-            Hover { hoverContents = parsedContents, hoverRange = parsedRange }
-      _ -> Left ("Unrecognized Hover value: " ++ ppJSON j)
-
-instance FromJSON HoverRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return HoverRegistrationOptions {  }
-      _ -> Left ("Unrecognized HoverRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedContext <- lookupMaybeFromJSON "context" vs
-           return
-            SignatureHelpParams { signatureHelpParamsContext = parsedContext }
-      _ -> Left ("Unrecognized SignatureHelpParams value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelp where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSignatures <- lookupFromJSON "signatures" vs
-           parsedActiveSignature <- lookupMaybeFromJSON "activeSignature" vs
-           parsedActiveParameter <- lookupMaybeFromJSON "activeParameter" vs
-           return
-            SignatureHelp { signatureHelpSignatures = parsedSignatures
-                          , signatureHelpActiveSignature = parsedActiveSignature
-                          , signatureHelpActiveParameter = parsedActiveParameter }
-      _ -> Left ("Unrecognized SignatureHelp value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return SignatureHelpRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized SignatureHelpRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DefinitionParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DefinitionParams {  }
-      _ -> Left ("Unrecognized DefinitionParams value: " ++ ppJSON j)
-
-instance FromJSON DefinitionRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DefinitionRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DefinitionRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON ReferenceParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedContext <- lookupFromJSON "context" vs
-           return ReferenceParams { referenceParamsContext = parsedContext }
-      _ -> Left ("Unrecognized ReferenceParams value: " ++ ppJSON j)
-
-instance FromJSON ReferenceRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ReferenceRegistrationOptions {  }
-      _ ->
-        Left ("Unrecognized ReferenceRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlightParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentHighlightParams {  }
-      _ -> Left ("Unrecognized DocumentHighlightParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlight where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           return
-            DocumentHighlight { documentHighlightRange = parsedRange
-                              , documentHighlightKind = parsedKind }
-      _ -> Left ("Unrecognized DocumentHighlight value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlightRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentHighlightRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentHighlightRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentSymbolParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            DocumentSymbolParams { documentSymbolParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized DocumentSymbolParams value: " ++ ppJSON j)
-
-instance FromJSON SymbolInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
-           parsedLocation <- lookupFromJSON "location" vs
-           return
-            SymbolInformation { symbolInformationDeprecated = parsedDeprecated
-                              , symbolInformationLocation = parsedLocation }
-      _ -> Left ("Unrecognized SymbolInformation value: " ++ ppJSON j)
-
-instance FromJSON DocumentSymbol where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedDetail <- lookupMaybeFromJSON "detail" vs
-           parsedKind <- lookupFromJSON "kind" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
-           parsedChildren <- lookupMaybeFromJSON "children" vs
-           return
-            DocumentSymbol { documentSymbolName = parsedName
-                           , documentSymbolDetail = parsedDetail
-                           , documentSymbolKind = parsedKind
-                           , documentSymbolTags = parsedTags
-                           , documentSymbolDeprecated = parsedDeprecated
-                           , documentSymbolRange = parsedRange
-                           , documentSymbolSelectionRange = parsedSelectionRange
-                           , documentSymbolChildren = parsedChildren }
-      _ -> Left ("Unrecognized DocumentSymbol value: " ++ ppJSON j)
-
-instance FromJSON DocumentSymbolRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentSymbolRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentSymbolRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON CodeActionParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedContext <- lookupFromJSON "context" vs
-           return
-            CodeActionParams { codeActionParamsTextDocument = parsedTextDocument
-                             , codeActionParamsRange = parsedRange
-                             , codeActionParamsContext = parsedContext }
-      _ -> Left ("Unrecognized CodeActionParams value: " ++ ppJSON j)
-
-instance FromJSON Command where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTitle <- lookupFromJSON "title" vs
-           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
-           parsedCommand <- lookupFromJSON "command" vs
-           parsedArguments <- lookupMaybeFromJSON "arguments" vs
-           return
-            Command { commandTitle = parsedTitle
-                    , commandTooltip = parsedTooltip
-                    , commandCommand = parsedCommand
-                    , commandArguments = parsedArguments }
-      _ -> Left ("Unrecognized Command value: " ++ ppJSON j)
-
-instance FromJSON CodeAction where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTitle <- lookupFromJSON "title" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           parsedDiagnostics <- lookupMaybeFromJSON "diagnostics" vs
-           parsedIsPreferred <- lookupMaybeFromJSON "isPreferred" vs
-           parsedDisabled <- lookupMaybeFromJSON "disabled" vs
-           parsedEdit <- lookupMaybeFromJSON "edit" vs
-           parsedCommand <- lookupMaybeFromJSON "command" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            CodeAction { codeActionTitle = parsedTitle
-                       , codeActionKind = parsedKind
-                       , codeActionDiagnostics = parsedDiagnostics
-                       , codeActionIsPreferred = parsedIsPreferred
-                       , codeActionDisabled = parsedDisabled
-                       , codeActionEdit = parsedEdit
-                       , codeActionCommand = parsedCommand
-                       , codeActionData = parsedData }
-      _ -> Left ("Unrecognized CodeAction value: " ++ ppJSON j)
-
-instance FromJSON CodeActionRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CodeActionRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized CodeActionRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceSymbolParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedQuery <- lookupFromJSON "query" vs
-           return
-            WorkspaceSymbolParams { workspaceSymbolParamsQuery = parsedQuery }
-      _ -> Left ("Unrecognized WorkspaceSymbolParams value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceSymbol where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLocation <- lookupFromJSON "location" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            WorkspaceSymbol { workspaceSymbolLocation = parsedLocation
-                            , workspaceSymbolData = parsedData }
-      _ -> Left ("Unrecognized WorkspaceSymbol value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceSymbolRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return WorkspaceSymbolRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceSymbolRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON CodeLensParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            CodeLensParams { codeLensParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized CodeLensParams value: " ++ ppJSON j)
-
-instance FromJSON CodeLens where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedCommand <- lookupMaybeFromJSON "command" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            CodeLens { codeLensRange = parsedRange
-                     , codeLensCommand = parsedCommand
-                     , codeLensData = parsedData }
-      _ -> Left ("Unrecognized CodeLens value: " ++ ppJSON j)
-
-instance FromJSON CodeLensRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CodeLensRegistrationOptions {  }
-      _ ->
-        Left ("Unrecognized CodeLensRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentLinkParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           return
-            DocumentLinkParams { documentLinkParamsTextDocument = parsedTextDocument }
-      _ -> Left ("Unrecognized DocumentLinkParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentLink where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedTarget <- lookupMaybeFromJSON "target" vs
-           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            DocumentLink { documentLinkRange = parsedRange
-                         , documentLinkTarget = parsedTarget
-                         , documentLinkTooltip = parsedTooltip
-                         , documentLinkData = parsedData }
-      _ -> Left ("Unrecognized DocumentLink value: " ++ ppJSON j)
-
-instance FromJSON DocumentLinkRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentLinkRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentLinkRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentFormattingParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedOptions <- lookupFromJSON "options" vs
-           return
-            DocumentFormattingParams { documentFormattingParamsTextDocument = parsedTextDocument
-                                     , documentFormattingParamsOptions = parsedOptions }
-      _ -> Left ("Unrecognized DocumentFormattingParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentFormattingRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentFormattingRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentFormattingRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentRangeFormattingParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRange <- lookupFromJSON "range" vs
-           parsedOptions <- lookupFromJSON "options" vs
-           return
-            DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument = parsedTextDocument
-                                          , documentRangeFormattingParamsRange = parsedRange
-                                          , documentRangeFormattingParamsOptions = parsedOptions }
-      _ ->
-        Left
-         ("Unrecognized DocumentRangeFormattingParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentRangeFormattingRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentRangeFormattingRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentRangeFormattingRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentRangesFormattingParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedRanges <- lookupFromJSON "ranges" vs
-           parsedOptions <- lookupFromJSON "options" vs
-           return
-            DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument = parsedTextDocument
-                                           , documentRangesFormattingParamsRanges = parsedRanges
-                                           , documentRangesFormattingParamsOptions = parsedOptions }
-      _ ->
-        Left
-         ("Unrecognized DocumentRangesFormattingParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentOnTypeFormattingParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedPosition <- lookupFromJSON "position" vs
-           parsedCh <- lookupFromJSON "ch" vs
-           parsedOptions <- lookupFromJSON "options" vs
-           return
-            DocumentOnTypeFormattingParams { documentOnTypeFormattingParamsTextDocument = parsedTextDocument
-                                           , documentOnTypeFormattingParamsPosition = parsedPosition
-                                           , documentOnTypeFormattingParamsCh = parsedCh
-                                           , documentOnTypeFormattingParamsOptions = parsedOptions }
-      _ ->
-        Left
-         ("Unrecognized DocumentOnTypeFormattingParams value: " ++ ppJSON j)
-
-instance FromJSON DocumentOnTypeFormattingRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentOnTypeFormattingRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized DocumentOnTypeFormattingRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON RenameParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedPosition <- lookupFromJSON "position" vs
-           parsedNewName <- lookupFromJSON "newName" vs
-           return
-            RenameParams { renameParamsTextDocument = parsedTextDocument
-                         , renameParamsPosition = parsedPosition
-                         , renameParamsNewName = parsedNewName }
-      _ -> Left ("Unrecognized RenameParams value: " ++ ppJSON j)
-
-instance FromJSON RenameRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return RenameRegistrationOptions {  }
-      _ -> Left ("Unrecognized RenameRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON PrepareRenameParams where
-  fromJSON j =
-    case j of
-      JObject vs -> do return PrepareRenameParams {  }
-      _ -> Left ("Unrecognized PrepareRenameParams value: " ++ ppJSON j)
-
-instance FromJSON ExecuteCommandParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCommand <- lookupFromJSON "command" vs
-           parsedArguments <- lookupMaybeFromJSON "arguments" vs
-           return
-            ExecuteCommandParams { executeCommandParamsCommand = parsedCommand
-                                 , executeCommandParamsArguments = parsedArguments }
-      _ -> Left ("Unrecognized ExecuteCommandParams value: " ++ ppJSON j)
-
-instance FromJSON ExecuteCommandRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ExecuteCommandRegistrationOptions {  }
-      _ ->
-        Left
-         ("Unrecognized ExecuteCommandRegistrationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ApplyWorkspaceEditParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupMaybeFromJSON "label" vs
-           parsedEdit <- lookupFromJSON "edit" vs
-           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
-           return
-            ApplyWorkspaceEditParams { applyWorkspaceEditParamsLabel = parsedLabel
-                                     , applyWorkspaceEditParamsEdit = parsedEdit
-                                     , applyWorkspaceEditParamsMetadata = parsedMetadata }
-      _ -> Left ("Unrecognized ApplyWorkspaceEditParams value: " ++ ppJSON j)
-
-instance FromJSON ApplyWorkspaceEditResult where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedApplied <- lookupFromJSON "applied" vs
-           parsedFailureReason <- lookupMaybeFromJSON "failureReason" vs
-           parsedFailedChange <- lookupMaybeFromJSON "failedChange" vs
-           return
-            ApplyWorkspaceEditResult { applyWorkspaceEditResultApplied = parsedApplied
-                                     , applyWorkspaceEditResultFailureReason = parsedFailureReason
-                                     , applyWorkspaceEditResultFailedChange = parsedFailedChange }
-      _ -> Left ("Unrecognized ApplyWorkspaceEditResult value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressBegin where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedTitle <- lookupFromJSON "title" vs
-           parsedCancellable <- lookupMaybeFromJSON "cancellable" vs
-           parsedMessage <- lookupMaybeFromJSON "message" vs
-           parsedPercentage <- lookupMaybeFromJSON "percentage" vs
-           return
-            WorkDoneProgressBegin { workDoneProgressBeginKind = parsedKind
-                                  , workDoneProgressBeginTitle = parsedTitle
-                                  , workDoneProgressBeginCancellable = parsedCancellable
-                                  , workDoneProgressBeginMessage = parsedMessage
-                                  , workDoneProgressBeginPercentage = parsedPercentage }
-      _ -> Left ("Unrecognized WorkDoneProgressBegin value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedCancellable <- lookupMaybeFromJSON "cancellable" vs
-           parsedMessage <- lookupMaybeFromJSON "message" vs
-           parsedPercentage <- lookupMaybeFromJSON "percentage" vs
-           return
-            WorkDoneProgressReport { workDoneProgressReportKind = parsedKind
-                                   , workDoneProgressReportCancellable = parsedCancellable
-                                   , workDoneProgressReportMessage = parsedMessage
-                                   , workDoneProgressReportPercentage = parsedPercentage }
-      _ -> Left ("Unrecognized WorkDoneProgressReport value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressEnd where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedMessage <- lookupMaybeFromJSON "message" vs
-           return
-            WorkDoneProgressEnd { workDoneProgressEndKind = parsedKind
-                                , workDoneProgressEndMessage = parsedMessage }
-      _ -> Left ("Unrecognized WorkDoneProgressEnd value: " ++ ppJSON j)
-
-instance FromJSON SetTraceParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValue <- lookupFromJSON "value" vs
-           return SetTraceParams { setTraceParamsValue = parsedValue }
-      _ -> Left ("Unrecognized SetTraceParams value: " ++ ppJSON j)
-
-instance FromJSON LogTraceParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedMessage <- lookupFromJSON "message" vs
-           parsedVerbose <- lookupMaybeFromJSON "verbose" vs
-           return
-            LogTraceParams { logTraceParamsMessage = parsedMessage
-                           , logTraceParamsVerbose = parsedVerbose }
-      _ -> Left ("Unrecognized LogTraceParams value: " ++ ppJSON j)
-
-instance FromJSON CancelParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedId <- lookupFromJSON "id" vs
-           return CancelParams { cancelParamsId = parsedId }
-      _ -> Left ("Unrecognized CancelParams value: " ++ ppJSON j)
-
-instance FromJSON ProgressParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedToken <- lookupFromJSON "token" vs
-           parsedValue <- lookupFromJSON "value" vs
-           return
-            ProgressParams { progressParamsToken = parsedToken
-                           , progressParamsValue = parsedValue }
-      _ -> Left ("Unrecognized ProgressParams value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentPositionParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedPosition <- lookupFromJSON "position" vs
-           return
-            TextDocumentPositionParams { textDocumentPositionParamsTextDocument = parsedTextDocument
-                                       , textDocumentPositionParamsPosition = parsedPosition }
-      _ ->
-        Left ("Unrecognized TextDocumentPositionParams value: " ++ ppJSON j)
-
-instance FromJSON WorkDoneProgressParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
-           return
-            WorkDoneProgressParams { workDoneProgressParamsWorkDoneToken = parsedWorkDoneToken }
-      _ -> Left ("Unrecognized WorkDoneProgressParams value: " ++ ppJSON j)
-
-instance FromJSON PartialResultParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedPartialResultToken <- lookupMaybeFromJSON
-                                        "partialResultToken"
-                                        vs
-           return
-            PartialResultParams { partialResultParamsPartialResultToken = parsedPartialResultToken }
-      _ -> Left ("Unrecognized PartialResultParams value: " ++ ppJSON j)
-
-instance FromJSON LocationLink where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedOriginSelectionRange <- lookupMaybeFromJSON
-                                          "originSelectionRange"
-                                          vs
-           parsedTargetUri <- lookupFromJSON "targetUri" vs
-           parsedTargetRange <- lookupFromJSON "targetRange" vs
-           parsedTargetSelectionRange <- lookupFromJSON "targetSelectionRange"
-                                          vs
-           return
-            LocationLink { locationLinkOriginSelectionRange = parsedOriginSelectionRange
-                         , locationLinkTargetUri = parsedTargetUri
-                         , locationLinkTargetRange = parsedTargetRange
-                         , locationLinkTargetSelectionRange = parsedTargetSelectionRange }
-      _ -> Left ("Unrecognized LocationLink value: " ++ ppJSON j)
-
-instance FromJSON Range where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStart <- lookupFromJSON "start" vs
-           parsedEnd <- lookupFromJSON "end" vs
-           return Range { rangeStart = parsedStart, rangeEnd = parsedEnd }
-      _ -> Left ("Unrecognized Range value: " ++ ppJSON j)
-
-instance FromJSON ImplementationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ImplementationOptions {  }
-      _ -> Left ("Unrecognized ImplementationOptions value: " ++ ppJSON j)
-
-instance FromJSON StaticRegistrationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedId <- lookupMaybeFromJSON "id" vs
-           return
-            StaticRegistrationOptions { staticRegistrationOptionsId = parsedId }
-      _ -> Left ("Unrecognized StaticRegistrationOptions value: " ++ ppJSON j)
-
-instance FromJSON TypeDefinitionOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeDefinitionOptions {  }
-      _ -> Left ("Unrecognized TypeDefinitionOptions value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceFoldersChangeEvent where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedAdded <- lookupFromJSON "added" vs
-           parsedRemoved <- lookupFromJSON "removed" vs
-           return
-            WorkspaceFoldersChangeEvent { workspaceFoldersChangeEventAdded = parsedAdded
-                                        , workspaceFoldersChangeEventRemoved = parsedRemoved }
-      _ ->
-        Left ("Unrecognized WorkspaceFoldersChangeEvent value: " ++ ppJSON j)
-
-instance FromJSON ConfigurationItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedScopeUri <- lookupMaybeFromJSON "scopeUri" vs
-           parsedSection <- lookupMaybeFromJSON "section" vs
-           return
-            ConfigurationItem { configurationItemScopeUri = parsedScopeUri
-                              , configurationItemSection = parsedSection }
-      _ -> Left ("Unrecognized ConfigurationItem value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentIdentifier where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           return
-            TextDocumentIdentifier { textDocumentIdentifierUri = parsedUri }
-      _ -> Left ("Unrecognized TextDocumentIdentifier value: " ++ ppJSON j)
-
-instance FromJSON Color where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRed <- lookupFromJSON "red" vs
-           parsedGreen <- lookupFromJSON "green" vs
-           parsedBlue <- lookupFromJSON "blue" vs
-           parsedAlpha <- lookupFromJSON "alpha" vs
-           return
-            Color { colorRed = parsedRed
-                  , colorGreen = parsedGreen
-                  , colorBlue = parsedBlue
-                  , colorAlpha = parsedAlpha }
-      _ -> Left ("Unrecognized Color value: " ++ ppJSON j)
-
-instance FromJSON DocumentColorOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentColorOptions {  }
-      _ -> Left ("Unrecognized DocumentColorOptions value: " ++ ppJSON j)
-
-instance FromJSON FoldingRangeOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return FoldingRangeOptions {  }
-      _ -> Left ("Unrecognized FoldingRangeOptions value: " ++ ppJSON j)
-
-instance FromJSON DeclarationOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DeclarationOptions {  }
-      _ -> Left ("Unrecognized DeclarationOptions value: " ++ ppJSON j)
-
-instance FromJSON Position where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLine <- lookupFromJSON "line" vs
-           parsedCharacter <- lookupFromJSON "character" vs
-           return
-            Position { positionLine = parsedLine
-                     , positionCharacter = parsedCharacter }
-      _ -> Left ("Unrecognized Position value: " ++ ppJSON j)
-
-instance FromJSON SelectionRangeOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return SelectionRangeOptions {  }
-      _ -> Left ("Unrecognized SelectionRangeOptions value: " ++ ppJSON j)
-
-instance FromJSON CallHierarchyOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return CallHierarchyOptions {  }
-      _ -> Left ("Unrecognized CallHierarchyOptions value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLegend <- lookupFromJSON "legend" vs
-           parsedRange <- lookupMaybeFromJSON "range" vs
-           parsedFull <- lookupMaybeFromJSON "full" vs
-           return
-            SemanticTokensOptions { semanticTokensOptionsLegend = parsedLegend
-                                  , semanticTokensOptionsRange = parsedRange
-                                  , semanticTokensOptionsFull = parsedFull }
-      _ -> Left ("Unrecognized SemanticTokensOptions value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStart <- lookupFromJSON "start" vs
-           parsedDeleteCount <- lookupFromJSON "deleteCount" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            SemanticTokensEdit { semanticTokensEditStart = parsedStart
-                               , semanticTokensEditDeleteCount = parsedDeleteCount
-                               , semanticTokensEditData = parsedData }
-      _ -> Left ("Unrecognized SemanticTokensEdit value: " ++ ppJSON j)
-
-instance FromJSON LinkedEditingRangeOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return LinkedEditingRangeOptions {  }
-      _ -> Left ("Unrecognized LinkedEditingRangeOptions value: " ++ ppJSON j)
-
-instance FromJSON FileCreate where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           return FileCreate { fileCreateUri = parsedUri }
-      _ -> Left ("Unrecognized FileCreate value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
-           parsedEdits <- lookupFromJSON "edits" vs
-           return
-            TextDocumentEdit { textDocumentEditTextDocument = parsedTextDocument
-                             , textDocumentEditEdits = parsedEdits }
-      _ -> Left ("Unrecognized TextDocumentEdit value: " ++ ppJSON j)
-
-instance FromJSON CreateFile where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedUri <- lookupFromJSON "uri" vs
-           parsedOptions <- lookupMaybeFromJSON "options" vs
-           return
-            CreateFile { createFileKind = parsedKind
-                       , createFileUri = parsedUri
-                       , createFileOptions = parsedOptions }
-      _ -> Left ("Unrecognized CreateFile value: " ++ ppJSON j)
-
-instance FromJSON RenameFile where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedOldUri <- lookupFromJSON "oldUri" vs
-           parsedNewUri <- lookupFromJSON "newUri" vs
-           parsedOptions <- lookupMaybeFromJSON "options" vs
-           return
-            RenameFile { renameFileKind = parsedKind
-                       , renameFileOldUri = parsedOldUri
-                       , renameFileNewUri = parsedNewUri
-                       , renameFileOptions = parsedOptions }
-      _ -> Left ("Unrecognized RenameFile value: " ++ ppJSON j)
-
-instance FromJSON DeleteFile where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedUri <- lookupFromJSON "uri" vs
-           parsedOptions <- lookupMaybeFromJSON "options" vs
-           return
-            DeleteFile { deleteFileKind = parsedKind
-                       , deleteFileUri = parsedUri
-                       , deleteFileOptions = parsedOptions }
-      _ -> Left ("Unrecognized DeleteFile value: " ++ ppJSON j)
-
-instance FromJSON ChangeAnnotation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupFromJSON "label" vs
-           parsedNeedsConfirmation <- lookupMaybeFromJSON "needsConfirmation"
-                                       vs
-           parsedDescription <- lookupMaybeFromJSON "description" vs
-           return
-            ChangeAnnotation { changeAnnotationLabel = parsedLabel
-                             , changeAnnotationNeedsConfirmation = parsedNeedsConfirmation
-                             , changeAnnotationDescription = parsedDescription }
-      _ -> Left ("Unrecognized ChangeAnnotation value: " ++ ppJSON j)
-
-instance FromJSON FileOperationFilter where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedScheme <- lookupMaybeFromJSON "scheme" vs
-           parsedPattern <- lookupFromJSON "pattern" vs
-           return
-            FileOperationFilter { fileOperationFilterScheme = parsedScheme
-                                , fileOperationFilterPattern = parsedPattern }
-      _ -> Left ("Unrecognized FileOperationFilter value: " ++ ppJSON j)
-
-instance FromJSON FileRename where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedOldUri <- lookupFromJSON "oldUri" vs
-           parsedNewUri <- lookupFromJSON "newUri" vs
-           return
-            FileRename { fileRenameOldUri = parsedOldUri
-                       , fileRenameNewUri = parsedNewUri }
-      _ -> Left ("Unrecognized FileRename value: " ++ ppJSON j)
-
-instance FromJSON FileDelete where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           return FileDelete { fileDeleteUri = parsedUri }
-      _ -> Left ("Unrecognized FileDelete value: " ++ ppJSON j)
-
-instance FromJSON MonikerOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return MonikerOptions {  }
-      _ -> Left ("Unrecognized MonikerOptions value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchyOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return TypeHierarchyOptions {  }
-      _ -> Left ("Unrecognized TypeHierarchyOptions value: " ++ ppJSON j)
-
-instance FromJSON InlineValueContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFrameId <- lookupFromJSON "frameId" vs
-           parsedStoppedLocation <- lookupFromJSON "stoppedLocation" vs
-           return
-            InlineValueContext { inlineValueContextFrameId = parsedFrameId
-                               , inlineValueContextStoppedLocation = parsedStoppedLocation }
-      _ -> Left ("Unrecognized InlineValueContext value: " ++ ppJSON j)
-
-instance FromJSON InlineValueText where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedText <- lookupFromJSON "text" vs
-           return
-            InlineValueText { inlineValueTextRange = parsedRange
-                            , inlineValueTextText = parsedText }
-      _ -> Left ("Unrecognized InlineValueText value: " ++ ppJSON j)
-
-instance FromJSON InlineValueVariableLookup where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedVariableName <- lookupMaybeFromJSON "variableName" vs
-           parsedCaseSensitiveLookup <- lookupFromJSON "caseSensitiveLookup"
-                                         vs
-           return
-            InlineValueVariableLookup { inlineValueVariableLookupRange = parsedRange
-                                      , inlineValueVariableLookupVariableName = parsedVariableName
-                                      , inlineValueVariableLookupCaseSensitiveLookup = parsedCaseSensitiveLookup }
-      _ -> Left ("Unrecognized InlineValueVariableLookup value: " ++ ppJSON j)
-
-instance FromJSON InlineValueEvaluatableExpression where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedExpression <- lookupMaybeFromJSON "expression" vs
-           return
-            InlineValueEvaluatableExpression { inlineValueEvaluatableExpressionRange = parsedRange
-                                             , inlineValueEvaluatableExpressionExpression = parsedExpression }
-      _ ->
-        Left
-         ("Unrecognized InlineValueEvaluatableExpression value: " ++ ppJSON j)
-
-instance FromJSON InlineValueOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InlineValueOptions {  }
-      _ -> Left ("Unrecognized InlineValueOptions value: " ++ ppJSON j)
-
-instance FromJSON InlayHintLabelPart where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValue <- lookupFromJSON "value" vs
-           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
-           parsedLocation <- lookupMaybeFromJSON "location" vs
-           parsedCommand <- lookupMaybeFromJSON "command" vs
-           return
-            InlayHintLabelPart { inlayHintLabelPartValue = parsedValue
-                               , inlayHintLabelPartTooltip = parsedTooltip
-                               , inlayHintLabelPartLocation = parsedLocation
-                               , inlayHintLabelPartCommand = parsedCommand }
-      _ -> Left ("Unrecognized InlayHintLabelPart value: " ++ ppJSON j)
-
-instance FromJSON MarkupContent where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedValue <- lookupFromJSON "value" vs
-           return
-            MarkupContent { markupContentKind = parsedKind
-                          , markupContentValue = parsedValue }
-      _ -> Left ("Unrecognized MarkupContent value: " ++ ppJSON j)
-
-instance FromJSON InlayHintOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           return
-            InlayHintOptions { inlayHintOptionsResolveProvider = parsedResolveProvider }
-      _ -> Left ("Unrecognized InlayHintOptions value: " ++ ppJSON j)
-
-instance FromJSON RelatedFullDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
-           return
-            RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
-      _ ->
-        Left
-         ("Unrecognized RelatedFullDocumentDiagnosticReport value: "
-           ++ ppJSON j)
-
-instance FromJSON RelatedUnchangedDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
-           return
-            RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
-      _ ->
-        Left
-         ("Unrecognized RelatedUnchangedDocumentDiagnosticReport value: "
-           ++ ppJSON j)
-
-instance FromJSON FullDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedResultId <- lookupMaybeFromJSON "resultId" vs
-           parsedItems <- lookupFromJSON "items" vs
-           return
-            FullDocumentDiagnosticReport { fullDocumentDiagnosticReportKind = parsedKind
-                                         , fullDocumentDiagnosticReportResultId = parsedResultId
-                                         , fullDocumentDiagnosticReportItems = parsedItems }
-      _ ->
-        Left ("Unrecognized FullDocumentDiagnosticReport value: " ++ ppJSON j)
-
-instance FromJSON UnchangedDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedResultId <- lookupFromJSON "resultId" vs
-           return
-            UnchangedDocumentDiagnosticReport { unchangedDocumentDiagnosticReportKind = parsedKind
-                                              , unchangedDocumentDiagnosticReportResultId = parsedResultId }
-      _ ->
-        Left
-         ("Unrecognized UnchangedDocumentDiagnosticReport value: "
-           ++ ppJSON j)
-
-instance FromJSON DiagnosticOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
-           parsedInterFileDependencies <- lookupFromJSON
-                                           "interFileDependencies"
-                                           vs
-           parsedWorkspaceDiagnostics <- lookupFromJSON "workspaceDiagnostics"
-                                          vs
-           return
-            DiagnosticOptions { diagnosticOptionsIdentifier = parsedIdentifier
-                              , diagnosticOptionsInterFileDependencies = parsedInterFileDependencies
-                              , diagnosticOptionsWorkspaceDiagnostics = parsedWorkspaceDiagnostics }
-      _ -> Left ("Unrecognized DiagnosticOptions value: " ++ ppJSON j)
-
-instance FromJSON PreviousResultId where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedValue <- lookupFromJSON "value" vs
-           return
-            PreviousResultId { previousResultIdUri = parsedUri
-                             , previousResultIdValue = parsedValue }
-      _ -> Left ("Unrecognized PreviousResultId value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocument where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedNotebookType <- lookupFromJSON "notebookType" vs
-           parsedVersion <- lookupFromJSON "version" vs
-           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
-           parsedCells <- lookupFromJSON "cells" vs
-           return
-            NotebookDocument { notebookDocumentUri = parsedUri
-                             , notebookDocumentNotebookType = parsedNotebookType
-                             , notebookDocumentVersion = parsedVersion
-                             , notebookDocumentMetadata = parsedMetadata
-                             , notebookDocumentCells = parsedCells }
-      _ -> Left ("Unrecognized NotebookDocument value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentItem where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedLanguageId <- lookupFromJSON "languageId" vs
-           parsedVersion <- lookupFromJSON "version" vs
-           parsedText <- lookupFromJSON "text" vs
-           return
-            TextDocumentItem { textDocumentItemUri = parsedUri
-                             , textDocumentItemLanguageId = parsedLanguageId
-                             , textDocumentItemVersion = parsedVersion
-                             , textDocumentItemText = parsedText }
-      _ -> Left ("Unrecognized TextDocumentItem value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentSyncOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookSelector <- lookupFromJSON "notebookSelector" vs
-           parsedSave <- lookupMaybeFromJSON "save" vs
-           return
-            NotebookDocumentSyncOptions { notebookDocumentSyncOptionsNotebookSelector = parsedNotebookSelector
-                                        , notebookDocumentSyncOptionsSave = parsedSave }
-      _ ->
-        Left ("Unrecognized NotebookDocumentSyncOptions value: " ++ ppJSON j)
-
-instance FromJSON VersionedNotebookDocumentIdentifier where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedVersion <- lookupFromJSON "version" vs
-           parsedUri <- lookupFromJSON "uri" vs
-           return
-            VersionedNotebookDocumentIdentifier { versionedNotebookDocumentIdentifierVersion = parsedVersion
-                                                , versionedNotebookDocumentIdentifierUri = parsedUri }
-      _ ->
-        Left
-         ("Unrecognized VersionedNotebookDocumentIdentifier value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookDocumentChangeEvent where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedMetadata <- lookupMaybeFromJSON "metadata" vs
-           parsedCells <- lookupMaybeFromJSON "cells" vs
-           return
-            NotebookDocumentChangeEvent { notebookDocumentChangeEventMetadata = parsedMetadata
-                                        , notebookDocumentChangeEventCells = parsedCells }
-      _ ->
-        Left ("Unrecognized NotebookDocumentChangeEvent value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentIdentifier where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           return
-            NotebookDocumentIdentifier { notebookDocumentIdentifierUri = parsedUri }
-      _ ->
-        Left ("Unrecognized NotebookDocumentIdentifier value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
-           parsedSelectedCompletionInfo <- lookupMaybeFromJSON
-                                            "selectedCompletionInfo"
-                                            vs
-           return
-            InlineCompletionContext { inlineCompletionContextTriggerKind = parsedTriggerKind
-                                    , inlineCompletionContextSelectedCompletionInfo = parsedSelectedCompletionInfo }
-      _ -> Left ("Unrecognized InlineCompletionContext value: " ++ ppJSON j)
-
-instance FromJSON StringValue where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedValue <- lookupFromJSON "value" vs
-           return
-            StringValue { stringValueKind = parsedKind
-                        , stringValueValue = parsedValue }
-      _ -> Left ("Unrecognized StringValue value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return InlineCompletionOptions {  }
-      _ -> Left ("Unrecognized InlineCompletionOptions value: " ++ ppJSON j)
-
-instance FromJSON Registration where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedId <- lookupFromJSON "id" vs
-           parsedMethod <- lookupFromJSON "method" vs
-           parsedRegisterOptions <- lookupMaybeFromJSON "registerOptions" vs
-           return
-            Registration { registrationId = parsedId
-                         , registrationMethod = parsedMethod
-                         , registrationRegisterOptions = parsedRegisterOptions }
-      _ -> Left ("Unrecognized Registration value: " ++ ppJSON j)
-
-instance FromJSON Unregistration where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedId <- lookupFromJSON "id" vs
-           parsedMethod <- lookupFromJSON "method" vs
-           return
-            Unregistration { unregistrationId = parsedId
-                           , unregistrationMethod = parsedMethod }
-      _ -> Left ("Unrecognized Unregistration value: " ++ ppJSON j)
-
-instance FromJSON BaseInitializeParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProcessId <- lookupFromJSON "processId" vs
-           parsedClientInfo <- lookupMaybeFromJSON "clientInfo" vs
-           parsedLocale <- lookupMaybeFromJSON "locale" vs
-           parsedRootPath <- lookupMaybeFromJSON "rootPath" vs
-           parsedRootUri <- lookupFromJSON "rootUri" vs
-           parsedCapabilities <- lookupFromJSON "capabilities" vs
-           parsedInitializationOptions <- lookupMaybeFromJSON
-                                           "initializationOptions"
-                                           vs
-           parsedTrace <- lookupMaybeFromJSON "trace" vs
-           return
-            BaseInitializeParams { baseInitializeParamsProcessId = parsedProcessId
-                                 , baseInitializeParamsClientInfo = parsedClientInfo
-                                 , baseInitializeParamsLocale = parsedLocale
-                                 , baseInitializeParamsRootPath = parsedRootPath
-                                 , baseInitializeParamsRootUri = parsedRootUri
-                                 , baseInitializeParamsCapabilities = parsedCapabilities
-                                 , baseInitializeParamsInitializationOptions = parsedInitializationOptions
-                                 , baseInitializeParamsTrace = parsedTrace }
-      _ -> Left ("Unrecognized BaseInitializeParams value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceFoldersInitializeParams where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
-           return
-            WorkspaceFoldersInitializeParams { workspaceFoldersInitializeParamsWorkspaceFolders = parsedWorkspaceFolders }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceFoldersInitializeParams value: " ++ ppJSON j)
-
-instance FromJSON ServerCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedPositionEncoding <- lookupMaybeFromJSON "positionEncoding" vs
-           parsedTextDocumentSync <- lookupMaybeFromJSON "textDocumentSync" vs
-           parsedNotebookDocumentSync <- lookupMaybeFromJSON
-                                          "notebookDocumentSync"
-                                          vs
-           parsedCompletionProvider <- lookupMaybeFromJSON
-                                        "completionProvider"
-                                        vs
-           parsedHoverProvider <- lookupMaybeFromJSON "hoverProvider" vs
-           parsedSignatureHelpProvider <- lookupMaybeFromJSON
-                                           "signatureHelpProvider"
-                                           vs
-           parsedDeclarationProvider <- lookupMaybeFromJSON
-                                         "declarationProvider"
-                                         vs
-           parsedDefinitionProvider <- lookupMaybeFromJSON
-                                        "definitionProvider"
-                                        vs
-           parsedTypeDefinitionProvider <- lookupMaybeFromJSON
-                                            "typeDefinitionProvider"
-                                            vs
-           parsedImplementationProvider <- lookupMaybeFromJSON
-                                            "implementationProvider"
-                                            vs
-           parsedReferencesProvider <- lookupMaybeFromJSON
-                                        "referencesProvider"
-                                        vs
-           parsedDocumentHighlightProvider <- lookupMaybeFromJSON
-                                               "documentHighlightProvider"
-                                               vs
-           parsedDocumentSymbolProvider <- lookupMaybeFromJSON
-                                            "documentSymbolProvider"
-                                            vs
-           parsedCodeActionProvider <- lookupMaybeFromJSON
-                                        "codeActionProvider"
-                                        vs
-           parsedCodeLensProvider <- lookupMaybeFromJSON "codeLensProvider" vs
-           parsedDocumentLinkProvider <- lookupMaybeFromJSON
-                                          "documentLinkProvider"
-                                          vs
-           parsedColorProvider <- lookupMaybeFromJSON "colorProvider" vs
-           parsedWorkspaceSymbolProvider <- lookupMaybeFromJSON
-                                             "workspaceSymbolProvider"
-                                             vs
-           parsedDocumentFormattingProvider <- lookupMaybeFromJSON
-                                                "documentFormattingProvider"
-                                                vs
-           parsedDocumentRangeFormattingProvider <- lookupMaybeFromJSON
-                                                     "documentRangeFormattingProvider"
-                                                     vs
-           parsedDocumentOnTypeFormattingProvider <- lookupMaybeFromJSON
-                                                      "documentOnTypeFormattingProvider"
-                                                      vs
-           parsedRenameProvider <- lookupMaybeFromJSON "renameProvider" vs
-           parsedFoldingRangeProvider <- lookupMaybeFromJSON
-                                          "foldingRangeProvider"
-                                          vs
-           parsedSelectionRangeProvider <- lookupMaybeFromJSON
-                                            "selectionRangeProvider"
-                                            vs
-           parsedExecuteCommandProvider <- lookupMaybeFromJSON
-                                            "executeCommandProvider"
-                                            vs
-           parsedCallHierarchyProvider <- lookupMaybeFromJSON
-                                           "callHierarchyProvider"
-                                           vs
-           parsedLinkedEditingRangeProvider <- lookupMaybeFromJSON
-                                                "linkedEditingRangeProvider"
-                                                vs
-           parsedSemanticTokensProvider <- lookupMaybeFromJSON
-                                            "semanticTokensProvider"
-                                            vs
-           parsedMonikerProvider <- lookupMaybeFromJSON "monikerProvider" vs
-           parsedTypeHierarchyProvider <- lookupMaybeFromJSON
-                                           "typeHierarchyProvider"
-                                           vs
-           parsedInlineValueProvider <- lookupMaybeFromJSON
-                                         "inlineValueProvider"
-                                         vs
-           parsedInlayHintProvider <- lookupMaybeFromJSON "inlayHintProvider"
-                                       vs
-           parsedDiagnosticProvider <- lookupMaybeFromJSON
-                                        "diagnosticProvider"
-                                        vs
-           parsedInlineCompletionProvider <- lookupMaybeFromJSON
-                                              "inlineCompletionProvider"
-                                              vs
-           parsedWorkspace <- lookupMaybeFromJSON "workspace" vs
-           parsedExperimental <- lookupMaybeFromJSON "experimental" vs
-           return
-            ServerCapabilities { serverCapabilitiesPositionEncoding = parsedPositionEncoding
-                               , serverCapabilitiesTextDocumentSync = parsedTextDocumentSync
-                               , serverCapabilitiesNotebookDocumentSync = parsedNotebookDocumentSync
-                               , serverCapabilitiesCompletionProvider = parsedCompletionProvider
-                               , serverCapabilitiesHoverProvider = parsedHoverProvider
-                               , serverCapabilitiesSignatureHelpProvider = parsedSignatureHelpProvider
-                               , serverCapabilitiesDeclarationProvider = parsedDeclarationProvider
-                               , serverCapabilitiesDefinitionProvider = parsedDefinitionProvider
-                               , serverCapabilitiesTypeDefinitionProvider = parsedTypeDefinitionProvider
-                               , serverCapabilitiesImplementationProvider = parsedImplementationProvider
-                               , serverCapabilitiesReferencesProvider = parsedReferencesProvider
-                               , serverCapabilitiesDocumentHighlightProvider = parsedDocumentHighlightProvider
-                               , serverCapabilitiesDocumentSymbolProvider = parsedDocumentSymbolProvider
-                               , serverCapabilitiesCodeActionProvider = parsedCodeActionProvider
-                               , serverCapabilitiesCodeLensProvider = parsedCodeLensProvider
-                               , serverCapabilitiesDocumentLinkProvider = parsedDocumentLinkProvider
-                               , serverCapabilitiesColorProvider = parsedColorProvider
-                               , serverCapabilitiesWorkspaceSymbolProvider = parsedWorkspaceSymbolProvider
-                               , serverCapabilitiesDocumentFormattingProvider = parsedDocumentFormattingProvider
-                               , serverCapabilitiesDocumentRangeFormattingProvider = parsedDocumentRangeFormattingProvider
-                               , serverCapabilitiesDocumentOnTypeFormattingProvider = parsedDocumentOnTypeFormattingProvider
-                               , serverCapabilitiesRenameProvider = parsedRenameProvider
-                               , serverCapabilitiesFoldingRangeProvider = parsedFoldingRangeProvider
-                               , serverCapabilitiesSelectionRangeProvider = parsedSelectionRangeProvider
-                               , serverCapabilitiesExecuteCommandProvider = parsedExecuteCommandProvider
-                               , serverCapabilitiesCallHierarchyProvider = parsedCallHierarchyProvider
-                               , serverCapabilitiesLinkedEditingRangeProvider = parsedLinkedEditingRangeProvider
-                               , serverCapabilitiesSemanticTokensProvider = parsedSemanticTokensProvider
-                               , serverCapabilitiesMonikerProvider = parsedMonikerProvider
-                               , serverCapabilitiesTypeHierarchyProvider = parsedTypeHierarchyProvider
-                               , serverCapabilitiesInlineValueProvider = parsedInlineValueProvider
-                               , serverCapabilitiesInlayHintProvider = parsedInlayHintProvider
-                               , serverCapabilitiesDiagnosticProvider = parsedDiagnosticProvider
-                               , serverCapabilitiesInlineCompletionProvider = parsedInlineCompletionProvider
-                               , serverCapabilitiesWorkspace = parsedWorkspace
-                               , serverCapabilitiesExperimental = parsedExperimental }
-      _ -> Left ("Unrecognized ServerCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ServerInfo where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedVersion <- lookupMaybeFromJSON "version" vs
-           return
-            ServerInfo { serverInfoName = parsedName
-                       , serverInfoVersion = parsedVersion }
-      _ -> Left ("Unrecognized ServerInfo value: " ++ ppJSON j)
-
-instance FromJSON VersionedTextDocumentIdentifier where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedVersion <- lookupFromJSON "version" vs
-           return
-            VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion = parsedVersion }
-      _ ->
-        Left
-         ("Unrecognized VersionedTextDocumentIdentifier value: " ++ ppJSON j)
-
-instance FromJSON SaveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIncludeText <- lookupMaybeFromJSON "includeText" vs
-           return SaveOptions { saveOptionsIncludeText = parsedIncludeText }
-      _ -> Left ("Unrecognized SaveOptions value: " ++ ppJSON j)
-
-instance FromJSON FileEvent where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedType <- lookupFromJSON "type" vs
-           return
-            FileEvent { fileEventUri = parsedUri, fileEventType = parsedType }
-      _ -> Left ("Unrecognized FileEvent value: " ++ ppJSON j)
-
-instance FromJSON FileSystemWatcher where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedGlobPattern <- lookupFromJSON "globPattern" vs
-           parsedKind <- lookupMaybeFromJSON "kind" vs
-           return
-            FileSystemWatcher { fileSystemWatcherGlobPattern = parsedGlobPattern
-                              , fileSystemWatcherKind = parsedKind }
-      _ -> Left ("Unrecognized FileSystemWatcher value: " ++ ppJSON j)
-
-instance FromJSON Diagnostic where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedSeverity <- lookupMaybeFromJSON "severity" vs
-           parsedCode <- lookupMaybeFromJSON "code" vs
-           parsedCodeDescription <- lookupMaybeFromJSON "codeDescription" vs
-           parsedSource <- lookupMaybeFromJSON "source" vs
-           parsedMessage <- lookupFromJSON "message" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedRelatedInformation <- lookupMaybeFromJSON
-                                        "relatedInformation"
-                                        vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            Diagnostic { diagnosticRange = parsedRange
-                       , diagnosticSeverity = parsedSeverity
-                       , diagnosticCode = parsedCode
-                       , diagnosticCodeDescription = parsedCodeDescription
-                       , diagnosticSource = parsedSource
-                       , diagnosticMessage = parsedMessage
-                       , diagnosticTags = parsedTags
-                       , diagnosticRelatedInformation = parsedRelatedInformation
-                       , diagnosticData = parsedData }
-      _ -> Left ("Unrecognized Diagnostic value: " ++ ppJSON j)
-
-instance FromJSON CompletionContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
-           parsedTriggerCharacter <- lookupMaybeFromJSON "triggerCharacter" vs
-           return
-            CompletionContext { completionContextTriggerKind = parsedTriggerKind
-                              , completionContextTriggerCharacter = parsedTriggerCharacter }
-      _ -> Left ("Unrecognized CompletionContext value: " ++ ppJSON j)
-
-instance FromJSON CompletionItemLabelDetails where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDetail <- lookupMaybeFromJSON "detail" vs
-           parsedDescription <- lookupMaybeFromJSON "description" vs
-           return
-            CompletionItemLabelDetails { completionItemLabelDetailsDetail = parsedDetail
-                                       , completionItemLabelDetailsDescription = parsedDescription }
-      _ ->
-        Left ("Unrecognized CompletionItemLabelDetails value: " ++ ppJSON j)
-
-instance FromJSON InsertReplaceEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNewText <- lookupFromJSON "newText" vs
-           parsedInsert <- lookupFromJSON "insert" vs
-           parsedReplace <- lookupFromJSON "replace" vs
-           return
-            InsertReplaceEdit { insertReplaceEditNewText = parsedNewText
-                              , insertReplaceEditInsert = parsedInsert
-                              , insertReplaceEditReplace = parsedReplace }
-      _ -> Left ("Unrecognized InsertReplaceEdit value: " ++ ppJSON j)
-
-instance FromJSON CompletionItemDefaults where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCommitCharacters <- lookupMaybeFromJSON "commitCharacters" vs
-           parsedEditRange <- lookupMaybeFromJSON "editRange" vs
-           parsedInsertTextFormat <- lookupMaybeFromJSON "insertTextFormat" vs
-           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           return
-            CompletionItemDefaults { completionItemDefaultsCommitCharacters = parsedCommitCharacters
-                                   , completionItemDefaultsEditRange = parsedEditRange
-                                   , completionItemDefaultsInsertTextFormat = parsedInsertTextFormat
-                                   , completionItemDefaultsInsertTextMode = parsedInsertTextMode
-                                   , completionItemDefaultsData = parsedData }
-      _ -> Left ("Unrecognized CompletionItemDefaults value: " ++ ppJSON j)
-
-instance FromJSON CompletionOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
-                                       vs
-           parsedAllCommitCharacters <- lookupMaybeFromJSON
-                                         "allCommitCharacters"
-                                         vs
-           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
-           return
-            CompletionOptions { completionOptionsTriggerCharacters = parsedTriggerCharacters
-                              , completionOptionsAllCommitCharacters = parsedAllCommitCharacters
-                              , completionOptionsResolveProvider = parsedResolveProvider
-                              , completionOptionsCompletionItem = parsedCompletionItem }
-      _ -> Left ("Unrecognized CompletionOptions value: " ++ ppJSON j)
-
-instance FromJSON HoverOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return HoverOptions {  }
-      _ -> Left ("Unrecognized HoverOptions value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
-           parsedTriggerCharacter <- lookupMaybeFromJSON "triggerCharacter" vs
-           parsedIsRetrigger <- lookupFromJSON "isRetrigger" vs
-           parsedActiveSignatureHelp <- lookupMaybeFromJSON
-                                         "activeSignatureHelp"
-                                         vs
-           return
-            SignatureHelpContext { signatureHelpContextTriggerKind = parsedTriggerKind
-                                 , signatureHelpContextTriggerCharacter = parsedTriggerCharacter
-                                 , signatureHelpContextIsRetrigger = parsedIsRetrigger
-                                 , signatureHelpContextActiveSignatureHelp = parsedActiveSignatureHelp }
-      _ -> Left ("Unrecognized SignatureHelpContext value: " ++ ppJSON j)
-
-instance FromJSON SignatureInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupFromJSON "label" vs
-           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
-           parsedParameters <- lookupMaybeFromJSON "parameters" vs
-           parsedActiveParameter <- lookupMaybeFromJSON "activeParameter" vs
-           return
-            SignatureInformation { signatureInformationLabel = parsedLabel
-                                 , signatureInformationDocumentation = parsedDocumentation
-                                 , signatureInformationParameters = parsedParameters
-                                 , signatureInformationActiveParameter = parsedActiveParameter }
-      _ -> Left ("Unrecognized SignatureInformation value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
-                                       vs
-           parsedRetriggerCharacters <- lookupMaybeFromJSON
-                                         "retriggerCharacters"
-                                         vs
-           return
-            SignatureHelpOptions { signatureHelpOptionsTriggerCharacters = parsedTriggerCharacters
-                                 , signatureHelpOptionsRetriggerCharacters = parsedRetriggerCharacters }
-      _ -> Left ("Unrecognized SignatureHelpOptions value: " ++ ppJSON j)
-
-instance FromJSON DefinitionOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DefinitionOptions {  }
-      _ -> Left ("Unrecognized DefinitionOptions value: " ++ ppJSON j)
-
-instance FromJSON ReferenceContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIncludeDeclaration <- lookupFromJSON "includeDeclaration" vs
-           return
-            ReferenceContext { referenceContextIncludeDeclaration = parsedIncludeDeclaration }
-      _ -> Left ("Unrecognized ReferenceContext value: " ++ ppJSON j)
-
-instance FromJSON ReferenceOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return ReferenceOptions {  }
-      _ -> Left ("Unrecognized ReferenceOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlightOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentHighlightOptions {  }
-      _ -> Left ("Unrecognized DocumentHighlightOptions value: " ++ ppJSON j)
-
-instance FromJSON BaseSymbolInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedKind <- lookupFromJSON "kind" vs
-           parsedTags <- lookupMaybeFromJSON "tags" vs
-           parsedContainerName <- lookupMaybeFromJSON "containerName" vs
-           return
-            BaseSymbolInformation { baseSymbolInformationName = parsedName
-                                  , baseSymbolInformationKind = parsedKind
-                                  , baseSymbolInformationTags = parsedTags
-                                  , baseSymbolInformationContainerName = parsedContainerName }
-      _ -> Left ("Unrecognized BaseSymbolInformation value: " ++ ppJSON j)
-
-instance FromJSON DocumentSymbolOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupMaybeFromJSON "label" vs
-           return
-            DocumentSymbolOptions { documentSymbolOptionsLabel = parsedLabel }
-      _ -> Left ("Unrecognized DocumentSymbolOptions value: " ++ ppJSON j)
-
-instance FromJSON CodeActionContext where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDiagnostics <- lookupFromJSON "diagnostics" vs
-           parsedOnly <- lookupMaybeFromJSON "only" vs
-           parsedTriggerKind <- lookupMaybeFromJSON "triggerKind" vs
-           return
-            CodeActionContext { codeActionContextDiagnostics = parsedDiagnostics
-                              , codeActionContextOnly = parsedOnly
-                              , codeActionContextTriggerKind = parsedTriggerKind }
-      _ -> Left ("Unrecognized CodeActionContext value: " ++ ppJSON j)
-
-instance FromJSON CodeActionDisabled where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedReason <- lookupFromJSON "reason" vs
-           return
-            CodeActionDisabled { codeActionDisabledReason = parsedReason }
-      _ -> Left ("Unrecognized CodeActionDisabled value: " ++ ppJSON j)
-
-instance FromJSON CodeActionOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCodeActionKinds <- lookupMaybeFromJSON "codeActionKinds" vs
-           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
-           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           return
-            CodeActionOptions { codeActionOptionsCodeActionKinds = parsedCodeActionKinds
-                              , codeActionOptionsDocumentation = parsedDocumentation
-                              , codeActionOptionsResolveProvider = parsedResolveProvider }
-      _ -> Left ("Unrecognized CodeActionOptions value: " ++ ppJSON j)
-
-instance FromJSON LocationUriOnly where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           return LocationUriOnly { locationUriOnlyUri = parsedUri }
-      _ -> Left ("Unrecognized LocationUriOnly value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceSymbolOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           return
-            WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider = parsedResolveProvider }
-      _ -> Left ("Unrecognized WorkspaceSymbolOptions value: " ++ ppJSON j)
-
-instance FromJSON CodeLensOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           return
-            CodeLensOptions { codeLensOptionsResolveProvider = parsedResolveProvider }
-      _ -> Left ("Unrecognized CodeLensOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentLinkOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
-           return
-            DocumentLinkOptions { documentLinkOptionsResolveProvider = parsedResolveProvider }
-      _ -> Left ("Unrecognized DocumentLinkOptions value: " ++ ppJSON j)
-
-instance FromJSON FormattingOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTabSize <- lookupFromJSON "tabSize" vs
-           parsedInsertSpaces <- lookupFromJSON "insertSpaces" vs
-           parsedTrimTrailingWhitespace <- lookupMaybeFromJSON
-                                            "trimTrailingWhitespace"
-                                            vs
-           parsedInsertFinalNewline <- lookupMaybeFromJSON
-                                        "insertFinalNewline"
-                                        vs
-           parsedTrimFinalNewlines <- lookupMaybeFromJSON "trimFinalNewlines"
-                                       vs
-           return
-            FormattingOptions { formattingOptionsTabSize = parsedTabSize
-                              , formattingOptionsInsertSpaces = parsedInsertSpaces
-                              , formattingOptionsTrimTrailingWhitespace = parsedTrimTrailingWhitespace
-                              , formattingOptionsInsertFinalNewline = parsedInsertFinalNewline
-                              , formattingOptionsTrimFinalNewlines = parsedTrimFinalNewlines }
-      _ -> Left ("Unrecognized FormattingOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentFormattingOptions where
-  fromJSON j =
-    case j of
-      JObject vs -> do return DocumentFormattingOptions {  }
-      _ -> Left ("Unrecognized DocumentFormattingOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentRangeFormattingOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
-           return
-            DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport = parsedRangesSupport }
-      _ ->
-        Left
-         ("Unrecognized DocumentRangeFormattingOptions value: " ++ ppJSON j)
-
-instance FromJSON DocumentOnTypeFormattingOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedFirstTriggerCharacter <- lookupFromJSON
-                                           "firstTriggerCharacter"
-                                           vs
-           parsedMoreTriggerCharacter <- lookupMaybeFromJSON
-                                          "moreTriggerCharacter"
-                                          vs
-           return
-            DocumentOnTypeFormattingOptions { documentOnTypeFormattingOptionsFirstTriggerCharacter = parsedFirstTriggerCharacter
-                                            , documentOnTypeFormattingOptionsMoreTriggerCharacter = parsedMoreTriggerCharacter }
-      _ ->
-        Left
-         ("Unrecognized DocumentOnTypeFormattingOptions value: " ++ ppJSON j)
-
-instance FromJSON RenameOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedPrepareProvider <- lookupMaybeFromJSON "prepareProvider" vs
-           return
-            RenameOptions { renameOptionsPrepareProvider = parsedPrepareProvider }
-      _ -> Left ("Unrecognized RenameOptions value: " ++ ppJSON j)
-
-instance FromJSON PrepareRenamePlaceholder where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedPlaceholder <- lookupFromJSON "placeholder" vs
-           return
-            PrepareRenamePlaceholder { prepareRenamePlaceholderRange = parsedRange
-                                     , prepareRenamePlaceholderPlaceholder = parsedPlaceholder }
-      _ -> Left ("Unrecognized PrepareRenamePlaceholder value: " ++ ppJSON j)
-
-instance FromJSON PrepareRenameDefaultBehavior where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDefaultBehavior <- lookupFromJSON "defaultBehavior" vs
-           return
-            PrepareRenameDefaultBehavior { prepareRenameDefaultBehaviorDefaultBehavior = parsedDefaultBehavior }
-      _ ->
-        Left ("Unrecognized PrepareRenameDefaultBehavior value: " ++ ppJSON j)
-
-instance FromJSON ExecuteCommandOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCommands <- lookupFromJSON "commands" vs
-           return
-            ExecuteCommandOptions { executeCommandOptionsCommands = parsedCommands }
-      _ -> Left ("Unrecognized ExecuteCommandOptions value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceEditMetadata where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIsRefactoring <- lookupMaybeFromJSON "isRefactoring" vs
-           return
-            WorkspaceEditMetadata { workspaceEditMetadataIsRefactoring = parsedIsRefactoring }
-      _ -> Left ("Unrecognized WorkspaceEditMetadata value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensLegend where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedTokenTypes <- lookupFromJSON "tokenTypes" vs
-           parsedTokenModifiers <- lookupFromJSON "tokenModifiers" vs
-           return
-            SemanticTokensLegend { semanticTokensLegendTokenTypes = parsedTokenTypes
-                                 , semanticTokensLegendTokenModifiers = parsedTokenModifiers }
-      _ -> Left ("Unrecognized SemanticTokensLegend value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensFullDelta where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDelta <- lookupMaybeFromJSON "delta" vs
-           return
-            SemanticTokensFullDelta { semanticTokensFullDeltaDelta = parsedDelta }
-      _ -> Left ("Unrecognized SemanticTokensFullDelta value: " ++ ppJSON j)
-
-instance FromJSON OptionalVersionedTextDocumentIdentifier where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedVersion <- lookupFromJSON "version" vs
-           return
-            OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion = parsedVersion }
-      _ ->
-        Left
-         ("Unrecognized OptionalVersionedTextDocumentIdentifier value: "
-           ++ ppJSON j)
-
-instance FromJSON AnnotatedTextEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedAnnotationId <- lookupFromJSON "annotationId" vs
-           return
-            AnnotatedTextEdit { annotatedTextEditAnnotationId = parsedAnnotationId }
-      _ -> Left ("Unrecognized AnnotatedTextEdit value: " ++ ppJSON j)
-
-instance FromJSON SnippetTextEdit where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedSnippet <- lookupFromJSON "snippet" vs
-           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
-           return
-            SnippetTextEdit { snippetTextEditRange = parsedRange
-                            , snippetTextEditSnippet = parsedSnippet
-                            , snippetTextEditAnnotationId = parsedAnnotationId }
-      _ -> Left ("Unrecognized SnippetTextEdit value: " ++ ppJSON j)
-
-instance FromJSON ResourceOperation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
-           return
-            ResourceOperation { resourceOperationKind = parsedKind
-                              , resourceOperationAnnotationId = parsedAnnotationId }
-      _ -> Left ("Unrecognized ResourceOperation value: " ++ ppJSON j)
-
-instance FromJSON CreateFileOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedOverwrite <- lookupMaybeFromJSON "overwrite" vs
-           parsedIgnoreIfExists <- lookupMaybeFromJSON "ignoreIfExists" vs
-           return
-            CreateFileOptions { createFileOptionsOverwrite = parsedOverwrite
-                              , createFileOptionsIgnoreIfExists = parsedIgnoreIfExists }
-      _ -> Left ("Unrecognized CreateFileOptions value: " ++ ppJSON j)
-
-instance FromJSON RenameFileOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedOverwrite <- lookupMaybeFromJSON "overwrite" vs
-           parsedIgnoreIfExists <- lookupMaybeFromJSON "ignoreIfExists" vs
-           return
-            RenameFileOptions { renameFileOptionsOverwrite = parsedOverwrite
-                              , renameFileOptionsIgnoreIfExists = parsedIgnoreIfExists }
-      _ -> Left ("Unrecognized RenameFileOptions value: " ++ ppJSON j)
-
-instance FromJSON DeleteFileOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRecursive <- lookupMaybeFromJSON "recursive" vs
-           parsedIgnoreIfNotExists <- lookupMaybeFromJSON "ignoreIfNotExists"
-                                       vs
-           return
-            DeleteFileOptions { deleteFileOptionsRecursive = parsedRecursive
-                              , deleteFileOptionsIgnoreIfNotExists = parsedIgnoreIfNotExists }
-      _ -> Left ("Unrecognized DeleteFileOptions value: " ++ ppJSON j)
-
-instance FromJSON FileOperationPattern where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedGlob <- lookupFromJSON "glob" vs
-           parsedMatches <- lookupMaybeFromJSON "matches" vs
-           parsedOptions <- lookupMaybeFromJSON "options" vs
-           return
-            FileOperationPattern { fileOperationPatternGlob = parsedGlob
-                                 , fileOperationPatternMatches = parsedMatches
-                                 , fileOperationPatternOptions = parsedOptions }
-      _ -> Left ("Unrecognized FileOperationPattern value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceFullDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedVersion <- lookupFromJSON "version" vs
-           return
-            WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri = parsedUri
-                                                  , workspaceFullDocumentDiagnosticReportVersion = parsedVersion }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceFullDocumentDiagnosticReport value: "
-           ++ ppJSON j)
-
-instance FromJSON WorkspaceUnchangedDocumentDiagnosticReport where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
-           parsedVersion <- lookupFromJSON "version" vs
-           return
-            WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri = parsedUri
-                                                       , workspaceUnchangedDocumentDiagnosticReportVersion = parsedVersion }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceUnchangedDocumentDiagnosticReport value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookCell where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedDocument <- lookupFromJSON "document" vs
-           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
-           parsedExecutionSummary <- lookupMaybeFromJSON "executionSummary" vs
-           return
-            NotebookCell { notebookCellKind = parsedKind
-                         , notebookCellDocument = parsedDocument
-                         , notebookCellMetadata = parsedMetadata
-                         , notebookCellExecutionSummary = parsedExecutionSummary }
-      _ -> Left ("Unrecognized NotebookCell value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentFilterWithNotebook where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebook <- lookupFromJSON "notebook" vs
-           parsedCells <- lookupMaybeFromJSON "cells" vs
-           return
-            NotebookDocumentFilterWithNotebook { notebookDocumentFilterWithNotebookNotebook = parsedNotebook
-                                               , notebookDocumentFilterWithNotebookCells = parsedCells }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentFilterWithNotebook value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookDocumentFilterWithCells where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebook <- lookupMaybeFromJSON "notebook" vs
-           parsedCells <- lookupFromJSON "cells" vs
-           return
-            NotebookDocumentFilterWithCells { notebookDocumentFilterWithCellsNotebook = parsedNotebook
-                                            , notebookDocumentFilterWithCellsCells = parsedCells }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentFilterWithCells value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentCellChanges where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStructure <- lookupMaybeFromJSON "structure" vs
-           parsedData <- lookupMaybeFromJSON "data" vs
-           parsedTextContent <- lookupMaybeFromJSON "textContent" vs
-           return
-            NotebookDocumentCellChanges { notebookDocumentCellChangesStructure = parsedStructure
-                                        , notebookDocumentCellChangesData = parsedData
-                                        , notebookDocumentCellChangesTextContent = parsedTextContent }
-      _ ->
-        Left ("Unrecognized NotebookDocumentCellChanges value: " ++ ppJSON j)
-
-instance FromJSON SelectedCompletionInfo where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedText <- lookupFromJSON "text" vs
-           return
-            SelectedCompletionInfo { selectedCompletionInfoRange = parsedRange
-                                   , selectedCompletionInfoText = parsedText }
-      _ -> Left ("Unrecognized SelectedCompletionInfo value: " ++ ppJSON j)
-
-instance FromJSON ClientInfo where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedName <- lookupFromJSON "name" vs
-           parsedVersion <- lookupMaybeFromJSON "version" vs
-           return
-            ClientInfo { clientInfoName = parsedName
-                       , clientInfoVersion = parsedVersion }
-      _ -> Left ("Unrecognized ClientInfo value: " ++ ppJSON j)
-
-instance FromJSON ClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkspace <- lookupMaybeFromJSON "workspace" vs
-           parsedTextDocument <- lookupMaybeFromJSON "textDocument" vs
-           parsedNotebookDocument <- lookupMaybeFromJSON "notebookDocument" vs
-           parsedWindow <- lookupMaybeFromJSON "window" vs
-           parsedGeneral <- lookupMaybeFromJSON "general" vs
-           parsedExperimental <- lookupMaybeFromJSON "experimental" vs
-           return
-            ClientCapabilities { clientCapabilitiesWorkspace = parsedWorkspace
-                               , clientCapabilitiesTextDocument = parsedTextDocument
-                               , clientCapabilitiesNotebookDocument = parsedNotebookDocument
-                               , clientCapabilitiesWindow = parsedWindow
-                               , clientCapabilitiesGeneral = parsedGeneral
-                               , clientCapabilitiesExperimental = parsedExperimental }
-      _ -> Left ("Unrecognized ClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentSyncOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedOpenClose <- lookupMaybeFromJSON "openClose" vs
-           parsedChange <- lookupMaybeFromJSON "change" vs
-           parsedWillSave <- lookupMaybeFromJSON "willSave" vs
-           parsedWillSaveWaitUntil <- lookupMaybeFromJSON "willSaveWaitUntil"
-                                       vs
-           parsedSave <- lookupMaybeFromJSON "save" vs
-           return
-            TextDocumentSyncOptions { textDocumentSyncOptionsOpenClose = parsedOpenClose
-                                    , textDocumentSyncOptionsChange = parsedChange
-                                    , textDocumentSyncOptionsWillSave = parsedWillSave
-                                    , textDocumentSyncOptionsWillSaveWaitUntil = parsedWillSaveWaitUntil
-                                    , textDocumentSyncOptionsSave = parsedSave }
-      _ -> Left ("Unrecognized TextDocumentSyncOptions value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
-           parsedFileOperations <- lookupMaybeFromJSON "fileOperations" vs
-           return
-            WorkspaceOptions { workspaceOptionsWorkspaceFolders = parsedWorkspaceFolders
-                             , workspaceOptionsFileOperations = parsedFileOperations }
-      _ -> Left ("Unrecognized WorkspaceOptions value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentContentChangePartial where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupFromJSON "range" vs
-           parsedRangeLength <- lookupMaybeFromJSON "rangeLength" vs
-           parsedText <- lookupFromJSON "text" vs
-           return
-            TextDocumentContentChangePartial { textDocumentContentChangePartialRange = parsedRange
-                                             , textDocumentContentChangePartialRangeLength = parsedRangeLength
-                                             , textDocumentContentChangePartialText = parsedText }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentContentChangePartial value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentContentChangeWholeDocument where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedText <- lookupFromJSON "text" vs
-           return
-            TextDocumentContentChangeWholeDocument { textDocumentContentChangeWholeDocumentText = parsedText }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentContentChangeWholeDocument value: "
-           ++ ppJSON j)
-
-instance FromJSON CodeDescription where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedHref <- lookupFromJSON "href" vs
-           return CodeDescription { codeDescriptionHref = parsedHref }
-      _ -> Left ("Unrecognized CodeDescription value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticRelatedInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLocation <- lookupFromJSON "location" vs
-           parsedMessage <- lookupFromJSON "message" vs
-           return
-            DiagnosticRelatedInformation { diagnosticRelatedInformationLocation = parsedLocation
-                                         , diagnosticRelatedInformationMessage = parsedMessage }
-      _ ->
-        Left ("Unrecognized DiagnosticRelatedInformation value: " ++ ppJSON j)
-
-instance FromJSON EditRangeWithInsertReplace where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedInsert <- lookupFromJSON "insert" vs
-           parsedReplace <- lookupFromJSON "replace" vs
-           return
-            EditRangeWithInsertReplace { editRangeWithInsertReplaceInsert = parsedInsert
-                                       , editRangeWithInsertReplaceReplace = parsedReplace }
-      _ ->
-        Left ("Unrecognized EditRangeWithInsertReplace value: " ++ ppJSON j)
-
-instance FromJSON ServerCompletionItemOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabelDetailsSupport <- lookupMaybeFromJSON
-                                         "labelDetailsSupport"
-                                         vs
-           return
-            ServerCompletionItemOptions { serverCompletionItemOptionsLabelDetailsSupport = parsedLabelDetailsSupport }
-      _ ->
-        Left ("Unrecognized ServerCompletionItemOptions value: " ++ ppJSON j)
-
-instance FromJSON MarkedStringWithLanguage where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLanguage <- lookupFromJSON "language" vs
-           parsedValue <- lookupFromJSON "value" vs
-           return
-            MarkedStringWithLanguage { markedStringWithLanguageLanguage = parsedLanguage
-                                     , markedStringWithLanguageValue = parsedValue }
-      _ -> Left ("Unrecognized MarkedStringWithLanguage value: " ++ ppJSON j)
-
-instance FromJSON ParameterInformation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabel <- lookupFromJSON "label" vs
-           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
-           return
-            ParameterInformation { parameterInformationLabel = parsedLabel
-                                 , parameterInformationDocumentation = parsedDocumentation }
-      _ -> Left ("Unrecognized ParameterInformation value: " ++ ppJSON j)
-
-instance FromJSON CodeActionKindDocumentation where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedKind <- lookupFromJSON "kind" vs
-           parsedCommand <- lookupFromJSON "command" vs
-           return
-            CodeActionKindDocumentation { codeActionKindDocumentationKind = parsedKind
-                                        , codeActionKindDocumentationCommand = parsedCommand }
-      _ ->
-        Left ("Unrecognized CodeActionKindDocumentation value: " ++ ppJSON j)
-
-instance FromJSON NotebookCellTextDocumentFilter where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebook <- lookupFromJSON "notebook" vs
-           parsedLanguage <- lookupMaybeFromJSON "language" vs
-           return
-            NotebookCellTextDocumentFilter { notebookCellTextDocumentFilterNotebook = parsedNotebook
-                                           , notebookCellTextDocumentFilterLanguage = parsedLanguage }
-      _ ->
-        Left
-         ("Unrecognized NotebookCellTextDocumentFilter value: " ++ ppJSON j)
-
-instance FromJSON FileOperationPatternOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedIgnoreCase <- lookupMaybeFromJSON "ignoreCase" vs
-           return
-            FileOperationPatternOptions { fileOperationPatternOptionsIgnoreCase = parsedIgnoreCase }
-      _ ->
-        Left ("Unrecognized FileOperationPatternOptions value: " ++ ppJSON j)
-
-instance FromJSON ExecutionSummary where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedExecutionOrder <- lookupFromJSON "executionOrder" vs
-           parsedSuccess <- lookupMaybeFromJSON "success" vs
-           return
-            ExecutionSummary { executionSummaryExecutionOrder = parsedExecutionOrder
-                             , executionSummarySuccess = parsedSuccess }
-      _ -> Left ("Unrecognized ExecutionSummary value: " ++ ppJSON j)
-
-instance FromJSON NotebookCellLanguage where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLanguage <- lookupFromJSON "language" vs
-           return
-            NotebookCellLanguage { notebookCellLanguageLanguage = parsedLanguage }
-      _ -> Left ("Unrecognized NotebookCellLanguage value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentCellChangeStructure where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedArray <- lookupFromJSON "array" vs
-           parsedDidOpen <- lookupMaybeFromJSON "didOpen" vs
-           parsedDidClose <- lookupMaybeFromJSON "didClose" vs
-           return
-            NotebookDocumentCellChangeStructure { notebookDocumentCellChangeStructureArray = parsedArray
-                                                , notebookDocumentCellChangeStructureDidOpen = parsedDidOpen
-                                                , notebookDocumentCellChangeStructureDidClose = parsedDidClose }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentCellChangeStructure value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookDocumentCellContentChanges where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDocument <- lookupFromJSON "document" vs
-           parsedChanges <- lookupFromJSON "changes" vs
-           return
-            NotebookDocumentCellContentChanges { notebookDocumentCellContentChangesDocument = parsedDocument
-                                               , notebookDocumentCellContentChangesChanges = parsedChanges }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentCellContentChanges value: "
-           ++ ppJSON j)
-
-instance FromJSON WorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedApplyEdit <- lookupMaybeFromJSON "applyEdit" vs
-           parsedWorkspaceEdit <- lookupMaybeFromJSON "workspaceEdit" vs
-           parsedDidChangeConfiguration <- lookupMaybeFromJSON
-                                            "didChangeConfiguration"
-                                            vs
-           parsedDidChangeWatchedFiles <- lookupMaybeFromJSON
-                                           "didChangeWatchedFiles"
-                                           vs
-           parsedSymbol <- lookupMaybeFromJSON "symbol" vs
-           parsedExecuteCommand <- lookupMaybeFromJSON "executeCommand" vs
-           parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
-           parsedConfiguration <- lookupMaybeFromJSON "configuration" vs
-           parsedSemanticTokens <- lookupMaybeFromJSON "semanticTokens" vs
-           parsedCodeLens <- lookupMaybeFromJSON "codeLens" vs
-           parsedFileOperations <- lookupMaybeFromJSON "fileOperations" vs
-           parsedInlineValue <- lookupMaybeFromJSON "inlineValue" vs
-           parsedInlayHint <- lookupMaybeFromJSON "inlayHint" vs
-           parsedDiagnostics <- lookupMaybeFromJSON "diagnostics" vs
-           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
-           return
-            WorkspaceClientCapabilities { workspaceClientCapabilitiesApplyEdit = parsedApplyEdit
-                                        , workspaceClientCapabilitiesWorkspaceEdit = parsedWorkspaceEdit
-                                        , workspaceClientCapabilitiesDidChangeConfiguration = parsedDidChangeConfiguration
-                                        , workspaceClientCapabilitiesDidChangeWatchedFiles = parsedDidChangeWatchedFiles
-                                        , workspaceClientCapabilitiesSymbol = parsedSymbol
-                                        , workspaceClientCapabilitiesExecuteCommand = parsedExecuteCommand
-                                        , workspaceClientCapabilitiesWorkspaceFolders = parsedWorkspaceFolders
-                                        , workspaceClientCapabilitiesConfiguration = parsedConfiguration
-                                        , workspaceClientCapabilitiesSemanticTokens = parsedSemanticTokens
-                                        , workspaceClientCapabilitiesCodeLens = parsedCodeLens
-                                        , workspaceClientCapabilitiesFileOperations = parsedFileOperations
-                                        , workspaceClientCapabilitiesInlineValue = parsedInlineValue
-                                        , workspaceClientCapabilitiesInlayHint = parsedInlayHint
-                                        , workspaceClientCapabilitiesDiagnostics = parsedDiagnostics
-                                        , workspaceClientCapabilitiesFoldingRange = parsedFoldingRange }
-      _ ->
-        Left ("Unrecognized WorkspaceClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSynchronization <- lookupMaybeFromJSON "synchronization" vs
-           parsedCompletion <- lookupMaybeFromJSON "completion" vs
-           parsedHover <- lookupMaybeFromJSON "hover" vs
-           parsedSignatureHelp <- lookupMaybeFromJSON "signatureHelp" vs
-           parsedDeclaration <- lookupMaybeFromJSON "declaration" vs
-           parsedDefinition <- lookupMaybeFromJSON "definition" vs
-           parsedTypeDefinition <- lookupMaybeFromJSON "typeDefinition" vs
-           parsedImplementation <- lookupMaybeFromJSON "implementation" vs
-           parsedReferences <- lookupMaybeFromJSON "references" vs
-           parsedDocumentHighlight <- lookupMaybeFromJSON "documentHighlight"
-                                       vs
-           parsedDocumentSymbol <- lookupMaybeFromJSON "documentSymbol" vs
-           parsedCodeAction <- lookupMaybeFromJSON "codeAction" vs
-           parsedCodeLens <- lookupMaybeFromJSON "codeLens" vs
-           parsedDocumentLink <- lookupMaybeFromJSON "documentLink" vs
-           parsedColorProvider <- lookupMaybeFromJSON "colorProvider" vs
-           parsedFormatting <- lookupMaybeFromJSON "formatting" vs
-           parsedRangeFormatting <- lookupMaybeFromJSON "rangeFormatting" vs
-           parsedOnTypeFormatting <- lookupMaybeFromJSON "onTypeFormatting" vs
-           parsedRename <- lookupMaybeFromJSON "rename" vs
-           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
-           parsedSelectionRange <- lookupMaybeFromJSON "selectionRange" vs
-           parsedPublishDiagnostics <- lookupMaybeFromJSON
-                                        "publishDiagnostics"
-                                        vs
-           parsedCallHierarchy <- lookupMaybeFromJSON "callHierarchy" vs
-           parsedSemanticTokens <- lookupMaybeFromJSON "semanticTokens" vs
-           parsedLinkedEditingRange <- lookupMaybeFromJSON
-                                        "linkedEditingRange"
-                                        vs
-           parsedMoniker <- lookupMaybeFromJSON "moniker" vs
-           parsedTypeHierarchy <- lookupMaybeFromJSON "typeHierarchy" vs
-           parsedInlineValue <- lookupMaybeFromJSON "inlineValue" vs
-           parsedInlayHint <- lookupMaybeFromJSON "inlayHint" vs
-           parsedDiagnostic <- lookupMaybeFromJSON "diagnostic" vs
-           parsedInlineCompletion <- lookupMaybeFromJSON "inlineCompletion" vs
-           return
-            TextDocumentClientCapabilities { textDocumentClientCapabilitiesSynchronization = parsedSynchronization
-                                           , textDocumentClientCapabilitiesCompletion = parsedCompletion
-                                           , textDocumentClientCapabilitiesHover = parsedHover
-                                           , textDocumentClientCapabilitiesSignatureHelp = parsedSignatureHelp
-                                           , textDocumentClientCapabilitiesDeclaration = parsedDeclaration
-                                           , textDocumentClientCapabilitiesDefinition = parsedDefinition
-                                           , textDocumentClientCapabilitiesTypeDefinition = parsedTypeDefinition
-                                           , textDocumentClientCapabilitiesImplementation = parsedImplementation
-                                           , textDocumentClientCapabilitiesReferences = parsedReferences
-                                           , textDocumentClientCapabilitiesDocumentHighlight = parsedDocumentHighlight
-                                           , textDocumentClientCapabilitiesDocumentSymbol = parsedDocumentSymbol
-                                           , textDocumentClientCapabilitiesCodeAction = parsedCodeAction
-                                           , textDocumentClientCapabilitiesCodeLens = parsedCodeLens
-                                           , textDocumentClientCapabilitiesDocumentLink = parsedDocumentLink
-                                           , textDocumentClientCapabilitiesColorProvider = parsedColorProvider
-                                           , textDocumentClientCapabilitiesFormatting = parsedFormatting
-                                           , textDocumentClientCapabilitiesRangeFormatting = parsedRangeFormatting
-                                           , textDocumentClientCapabilitiesOnTypeFormatting = parsedOnTypeFormatting
-                                           , textDocumentClientCapabilitiesRename = parsedRename
-                                           , textDocumentClientCapabilitiesFoldingRange = parsedFoldingRange
-                                           , textDocumentClientCapabilitiesSelectionRange = parsedSelectionRange
-                                           , textDocumentClientCapabilitiesPublishDiagnostics = parsedPublishDiagnostics
-                                           , textDocumentClientCapabilitiesCallHierarchy = parsedCallHierarchy
-                                           , textDocumentClientCapabilitiesSemanticTokens = parsedSemanticTokens
-                                           , textDocumentClientCapabilitiesLinkedEditingRange = parsedLinkedEditingRange
-                                           , textDocumentClientCapabilitiesMoniker = parsedMoniker
-                                           , textDocumentClientCapabilitiesTypeHierarchy = parsedTypeHierarchy
-                                           , textDocumentClientCapabilitiesInlineValue = parsedInlineValue
-                                           , textDocumentClientCapabilitiesInlayHint = parsedInlayHint
-                                           , textDocumentClientCapabilitiesDiagnostic = parsedDiagnostic
-                                           , textDocumentClientCapabilitiesInlineCompletion = parsedInlineCompletion }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSynchronization <- lookupFromJSON "synchronization" vs
-           return
-            NotebookDocumentClientCapabilities { notebookDocumentClientCapabilitiesSynchronization = parsedSynchronization }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON WindowClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
-           parsedShowMessage <- lookupMaybeFromJSON "showMessage" vs
-           parsedShowDocument <- lookupMaybeFromJSON "showDocument" vs
-           return
-            WindowClientCapabilities { windowClientCapabilitiesWorkDoneProgress = parsedWorkDoneProgress
-                                     , windowClientCapabilitiesShowMessage = parsedShowMessage
-                                     , windowClientCapabilitiesShowDocument = parsedShowDocument }
-      _ -> Left ("Unrecognized WindowClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON GeneralClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStaleRequestSupport <- lookupMaybeFromJSON
-                                         "staleRequestSupport"
-                                         vs
-           parsedRegularExpressions <- lookupMaybeFromJSON
-                                        "regularExpressions"
-                                        vs
-           parsedMarkdown <- lookupMaybeFromJSON "markdown" vs
-           parsedPositionEncodings <- lookupMaybeFromJSON "positionEncodings"
-                                       vs
-           return
-            GeneralClientCapabilities { generalClientCapabilitiesStaleRequestSupport = parsedStaleRequestSupport
-                                      , generalClientCapabilitiesRegularExpressions = parsedRegularExpressions
-                                      , generalClientCapabilitiesMarkdown = parsedMarkdown
-                                      , generalClientCapabilitiesPositionEncodings = parsedPositionEncodings }
-      _ -> Left ("Unrecognized GeneralClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceFoldersServerCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSupported <- lookupMaybeFromJSON "supported" vs
-           parsedChangeNotifications <- lookupMaybeFromJSON
-                                         "changeNotifications"
-                                         vs
-           return
-            WorkspaceFoldersServerCapabilities { workspaceFoldersServerCapabilitiesSupported = parsedSupported
-                                               , workspaceFoldersServerCapabilitiesChangeNotifications = parsedChangeNotifications }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceFoldersServerCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON FileOperationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDidCreate <- lookupMaybeFromJSON "didCreate" vs
-           parsedWillCreate <- lookupMaybeFromJSON "willCreate" vs
-           parsedDidRename <- lookupMaybeFromJSON "didRename" vs
-           parsedWillRename <- lookupMaybeFromJSON "willRename" vs
-           parsedDidDelete <- lookupMaybeFromJSON "didDelete" vs
-           parsedWillDelete <- lookupMaybeFromJSON "willDelete" vs
-           return
-            FileOperationOptions { fileOperationOptionsDidCreate = parsedDidCreate
-                                 , fileOperationOptionsWillCreate = parsedWillCreate
-                                 , fileOperationOptionsDidRename = parsedDidRename
-                                 , fileOperationOptionsWillRename = parsedWillRename
-                                 , fileOperationOptionsDidDelete = parsedDidDelete
-                                 , fileOperationOptionsWillDelete = parsedWillDelete }
-      _ -> Left ("Unrecognized FileOperationOptions value: " ++ ppJSON j)
-
-instance FromJSON RelativePattern where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedBaseUri <- lookupFromJSON "baseUri" vs
-           parsedPattern <- lookupFromJSON "pattern" vs
-           return
-            RelativePattern { relativePatternBaseUri = parsedBaseUri
-                            , relativePatternPattern = parsedPattern }
-      _ -> Left ("Unrecognized RelativePattern value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentFilterLanguage where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLanguage <- lookupFromJSON "language" vs
-           parsedScheme <- lookupMaybeFromJSON "scheme" vs
-           parsedPattern <- lookupMaybeFromJSON "pattern" vs
-           return
-            TextDocumentFilterLanguage { textDocumentFilterLanguageLanguage = parsedLanguage
-                                       , textDocumentFilterLanguageScheme = parsedScheme
-                                       , textDocumentFilterLanguagePattern = parsedPattern }
-      _ ->
-        Left ("Unrecognized TextDocumentFilterLanguage value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentFilterScheme where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLanguage <- lookupMaybeFromJSON "language" vs
-           parsedScheme <- lookupFromJSON "scheme" vs
-           parsedPattern <- lookupMaybeFromJSON "pattern" vs
-           return
-            TextDocumentFilterScheme { textDocumentFilterSchemeLanguage = parsedLanguage
-                                     , textDocumentFilterSchemeScheme = parsedScheme
-                                     , textDocumentFilterSchemePattern = parsedPattern }
-      _ -> Left ("Unrecognized TextDocumentFilterScheme value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentFilterPattern where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLanguage <- lookupMaybeFromJSON "language" vs
-           parsedScheme <- lookupMaybeFromJSON "scheme" vs
-           parsedPattern <- lookupFromJSON "pattern" vs
-           return
-            TextDocumentFilterPattern { textDocumentFilterPatternLanguage = parsedLanguage
-                                      , textDocumentFilterPatternScheme = parsedScheme
-                                      , textDocumentFilterPatternPattern = parsedPattern }
-      _ -> Left ("Unrecognized TextDocumentFilterPattern value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentFilterNotebookType where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookType <- lookupFromJSON "notebookType" vs
-           parsedScheme <- lookupMaybeFromJSON "scheme" vs
-           parsedPattern <- lookupMaybeFromJSON "pattern" vs
-           return
-            NotebookDocumentFilterNotebookType { notebookDocumentFilterNotebookTypeNotebookType = parsedNotebookType
-                                               , notebookDocumentFilterNotebookTypeScheme = parsedScheme
-                                               , notebookDocumentFilterNotebookTypePattern = parsedPattern }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentFilterNotebookType value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookDocumentFilterScheme where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookType <- lookupMaybeFromJSON "notebookType" vs
-           parsedScheme <- lookupFromJSON "scheme" vs
-           parsedPattern <- lookupMaybeFromJSON "pattern" vs
-           return
-            NotebookDocumentFilterScheme { notebookDocumentFilterSchemeNotebookType = parsedNotebookType
-                                         , notebookDocumentFilterSchemeScheme = parsedScheme
-                                         , notebookDocumentFilterSchemePattern = parsedPattern }
-      _ ->
-        Left ("Unrecognized NotebookDocumentFilterScheme value: " ++ ppJSON j)
-
-instance FromJSON NotebookDocumentFilterPattern where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedNotebookType <- lookupMaybeFromJSON "notebookType" vs
-           parsedScheme <- lookupMaybeFromJSON "scheme" vs
-           parsedPattern <- lookupFromJSON "pattern" vs
-           return
-            NotebookDocumentFilterPattern { notebookDocumentFilterPatternNotebookType = parsedNotebookType
-                                          , notebookDocumentFilterPatternScheme = parsedScheme
-                                          , notebookDocumentFilterPatternPattern = parsedPattern }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentFilterPattern value: " ++ ppJSON j)
-
-instance FromJSON NotebookCellArrayChange where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedStart <- lookupFromJSON "start" vs
-           parsedDeleteCount <- lookupFromJSON "deleteCount" vs
-           parsedCells <- lookupMaybeFromJSON "cells" vs
-           return
-            NotebookCellArrayChange { notebookCellArrayChangeStart = parsedStart
-                                    , notebookCellArrayChangeDeleteCount = parsedDeleteCount
-                                    , notebookCellArrayChangeCells = parsedCells }
-      _ -> Left ("Unrecognized NotebookCellArrayChange value: " ++ ppJSON j)
-
-instance FromJSON WorkspaceEditClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDocumentChanges <- lookupMaybeFromJSON "documentChanges" vs
-           parsedResourceOperations <- lookupMaybeFromJSON
-                                        "resourceOperations"
-                                        vs
-           parsedFailureHandling <- lookupMaybeFromJSON "failureHandling" vs
-           parsedNormalizesLineEndings <- lookupMaybeFromJSON
-                                           "normalizesLineEndings"
-                                           vs
-           parsedChangeAnnotationSupport <- lookupMaybeFromJSON
-                                             "changeAnnotationSupport"
-                                             vs
-           parsedMetadataSupport <- lookupMaybeFromJSON "metadataSupport" vs
-           parsedSnippetEditSupport <- lookupMaybeFromJSON
-                                        "snippetEditSupport"
-                                        vs
-           return
-            WorkspaceEditClientCapabilities { workspaceEditClientCapabilitiesDocumentChanges = parsedDocumentChanges
-                                            , workspaceEditClientCapabilitiesResourceOperations = parsedResourceOperations
-                                            , workspaceEditClientCapabilitiesFailureHandling = parsedFailureHandling
-                                            , workspaceEditClientCapabilitiesNormalizesLineEndings = parsedNormalizesLineEndings
-                                            , workspaceEditClientCapabilitiesChangeAnnotationSupport = parsedChangeAnnotationSupport
-                                            , workspaceEditClientCapabilitiesMetadataSupport = parsedMetadataSupport
-                                            , workspaceEditClientCapabilitiesSnippetEditSupport = parsedSnippetEditSupport }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceEditClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DidChangeConfigurationClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            DidChangeConfigurationClientCapabilities { didChangeConfigurationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized DidChangeConfigurationClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON DidChangeWatchedFilesClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedRelativePatternSupport <- lookupMaybeFromJSON
-                                            "relativePatternSupport"
-                                            vs
-           return
-            DidChangeWatchedFilesClientCapabilities { didChangeWatchedFilesClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                                    , didChangeWatchedFilesClientCapabilitiesRelativePatternSupport = parsedRelativePatternSupport }
-      _ ->
-        Left
-         ("Unrecognized DidChangeWatchedFilesClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON WorkspaceSymbolClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedSymbolKind <- lookupMaybeFromJSON "symbolKind" vs
-           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
-           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
-           return
-            WorkspaceSymbolClientCapabilities { workspaceSymbolClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                              , workspaceSymbolClientCapabilitiesSymbolKind = parsedSymbolKind
-                                              , workspaceSymbolClientCapabilitiesTagSupport = parsedTagSupport
-                                              , workspaceSymbolClientCapabilitiesResolveSupport = parsedResolveSupport }
-      _ ->
-        Left
-         ("Unrecognized WorkspaceSymbolClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON ExecuteCommandClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            ExecuteCommandClientCapabilities { executeCommandClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized ExecuteCommandClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            SemanticTokensWorkspaceClientCapabilities { semanticTokensWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized SemanticTokensWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON CodeLensWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            CodeLensWorkspaceClientCapabilities { codeLensWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized CodeLensWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON FileOperationClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedDidCreate <- lookupMaybeFromJSON "didCreate" vs
-           parsedWillCreate <- lookupMaybeFromJSON "willCreate" vs
-           parsedDidRename <- lookupMaybeFromJSON "didRename" vs
-           parsedWillRename <- lookupMaybeFromJSON "willRename" vs
-           parsedDidDelete <- lookupMaybeFromJSON "didDelete" vs
-           parsedWillDelete <- lookupMaybeFromJSON "willDelete" vs
-           return
-            FileOperationClientCapabilities { fileOperationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                            , fileOperationClientCapabilitiesDidCreate = parsedDidCreate
-                                            , fileOperationClientCapabilitiesWillCreate = parsedWillCreate
-                                            , fileOperationClientCapabilitiesDidRename = parsedDidRename
-                                            , fileOperationClientCapabilitiesWillRename = parsedWillRename
-                                            , fileOperationClientCapabilitiesDidDelete = parsedDidDelete
-                                            , fileOperationClientCapabilitiesWillDelete = parsedWillDelete }
-      _ ->
-        Left
-         ("Unrecognized FileOperationClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON InlineValueWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            InlineValueWorkspaceClientCapabilities { inlineValueWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized InlineValueWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON InlayHintWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            InlayHintWorkspaceClientCapabilities { inlayHintWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized InlayHintWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON DiagnosticWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            DiagnosticWorkspaceClientCapabilities { diagnosticWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized DiagnosticWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON FoldingRangeWorkspaceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
-           return
-            FoldingRangeWorkspaceClientCapabilities { foldingRangeWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
-      _ ->
-        Left
-         ("Unrecognized FoldingRangeWorkspaceClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON TextDocumentSyncClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedWillSave <- lookupMaybeFromJSON "willSave" vs
-           parsedWillSaveWaitUntil <- lookupMaybeFromJSON "willSaveWaitUntil"
-                                       vs
-           parsedDidSave <- lookupMaybeFromJSON "didSave" vs
-           return
-            TextDocumentSyncClientCapabilities { textDocumentSyncClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                               , textDocumentSyncClientCapabilitiesWillSave = parsedWillSave
-                                               , textDocumentSyncClientCapabilitiesWillSaveWaitUntil = parsedWillSaveWaitUntil
-                                               , textDocumentSyncClientCapabilitiesDidSave = parsedDidSave }
-      _ ->
-        Left
-         ("Unrecognized TextDocumentSyncClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON CompletionClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
-           parsedCompletionItemKind <- lookupMaybeFromJSON
-                                        "completionItemKind"
-                                        vs
-           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
-           parsedContextSupport <- lookupMaybeFromJSON "contextSupport" vs
-           parsedCompletionList <- lookupMaybeFromJSON "completionList" vs
-           return
-            CompletionClientCapabilities { completionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                         , completionClientCapabilitiesCompletionItem = parsedCompletionItem
-                                         , completionClientCapabilitiesCompletionItemKind = parsedCompletionItemKind
-                                         , completionClientCapabilitiesInsertTextMode = parsedInsertTextMode
-                                         , completionClientCapabilitiesContextSupport = parsedContextSupport
-                                         , completionClientCapabilitiesCompletionList = parsedCompletionList }
-      _ ->
-        Left ("Unrecognized CompletionClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON HoverClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedContentFormat <- lookupMaybeFromJSON "contentFormat" vs
-           return
-            HoverClientCapabilities { hoverClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                    , hoverClientCapabilitiesContentFormat = parsedContentFormat }
-      _ -> Left ("Unrecognized HoverClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedSignatureInformation <- lookupMaybeFromJSON
-                                          "signatureInformation"
-                                          vs
-           parsedContextSupport <- lookupMaybeFromJSON "contextSupport" vs
-           return
-            SignatureHelpClientCapabilities { signatureHelpClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                            , signatureHelpClientCapabilitiesSignatureInformation = parsedSignatureInformation
-                                            , signatureHelpClientCapabilitiesContextSupport = parsedContextSupport }
-      _ ->
-        Left
-         ("Unrecognized SignatureHelpClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DeclarationClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
-           return
-            DeclarationClientCapabilities { declarationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                          , declarationClientCapabilitiesLinkSupport = parsedLinkSupport }
-      _ ->
-        Left
-         ("Unrecognized DeclarationClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DefinitionClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
-           return
-            DefinitionClientCapabilities { definitionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                         , definitionClientCapabilitiesLinkSupport = parsedLinkSupport }
-      _ ->
-        Left ("Unrecognized DefinitionClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON TypeDefinitionClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
-           return
-            TypeDefinitionClientCapabilities { typeDefinitionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                             , typeDefinitionClientCapabilitiesLinkSupport = parsedLinkSupport }
-      _ ->
-        Left
-         ("Unrecognized TypeDefinitionClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ImplementationClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
-           return
-            ImplementationClientCapabilities { implementationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                             , implementationClientCapabilitiesLinkSupport = parsedLinkSupport }
-      _ ->
-        Left
-         ("Unrecognized ImplementationClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ReferenceClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            ReferenceClientCapabilities { referenceClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left ("Unrecognized ReferenceClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlightClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            DocumentHighlightClientCapabilities { documentHighlightClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized DocumentHighlightClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentSymbolClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedSymbolKind <- lookupMaybeFromJSON "symbolKind" vs
-           parsedHierarchicalDocumentSymbolSupport <- lookupMaybeFromJSON
-                                                       "hierarchicalDocumentSymbolSupport"
-                                                       vs
-           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
-           parsedLabelSupport <- lookupMaybeFromJSON "labelSupport" vs
-           return
-            DocumentSymbolClientCapabilities { documentSymbolClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                             , documentSymbolClientCapabilitiesSymbolKind = parsedSymbolKind
-                                             , documentSymbolClientCapabilitiesHierarchicalDocumentSymbolSupport = parsedHierarchicalDocumentSymbolSupport
-                                             , documentSymbolClientCapabilitiesTagSupport = parsedTagSupport
-                                             , documentSymbolClientCapabilitiesLabelSupport = parsedLabelSupport }
-      _ ->
-        Left
-         ("Unrecognized DocumentSymbolClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON CodeActionClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedCodeActionLiteralSupport <- lookupMaybeFromJSON
-                                              "codeActionLiteralSupport"
-                                              vs
-           parsedIsPreferredSupport <- lookupMaybeFromJSON
-                                        "isPreferredSupport"
-                                        vs
-           parsedDisabledSupport <- lookupMaybeFromJSON "disabledSupport" vs
-           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
-           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
-           parsedHonorsChangeAnnotations <- lookupMaybeFromJSON
-                                             "honorsChangeAnnotations"
-                                             vs
-           parsedDocumentationSupport <- lookupMaybeFromJSON
-                                          "documentationSupport"
-                                          vs
-           return
-            CodeActionClientCapabilities { codeActionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                         , codeActionClientCapabilitiesCodeActionLiteralSupport = parsedCodeActionLiteralSupport
-                                         , codeActionClientCapabilitiesIsPreferredSupport = parsedIsPreferredSupport
-                                         , codeActionClientCapabilitiesDisabledSupport = parsedDisabledSupport
-                                         , codeActionClientCapabilitiesDataSupport = parsedDataSupport
-                                         , codeActionClientCapabilitiesResolveSupport = parsedResolveSupport
-                                         , codeActionClientCapabilitiesHonorsChangeAnnotations = parsedHonorsChangeAnnotations
-                                         , codeActionClientCapabilitiesDocumentationSupport = parsedDocumentationSupport }
-      _ ->
-        Left ("Unrecognized CodeActionClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON CodeLensClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
-           return
-            CodeLensClientCapabilities { codeLensClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                       , codeLensClientCapabilitiesResolveSupport = parsedResolveSupport }
-      _ ->
-        Left ("Unrecognized CodeLensClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DocumentLinkClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedTooltipSupport <- lookupMaybeFromJSON "tooltipSupport" vs
-           return
-            DocumentLinkClientCapabilities { documentLinkClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                           , documentLinkClientCapabilitiesTooltipSupport = parsedTooltipSupport }
-      _ ->
-        Left
-         ("Unrecognized DocumentLinkClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DocumentColorClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            DocumentColorClientCapabilities { documentColorClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized DocumentColorClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DocumentFormattingClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            DocumentFormattingClientCapabilities { documentFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized DocumentFormattingClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentRangeFormattingClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
-           return
-            DocumentRangeFormattingClientCapabilities { documentRangeFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                                      , documentRangeFormattingClientCapabilitiesRangesSupport = parsedRangesSupport }
-      _ ->
-        Left
-         ("Unrecognized DocumentRangeFormattingClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON DocumentOnTypeFormattingClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            DocumentOnTypeFormattingClientCapabilities { documentOnTypeFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized DocumentOnTypeFormattingClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON RenameClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedPrepareSupport <- lookupMaybeFromJSON "prepareSupport" vs
-           parsedPrepareSupportDefaultBehavior <- lookupMaybeFromJSON
-                                                   "prepareSupportDefaultBehavior"
-                                                   vs
-           parsedHonorsChangeAnnotations <- lookupMaybeFromJSON
-                                             "honorsChangeAnnotations"
-                                             vs
-           return
-            RenameClientCapabilities { renameClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                     , renameClientCapabilitiesPrepareSupport = parsedPrepareSupport
-                                     , renameClientCapabilitiesPrepareSupportDefaultBehavior = parsedPrepareSupportDefaultBehavior
-                                     , renameClientCapabilitiesHonorsChangeAnnotations = parsedHonorsChangeAnnotations }
-      _ -> Left ("Unrecognized RenameClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON FoldingRangeClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedRangeLimit <- lookupMaybeFromJSON "rangeLimit" vs
-           parsedLineFoldingOnly <- lookupMaybeFromJSON "lineFoldingOnly" vs
-           parsedFoldingRangeKind <- lookupMaybeFromJSON "foldingRangeKind" vs
-           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
-           return
-            FoldingRangeClientCapabilities { foldingRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                           , foldingRangeClientCapabilitiesRangeLimit = parsedRangeLimit
-                                           , foldingRangeClientCapabilitiesLineFoldingOnly = parsedLineFoldingOnly
-                                           , foldingRangeClientCapabilitiesFoldingRangeKind = parsedFoldingRangeKind
-                                           , foldingRangeClientCapabilitiesFoldingRange = parsedFoldingRange }
-      _ ->
-        Left
-         ("Unrecognized FoldingRangeClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON SelectionRangeClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            SelectionRangeClientCapabilities { selectionRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized SelectionRangeClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON PublishDiagnosticsClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedVersionSupport <- lookupMaybeFromJSON "versionSupport" vs
-           return
-            PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport = parsedVersionSupport }
-      _ ->
-        Left
-         ("Unrecognized PublishDiagnosticsClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON CallHierarchyClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            CallHierarchyClientCapabilities { callHierarchyClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized CallHierarchyClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokensClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedRequests <- lookupFromJSON "requests" vs
-           parsedTokenTypes <- lookupFromJSON "tokenTypes" vs
-           parsedTokenModifiers <- lookupFromJSON "tokenModifiers" vs
-           parsedFormats <- lookupFromJSON "formats" vs
-           parsedOverlappingTokenSupport <- lookupMaybeFromJSON
-                                             "overlappingTokenSupport"
-                                             vs
-           parsedMultilineTokenSupport <- lookupMaybeFromJSON
-                                           "multilineTokenSupport"
-                                           vs
-           parsedServerCancelSupport <- lookupMaybeFromJSON
-                                         "serverCancelSupport"
-                                         vs
-           parsedAugmentsSyntaxTokens <- lookupMaybeFromJSON
-                                          "augmentsSyntaxTokens"
-                                          vs
-           return
-            SemanticTokensClientCapabilities { semanticTokensClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                             , semanticTokensClientCapabilitiesRequests = parsedRequests
-                                             , semanticTokensClientCapabilitiesTokenTypes = parsedTokenTypes
-                                             , semanticTokensClientCapabilitiesTokenModifiers = parsedTokenModifiers
-                                             , semanticTokensClientCapabilitiesFormats = parsedFormats
-                                             , semanticTokensClientCapabilitiesOverlappingTokenSupport = parsedOverlappingTokenSupport
-                                             , semanticTokensClientCapabilitiesMultilineTokenSupport = parsedMultilineTokenSupport
-                                             , semanticTokensClientCapabilitiesServerCancelSupport = parsedServerCancelSupport
-                                             , semanticTokensClientCapabilitiesAugmentsSyntaxTokens = parsedAugmentsSyntaxTokens }
-      _ ->
-        Left
-         ("Unrecognized SemanticTokensClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON LinkedEditingRangeClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            LinkedEditingRangeClientCapabilities { linkedEditingRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized LinkedEditingRangeClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON MonikerClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            MonikerClientCapabilities { monikerClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ -> Left ("Unrecognized MonikerClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON TypeHierarchyClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            TypeHierarchyClientCapabilities { typeHierarchyClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized TypeHierarchyClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON InlineValueClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            InlineValueClientCapabilities { inlineValueClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized InlineValueClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON InlayHintClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
-           return
-            InlayHintClientCapabilities { inlayHintClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                        , inlayHintClientCapabilitiesResolveSupport = parsedResolveSupport }
-      _ ->
-        Left ("Unrecognized InlayHintClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedRelatedDocumentSupport <- lookupMaybeFromJSON
-                                            "relatedDocumentSupport"
-                                            vs
-           return
-            DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                         , diagnosticClientCapabilitiesRelatedDocumentSupport = parsedRelatedDocumentSupport }
-      _ ->
-        Left ("Unrecognized DiagnosticClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           return
-            InlineCompletionClientCapabilities { inlineCompletionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
-      _ ->
-        Left
-         ("Unrecognized InlineCompletionClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON NotebookDocumentSyncClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
-                                         "dynamicRegistration"
-                                         vs
-           parsedExecutionSummarySupport <- lookupMaybeFromJSON
-                                             "executionSummarySupport"
-                                             vs
-           return
-            NotebookDocumentSyncClientCapabilities { notebookDocumentSyncClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
-                                                   , notebookDocumentSyncClientCapabilitiesExecutionSummarySupport = parsedExecutionSummarySupport }
-      _ ->
-        Left
-         ("Unrecognized NotebookDocumentSyncClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON ShowMessageRequestClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedMessageActionItem <- lookupMaybeFromJSON "messageActionItem"
-                                       vs
-           return
-            ShowMessageRequestClientCapabilities { showMessageRequestClientCapabilitiesMessageActionItem = parsedMessageActionItem }
-      _ ->
-        Left
-         ("Unrecognized ShowMessageRequestClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON ShowDocumentClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSupport <- lookupFromJSON "support" vs
-           return
-            ShowDocumentClientCapabilities { showDocumentClientCapabilitiesSupport = parsedSupport }
-      _ ->
-        Left
-         ("Unrecognized ShowDocumentClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON StaleRequestSupportOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCancel <- lookupFromJSON "cancel" vs
-           parsedRetryOnContentModified <- lookupFromJSON
-                                            "retryOnContentModified"
-                                            vs
-           return
-            StaleRequestSupportOptions { staleRequestSupportOptionsCancel = parsedCancel
-                                       , staleRequestSupportOptionsRetryOnContentModified = parsedRetryOnContentModified }
-      _ ->
-        Left ("Unrecognized StaleRequestSupportOptions value: " ++ ppJSON j)
-
-instance FromJSON RegularExpressionsClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedEngine <- lookupFromJSON "engine" vs
-           parsedVersion <- lookupMaybeFromJSON "version" vs
-           return
-            RegularExpressionsClientCapabilities { regularExpressionsClientCapabilitiesEngine = parsedEngine
-                                                 , regularExpressionsClientCapabilitiesVersion = parsedVersion }
-      _ ->
-        Left
-         ("Unrecognized RegularExpressionsClientCapabilities value: "
-           ++ ppJSON j)
-
-instance FromJSON MarkdownClientCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedParser <- lookupFromJSON "parser" vs
-           parsedVersion <- lookupMaybeFromJSON "version" vs
-           parsedAllowedTags <- lookupMaybeFromJSON "allowedTags" vs
-           return
-            MarkdownClientCapabilities { markdownClientCapabilitiesParser = parsedParser
-                                       , markdownClientCapabilitiesVersion = parsedVersion
-                                       , markdownClientCapabilitiesAllowedTags = parsedAllowedTags }
-      _ ->
-        Left ("Unrecognized MarkdownClientCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ChangeAnnotationsSupportOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedGroupsOnLabel <- lookupMaybeFromJSON "groupsOnLabel" vs
-           return
-            ChangeAnnotationsSupportOptions { changeAnnotationsSupportOptionsGroupsOnLabel = parsedGroupsOnLabel }
-      _ ->
-        Left
-         ("Unrecognized ChangeAnnotationsSupportOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientSymbolKindOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
-           return
-            ClientSymbolKindOptions { clientSymbolKindOptionsValueSet = parsedValueSet }
-      _ -> Left ("Unrecognized ClientSymbolKindOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientSymbolTagOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupFromJSON "valueSet" vs
-           return
-            ClientSymbolTagOptions { clientSymbolTagOptionsValueSet = parsedValueSet }
-      _ -> Left ("Unrecognized ClientSymbolTagOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientSymbolResolveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProperties <- lookupFromJSON "properties" vs
-           return
-            ClientSymbolResolveOptions { clientSymbolResolveOptionsProperties = parsedProperties }
-      _ ->
-        Left ("Unrecognized ClientSymbolResolveOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientCompletionItemOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedSnippetSupport <- lookupMaybeFromJSON "snippetSupport" vs
-           parsedCommitCharactersSupport <- lookupMaybeFromJSON
-                                             "commitCharactersSupport"
-                                             vs
-           parsedDocumentationFormat <- lookupMaybeFromJSON
-                                         "documentationFormat"
-                                         vs
-           parsedDeprecatedSupport <- lookupMaybeFromJSON "deprecatedSupport"
-                                       vs
-           parsedPreselectSupport <- lookupMaybeFromJSON "preselectSupport" vs
-           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
-           parsedInsertReplaceSupport <- lookupMaybeFromJSON
-                                          "insertReplaceSupport"
-                                          vs
-           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
-           parsedInsertTextModeSupport <- lookupMaybeFromJSON
-                                           "insertTextModeSupport"
-                                           vs
-           parsedLabelDetailsSupport <- lookupMaybeFromJSON
-                                         "labelDetailsSupport"
-                                         vs
-           return
-            ClientCompletionItemOptions { clientCompletionItemOptionsSnippetSupport = parsedSnippetSupport
-                                        , clientCompletionItemOptionsCommitCharactersSupport = parsedCommitCharactersSupport
-                                        , clientCompletionItemOptionsDocumentationFormat = parsedDocumentationFormat
-                                        , clientCompletionItemOptionsDeprecatedSupport = parsedDeprecatedSupport
-                                        , clientCompletionItemOptionsPreselectSupport = parsedPreselectSupport
-                                        , clientCompletionItemOptionsTagSupport = parsedTagSupport
-                                        , clientCompletionItemOptionsInsertReplaceSupport = parsedInsertReplaceSupport
-                                        , clientCompletionItemOptionsResolveSupport = parsedResolveSupport
-                                        , clientCompletionItemOptionsInsertTextModeSupport = parsedInsertTextModeSupport
-                                        , clientCompletionItemOptionsLabelDetailsSupport = parsedLabelDetailsSupport }
-      _ ->
-        Left ("Unrecognized ClientCompletionItemOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientCompletionItemOptionsKind where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
-           return
-            ClientCompletionItemOptionsKind { clientCompletionItemOptionsKindValueSet = parsedValueSet }
-      _ ->
-        Left
-         ("Unrecognized ClientCompletionItemOptionsKind value: " ++ ppJSON j)
-
-instance FromJSON CompletionListCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedItemDefaults <- lookupMaybeFromJSON "itemDefaults" vs
-           return
-            CompletionListCapabilities { completionListCapabilitiesItemDefaults = parsedItemDefaults }
-      _ ->
-        Left ("Unrecognized CompletionListCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ClientSignatureInformationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDocumentationFormat <- lookupMaybeFromJSON
-                                         "documentationFormat"
-                                         vs
-           parsedParameterInformation <- lookupMaybeFromJSON
-                                          "parameterInformation"
-                                          vs
-           parsedActiveParameterSupport <- lookupMaybeFromJSON
-                                            "activeParameterSupport"
-                                            vs
-           parsedNoActiveParameterSupport <- lookupMaybeFromJSON
-                                              "noActiveParameterSupport"
-                                              vs
-           return
-            ClientSignatureInformationOptions { clientSignatureInformationOptionsDocumentationFormat = parsedDocumentationFormat
-                                              , clientSignatureInformationOptionsParameterInformation = parsedParameterInformation
-                                              , clientSignatureInformationOptionsActiveParameterSupport = parsedActiveParameterSupport
-                                              , clientSignatureInformationOptionsNoActiveParameterSupport = parsedNoActiveParameterSupport }
-      _ ->
-        Left
-         ("Unrecognized ClientSignatureInformationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ClientCodeActionLiteralOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCodeActionKind <- lookupFromJSON "codeActionKind" vs
-           return
-            ClientCodeActionLiteralOptions { clientCodeActionLiteralOptionsCodeActionKind = parsedCodeActionKind }
-      _ ->
-        Left
-         ("Unrecognized ClientCodeActionLiteralOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientCodeActionResolveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProperties <- lookupFromJSON "properties" vs
-           return
-            ClientCodeActionResolveOptions { clientCodeActionResolveOptionsProperties = parsedProperties }
-      _ ->
-        Left
-         ("Unrecognized ClientCodeActionResolveOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientCodeLensResolveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProperties <- lookupFromJSON "properties" vs
-           return
-            ClientCodeLensResolveOptions { clientCodeLensResolveOptionsProperties = parsedProperties }
-      _ ->
-        Left ("Unrecognized ClientCodeLensResolveOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientFoldingRangeKindOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
-           return
-            ClientFoldingRangeKindOptions { clientFoldingRangeKindOptionsValueSet = parsedValueSet }
-      _ ->
-        Left
-         ("Unrecognized ClientFoldingRangeKindOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientFoldingRangeOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedCollapsedText <- lookupMaybeFromJSON "collapsedText" vs
-           return
-            ClientFoldingRangeOptions { clientFoldingRangeOptionsCollapsedText = parsedCollapsedText }
-      _ -> Left ("Unrecognized ClientFoldingRangeOptions value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticsCapabilities where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRelatedInformation <- lookupMaybeFromJSON
-                                        "relatedInformation"
-                                        vs
-           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
-           parsedCodeDescriptionSupport <- lookupMaybeFromJSON
-                                            "codeDescriptionSupport"
-                                            vs
-           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
-           return
-            DiagnosticsCapabilities { diagnosticsCapabilitiesRelatedInformation = parsedRelatedInformation
-                                    , diagnosticsCapabilitiesTagSupport = parsedTagSupport
-                                    , diagnosticsCapabilitiesCodeDescriptionSupport = parsedCodeDescriptionSupport
-                                    , diagnosticsCapabilitiesDataSupport = parsedDataSupport }
-      _ -> Left ("Unrecognized DiagnosticsCapabilities value: " ++ ppJSON j)
-
-instance FromJSON ClientSemanticTokensRequestOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedRange <- lookupMaybeFromJSON "range" vs
-           parsedFull <- lookupMaybeFromJSON "full" vs
-           return
-            ClientSemanticTokensRequestOptions { clientSemanticTokensRequestOptionsRange = parsedRange
-                                               , clientSemanticTokensRequestOptionsFull = parsedFull }
-      _ ->
-        Left
-         ("Unrecognized ClientSemanticTokensRequestOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ClientInlayHintResolveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProperties <- lookupFromJSON "properties" vs
-           return
-            ClientInlayHintResolveOptions { clientInlayHintResolveOptionsProperties = parsedProperties }
-      _ ->
-        Left
-         ("Unrecognized ClientInlayHintResolveOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientShowMessageActionItemOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedAdditionalPropertiesSupport <- lookupMaybeFromJSON
-                                                 "additionalPropertiesSupport"
-                                                 vs
-           return
-            ClientShowMessageActionItemOptions { clientShowMessageActionItemOptionsAdditionalPropertiesSupport = parsedAdditionalPropertiesSupport }
-      _ ->
-        Left
-         ("Unrecognized ClientShowMessageActionItemOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON CompletionItemTagOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupFromJSON "valueSet" vs
-           return
-            CompletionItemTagOptions { completionItemTagOptionsValueSet = parsedValueSet }
-      _ -> Left ("Unrecognized CompletionItemTagOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientCompletionItemResolveOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedProperties <- lookupFromJSON "properties" vs
-           return
-            ClientCompletionItemResolveOptions { clientCompletionItemResolveOptionsProperties = parsedProperties }
-      _ ->
-        Left
-         ("Unrecognized ClientCompletionItemResolveOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ClientCompletionItemInsertTextModeOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupFromJSON "valueSet" vs
-           return
-            ClientCompletionItemInsertTextModeOptions { clientCompletionItemInsertTextModeOptionsValueSet = parsedValueSet }
-      _ ->
-        Left
-         ("Unrecognized ClientCompletionItemInsertTextModeOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ClientSignatureParameterInformationOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedLabelOffsetSupport <- lookupMaybeFromJSON
-                                        "labelOffsetSupport"
-                                        vs
-           return
-            ClientSignatureParameterInformationOptions { clientSignatureParameterInformationOptionsLabelOffsetSupport = parsedLabelOffsetSupport }
-      _ ->
-        Left
-         ("Unrecognized ClientSignatureParameterInformationOptions value: "
-           ++ ppJSON j)
-
-instance FromJSON ClientCodeActionKindOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupFromJSON "valueSet" vs
-           return
-            ClientCodeActionKindOptions { clientCodeActionKindOptionsValueSet = parsedValueSet }
-      _ ->
-        Left ("Unrecognized ClientCodeActionKindOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientDiagnosticsTagOptions where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedValueSet <- lookupFromJSON "valueSet" vs
-           return
-            ClientDiagnosticsTagOptions { clientDiagnosticsTagOptionsValueSet = parsedValueSet }
-      _ ->
-        Left ("Unrecognized ClientDiagnosticsTagOptions value: " ++ ppJSON j)
-
-instance FromJSON ClientSemanticTokensRequestFullDelta where
-  fromJSON j =
-    case j of
-      JObject vs ->
-        do parsedDelta <- lookupMaybeFromJSON "delta" vs
-           return
-            ClientSemanticTokensRequestFullDelta { clientSemanticTokensRequestFullDeltaDelta = parsedDelta }
-      _ ->
-        Left
-         ("Unrecognized ClientSemanticTokensRequestFullDelta value: "
-           ++ ppJSON j)
-
-instance FromJSON SemanticTokenTypes where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "namespace" -> Right SemanticTokenTypesNamespace
-         "type" -> Right SemanticTokenTypesType
-         "class" -> Right SemanticTokenTypesClass
-         "enum" -> Right SemanticTokenTypesEnum
-         "interface" -> Right SemanticTokenTypesInterface
-         "struct" -> Right SemanticTokenTypesStruct
-         "typeParameter" -> Right SemanticTokenTypesTypeParameter
-         "parameter" -> Right SemanticTokenTypesParameter
-         "variable" -> Right SemanticTokenTypesVariable
-         "property" -> Right SemanticTokenTypesProperty
-         "enumMember" -> Right SemanticTokenTypesEnumMember
-         "event" -> Right SemanticTokenTypesEvent
-         "function" -> Right SemanticTokenTypesFunction
-         "method" -> Right SemanticTokenTypesMethod
-         "macro" -> Right SemanticTokenTypesMacro
-         "keyword" -> Right SemanticTokenTypesKeyword
-         "modifier" -> Right SemanticTokenTypesModifier
-         "comment" -> Right SemanticTokenTypesComment
-         "string" -> Right SemanticTokenTypesString
-         "number" -> Right SemanticTokenTypesNumber
-         "regexp" -> Right SemanticTokenTypesRegexp
-         "operator" -> Right SemanticTokenTypesOperator
-         "decorator" -> Right SemanticTokenTypesDecorator
-         "label" -> Right SemanticTokenTypesLabel
-         _ -> Left ("Unrecognized SemanticTokenTypes value: " ++ ppJSON j)
-
-instance FromJSON SemanticTokenModifiers where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "declaration" -> Right SemanticTokenModifiersDeclaration
-         "definition" -> Right SemanticTokenModifiersDefinition
-         "readonly" -> Right SemanticTokenModifiersReadonly
-         "static" -> Right SemanticTokenModifiersStatic
-         "deprecated" -> Right SemanticTokenModifiersDeprecated
-         "abstract" -> Right SemanticTokenModifiersAbstract
-         "async" -> Right SemanticTokenModifiersAsync
-         "modification" -> Right SemanticTokenModifiersModification
-         "documentation" -> Right SemanticTokenModifiersDocumentation
-         "defaultLibrary" -> Right SemanticTokenModifiersDefaultLibrary
-         _ -> Left ("Unrecognized SemanticTokenModifiers value: " ++ ppJSON j)
-
-instance FromJSON DocumentDiagnosticReportKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "full" -> Right DocumentDiagnosticReportKindFull
-         "unchanged" -> Right DocumentDiagnosticReportKindUnchanged
-         _ ->
-           Left
-            ("Unrecognized DocumentDiagnosticReportKind value: " ++ ppJSON j)
-
-instance FromJSON ErrorCodes where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         -32700 -> Right ErrorCodesParseError
-         -32600 -> Right ErrorCodesInvalidRequest
-         -32601 -> Right ErrorCodesMethodNotFound
-         -32602 -> Right ErrorCodesInvalidParams
-         -32603 -> Right ErrorCodesInternalError
-         -32002 -> Right ErrorCodesServerNotInitialized
-         -32001 -> Right ErrorCodesUnknownErrorCode
-         _ -> Left ("Unrecognized ErrorCodes value: " ++ ppJSON j)
-
-instance FromJSON LSPErrorCodes where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         -32803 -> Right LSPErrorCodesRequestFailed
-         -32802 -> Right LSPErrorCodesServerCancelled
-         -32801 -> Right LSPErrorCodesContentModified
-         -32800 -> Right LSPErrorCodesRequestCancelled
-         _ -> Left ("Unrecognized LSPErrorCodes value: " ++ ppJSON j)
-
-instance FromJSON FoldingRangeKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "comment" -> Right FoldingRangeKindComment
-         "imports" -> Right FoldingRangeKindImports
-         "region" -> Right FoldingRangeKindRegion
-         _ -> Left ("Unrecognized FoldingRangeKind value: " ++ ppJSON j)
-
-instance FromJSON SymbolKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right SymbolKindFile
-         2 -> Right SymbolKindModule
-         3 -> Right SymbolKindNamespace
-         4 -> Right SymbolKindPackage
-         5 -> Right SymbolKindClass
-         6 -> Right SymbolKindMethod
-         7 -> Right SymbolKindProperty
-         8 -> Right SymbolKindField
-         9 -> Right SymbolKindConstructor
-         10 -> Right SymbolKindEnum
-         11 -> Right SymbolKindInterface
-         12 -> Right SymbolKindFunction
-         13 -> Right SymbolKindVariable
-         14 -> Right SymbolKindConstant
-         15 -> Right SymbolKindString
-         16 -> Right SymbolKindNumber
-         17 -> Right SymbolKindBoolean
-         18 -> Right SymbolKindArray
-         19 -> Right SymbolKindObject
-         20 -> Right SymbolKindKey
-         21 -> Right SymbolKindNull
-         22 -> Right SymbolKindEnumMember
-         23 -> Right SymbolKindStruct
-         24 -> Right SymbolKindEvent
-         25 -> Right SymbolKindOperator
-         26 -> Right SymbolKindTypeParameter
-         _ -> Left ("Unrecognized SymbolKind value: " ++ ppJSON j)
-
-instance FromJSON SymbolTag where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right SymbolTagDeprecated
-         _ -> Left ("Unrecognized SymbolTag value: " ++ ppJSON j)
-
-instance FromJSON UniquenessLevel where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "document" -> Right UniquenessLevelDocument
-         "project" -> Right UniquenessLevelProject
-         "group" -> Right UniquenessLevelGroup
-         "scheme" -> Right UniquenessLevelScheme
-         "global" -> Right UniquenessLevelGlobal
-         _ -> Left ("Unrecognized UniquenessLevel value: " ++ ppJSON j)
-
-instance FromJSON MonikerKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "import" -> Right MonikerKindImport
-         "export" -> Right MonikerKindExport
-         "local" -> Right MonikerKindLocal
-         _ -> Left ("Unrecognized MonikerKind value: " ++ ppJSON j)
-
-instance FromJSON InlayHintKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right InlayHintKindType
-         2 -> Right InlayHintKindParameter
-         _ -> Left ("Unrecognized InlayHintKind value: " ++ ppJSON j)
-
-instance FromJSON MessageType where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right MessageTypeError
-         2 -> Right MessageTypeWarning
-         3 -> Right MessageTypeInfo
-         4 -> Right MessageTypeLog
-         5 -> Right MessageTypeDebug
-         _ -> Left ("Unrecognized MessageType value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentSyncKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         0 -> Right TextDocumentSyncKindNone
-         1 -> Right TextDocumentSyncKindFull
-         2 -> Right TextDocumentSyncKindIncremental
-         _ -> Left ("Unrecognized TextDocumentSyncKind value: " ++ ppJSON j)
-
-instance FromJSON TextDocumentSaveReason where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right TextDocumentSaveReasonManual
-         2 -> Right TextDocumentSaveReasonAfterDelay
-         3 -> Right TextDocumentSaveReasonFocusOut
-         _ -> Left ("Unrecognized TextDocumentSaveReason value: " ++ ppJSON j)
-
-instance FromJSON CompletionItemKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right CompletionItemKindText
-         2 -> Right CompletionItemKindMethod
-         3 -> Right CompletionItemKindFunction
-         4 -> Right CompletionItemKindConstructor
-         5 -> Right CompletionItemKindField
-         6 -> Right CompletionItemKindVariable
-         7 -> Right CompletionItemKindClass
-         8 -> Right CompletionItemKindInterface
-         9 -> Right CompletionItemKindModule
-         10 -> Right CompletionItemKindProperty
-         11 -> Right CompletionItemKindUnit
-         12 -> Right CompletionItemKindValue
-         13 -> Right CompletionItemKindEnum
-         14 -> Right CompletionItemKindKeyword
-         15 -> Right CompletionItemKindSnippet
-         16 -> Right CompletionItemKindColor
-         17 -> Right CompletionItemKindFile
-         18 -> Right CompletionItemKindReference
-         19 -> Right CompletionItemKindFolder
-         20 -> Right CompletionItemKindEnumMember
-         21 -> Right CompletionItemKindConstant
-         22 -> Right CompletionItemKindStruct
-         23 -> Right CompletionItemKindEvent
-         24 -> Right CompletionItemKindOperator
-         25 -> Right CompletionItemKindTypeParameter
-         _ -> Left ("Unrecognized CompletionItemKind value: " ++ ppJSON j)
-
-instance FromJSON CompletionItemTag where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right CompletionItemTagDeprecated
-         _ -> Left ("Unrecognized CompletionItemTag value: " ++ ppJSON j)
-
-instance FromJSON InsertTextFormat where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right InsertTextFormatPlainText
-         2 -> Right InsertTextFormatSnippet
-         _ -> Left ("Unrecognized InsertTextFormat value: " ++ ppJSON j)
-
-instance FromJSON InsertTextMode where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right InsertTextModeAsIs
-         2 -> Right InsertTextModeAdjustIndentation
-         _ -> Left ("Unrecognized InsertTextMode value: " ++ ppJSON j)
-
-instance FromJSON DocumentHighlightKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right DocumentHighlightKindText
-         2 -> Right DocumentHighlightKindRead
-         3 -> Right DocumentHighlightKindWrite
-         _ -> Left ("Unrecognized DocumentHighlightKind value: " ++ ppJSON j)
-
-instance FromJSON CodeActionKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "" -> Right CodeActionKindEmpty
-         "quickfix" -> Right CodeActionKindQuickFix
-         "refactor" -> Right CodeActionKindRefactor
-         "refactor.extract" -> Right CodeActionKindRefactorExtract
-         "refactor.inline" -> Right CodeActionKindRefactorInline
-         "refactor.move" -> Right CodeActionKindRefactorMove
-         "refactor.rewrite" -> Right CodeActionKindRefactorRewrite
-         "source" -> Right CodeActionKindSource
-         "source.organizeImports" -> Right CodeActionKindSourceOrganizeImports
-         "source.fixAll" -> Right CodeActionKindSourceFixAll
-         "notebook" -> Right CodeActionKindNotebook
-         _ -> Left ("Unrecognized CodeActionKind value: " ++ ppJSON j)
-
-instance FromJSON TraceValue where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "off" -> Right TraceValueOff
-         "messages" -> Right TraceValueMessages
-         "verbose" -> Right TraceValueVerbose
-         _ -> Left ("Unrecognized TraceValue value: " ++ ppJSON j)
-
-instance FromJSON MarkupKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "plaintext" -> Right MarkupKindPlainText
-         "markdown" -> Right MarkupKindMarkdown
-         _ -> Left ("Unrecognized MarkupKind value: " ++ ppJSON j)
-
-instance FromJSON LanguageKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "abap" -> Right LanguageKindABAP
-         "bat" -> Right LanguageKindWindowsBat
-         "bibtex" -> Right LanguageKindBibTeX
-         "clojure" -> Right LanguageKindClojure
-         "coffeescript" -> Right LanguageKindCoffeescript
-         "c" -> Right LanguageKindC
-         "cpp" -> Right LanguageKindCPP
-         "csharp" -> Right LanguageKindCSharp
-         "css" -> Right LanguageKindCSS
-         "d" -> Right LanguageKindD
-         "pascal" -> Right LanguageKindDelphi
-         "diff" -> Right LanguageKindDiff
-         "dart" -> Right LanguageKindDart
-         "dockerfile" -> Right LanguageKindDockerfile
-         "elixir" -> Right LanguageKindElixir
-         "erlang" -> Right LanguageKindErlang
-         "fsharp" -> Right LanguageKindFSharp
-         "git-commit" -> Right LanguageKindGitCommit
-         "rebase" -> Right LanguageKindGitRebase
-         "go" -> Right LanguageKindGo
-         "groovy" -> Right LanguageKindGroovy
-         "handlebars" -> Right LanguageKindHandlebars
-         "haskell" -> Right LanguageKindHaskell
-         "html" -> Right LanguageKindHTML
-         "ini" -> Right LanguageKindIni
-         "java" -> Right LanguageKindJava
-         "javascript" -> Right LanguageKindJavaScript
-         "javascriptreact" -> Right LanguageKindJavaScriptReact
-         "json" -> Right LanguageKindJSON
-         "latex" -> Right LanguageKindLaTeX
-         "less" -> Right LanguageKindLess
-         "lua" -> Right LanguageKindLua
-         "makefile" -> Right LanguageKindMakefile
-         "markdown" -> Right LanguageKindMarkdown
-         "objective-c" -> Right LanguageKindObjectiveC
-         "objective-cpp" -> Right LanguageKindObjectiveCPP
-         "pascal" -> Right LanguageKindPascal
-         "perl" -> Right LanguageKindPerl
-         "perl6" -> Right LanguageKindPerl6
-         "php" -> Right LanguageKindPHP
-         "powershell" -> Right LanguageKindPowershell
-         "jade" -> Right LanguageKindPug
-         "python" -> Right LanguageKindPython
-         "r" -> Right LanguageKindR
-         "razor" -> Right LanguageKindRazor
-         "ruby" -> Right LanguageKindRuby
-         "rust" -> Right LanguageKindRust
-         "scss" -> Right LanguageKindSCSS
-         "sass" -> Right LanguageKindSASS
-         "scala" -> Right LanguageKindScala
-         "shaderlab" -> Right LanguageKindShaderLab
-         "shellscript" -> Right LanguageKindShellScript
-         "sql" -> Right LanguageKindSQL
-         "swift" -> Right LanguageKindSwift
-         "typescript" -> Right LanguageKindTypeScript
-         "typescriptreact" -> Right LanguageKindTypeScriptReact
-         "tex" -> Right LanguageKindTeX
-         "vb" -> Right LanguageKindVisualBasic
-         "xml" -> Right LanguageKindXML
-         "xsl" -> Right LanguageKindXSL
-         "yaml" -> Right LanguageKindYAML
-         _ -> Left ("Unrecognized LanguageKind value: " ++ ppJSON j)
-
-instance FromJSON InlineCompletionTriggerKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right InlineCompletionTriggerKindInvoked
-         2 -> Right InlineCompletionTriggerKindAutomatic
-         _ ->
-           Left
-            ("Unrecognized InlineCompletionTriggerKind value: " ++ ppJSON j)
-
-instance FromJSON PositionEncodingKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "utf-8" -> Right PositionEncodingKindUTF8
-         "utf-16" -> Right PositionEncodingKindUTF16
-         "utf-32" -> Right PositionEncodingKindUTF32
-         _ -> Left ("Unrecognized PositionEncodingKind value: " ++ ppJSON j)
-
-instance FromJSON FileChangeType where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right FileChangeTypeCreated
-         2 -> Right FileChangeTypeChanged
-         3 -> Right FileChangeTypeDeleted
-         _ -> Left ("Unrecognized FileChangeType value: " ++ ppJSON j)
-
-instance FromJSON WatchKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right WatchKindCreate
-         2 -> Right WatchKindChange
-         4 -> Right WatchKindDelete
-         _ -> Left ("Unrecognized WatchKind value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticSeverity where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right DiagnosticSeverityError
-         2 -> Right DiagnosticSeverityWarning
-         3 -> Right DiagnosticSeverityInformation
-         4 -> Right DiagnosticSeverityHint
-         _ -> Left ("Unrecognized DiagnosticSeverity value: " ++ ppJSON j)
-
-instance FromJSON DiagnosticTag where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right DiagnosticTagUnnecessary
-         2 -> Right DiagnosticTagDeprecated
-         _ -> Left ("Unrecognized DiagnosticTag value: " ++ ppJSON j)
-
-instance FromJSON CompletionTriggerKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right CompletionTriggerKindInvoked
-         2 -> Right CompletionTriggerKindTriggerCharacter
-         3 -> Right CompletionTriggerKindTriggerForIncompleteCompletions
-         _ -> Left ("Unrecognized CompletionTriggerKind value: " ++ ppJSON j)
-
-instance FromJSON SignatureHelpTriggerKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right SignatureHelpTriggerKindInvoked
-         2 -> Right SignatureHelpTriggerKindTriggerCharacter
-         3 -> Right SignatureHelpTriggerKindContentChange
-         _ ->
-           Left ("Unrecognized SignatureHelpTriggerKind value: " ++ ppJSON j)
-
-instance FromJSON CodeActionTriggerKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right CodeActionTriggerKindInvoked
-         2 -> Right CodeActionTriggerKindAutomatic
-         _ -> Left ("Unrecognized CodeActionTriggerKind value: " ++ ppJSON j)
-
-instance FromJSON FileOperationPatternKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "file" -> Right FileOperationPatternKindFile
-         "folder" -> Right FileOperationPatternKindFolder
-         _ ->
-           Left ("Unrecognized FileOperationPatternKind value: " ++ ppJSON j)
-
-instance FromJSON NotebookCellKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right NotebookCellKindMarkup
-         2 -> Right NotebookCellKindCode
-         _ -> Left ("Unrecognized NotebookCellKind value: " ++ ppJSON j)
-
-instance FromJSON ResourceOperationKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "create" -> Right ResourceOperationKindCreate
-         "rename" -> Right ResourceOperationKindRename
-         "delete" -> Right ResourceOperationKindDelete
-         _ -> Left ("Unrecognized ResourceOperationKind value: " ++ ppJSON j)
-
-instance FromJSON FailureHandlingKind where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "abort" -> Right FailureHandlingKindAbort
-         "transactional" -> Right FailureHandlingKindTransactional
-         "textOnlyTransactional" ->
-           Right FailureHandlingKindTextOnlyTransactional
-         "undo" -> Right FailureHandlingKindUndo
-         _ -> Left ("Unrecognized FailureHandlingKind value: " ++ ppJSON j)
-
-instance FromJSON PrepareSupportDefaultBehavior where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: Int of
-         1 -> Right PrepareSupportDefaultBehaviorIdentifier
-         _ ->
-           Left
-            ("Unrecognized PrepareSupportDefaultBehavior value: " ++ ppJSON j)
-
-instance FromJSON TokenFormat where
-  fromJSON j =
-    do raw <- fromJSON j
-       case raw :: String of
-         "relative" -> Right TokenFormatRelative
-         _ -> Left ("Unrecognized TokenFormat value: " ++ ppJSON j)
-
-data ImplementationParams = ImplementationParams {  }
- deriving (Show,Eq)
-
-data Location = Location { locationUri :: DocumentUri
-                         , locationRange :: Range }
- deriving (Show,Eq)
-
-data ImplementationRegistrationOptions = ImplementationRegistrationOptions {  }
- deriving (Show,Eq)
-
-data TypeDefinitionParams = TypeDefinitionParams {  }
- deriving (Show,Eq)
-
-data TypeDefinitionRegistrationOptions = TypeDefinitionRegistrationOptions {  }
- deriving (Show,Eq)
-
-data WorkspaceFolder = WorkspaceFolder { workspaceFolderUri :: Uri
-                                       , workspaceFolderName :: String }
- deriving (Show,Eq)
-
-data DidChangeWorkspaceFoldersParams = DidChangeWorkspaceFoldersParams { didChangeWorkspaceFoldersParamsEvent :: WorkspaceFoldersChangeEvent }
- deriving (Show,Eq)
-
-data ConfigurationParams = ConfigurationParams { configurationParamsItems :: [ConfigurationItem] }
- deriving (Show,Eq)
-
-data DocumentColorParams = DocumentColorParams { documentColorParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data ColorInformation = ColorInformation { colorInformationRange :: Range
-                                         , colorInformationColor :: Color }
- deriving (Show,Eq)
-
-data DocumentColorRegistrationOptions = DocumentColorRegistrationOptions {  }
- deriving (Show,Eq)
-
-data ColorPresentationParams = ColorPresentationParams { colorPresentationParamsTextDocument :: TextDocumentIdentifier
-                                                       , colorPresentationParamsColor :: Color
-                                                       , colorPresentationParamsRange :: Range }
- deriving (Show,Eq)
-
-data ColorPresentation = ColorPresentation { colorPresentationLabel :: String
-                                           , colorPresentationTextEdit :: Maybe TextEdit
-                                           , colorPresentationAdditionalTextEdits :: Maybe [TextEdit] }
- deriving (Show,Eq)
-
-data WorkDoneProgressOptions = WorkDoneProgressOptions { workDoneProgressOptionsWorkDoneProgress :: Maybe Bool }
- deriving (Show,Eq)
-
-data TextDocumentRegistrationOptions = TextDocumentRegistrationOptions { textDocumentRegistrationOptionsDocumentSelector :: Either DocumentSelector () }
- deriving (Show,Eq)
-
-data FoldingRangeParams = FoldingRangeParams { foldingRangeParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data FoldingRange = FoldingRange { foldingRangeStartLine :: Int
-                                 , foldingRangeStartCharacter :: Maybe Int
-                                 , foldingRangeEndLine :: Int
-                                 , foldingRangeEndCharacter :: Maybe Int
-                                 , foldingRangeKind :: Maybe FoldingRangeKind
-                                 , foldingRangeCollapsedText :: Maybe String }
- deriving (Show,Eq)
-
-data FoldingRangeRegistrationOptions = FoldingRangeRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DeclarationParams = DeclarationParams {  }
- deriving (Show,Eq)
-
-data DeclarationRegistrationOptions = DeclarationRegistrationOptions {  }
- deriving (Show,Eq)
-
-data SelectionRangeParams = SelectionRangeParams { selectionRangeParamsTextDocument :: TextDocumentIdentifier
-                                                 , selectionRangeParamsPositions :: [Position] }
- deriving (Show,Eq)
-
-data SelectionRange = SelectionRange { selectionRangeRange :: Range
-                                     , selectionRangeParent :: Maybe SelectionRange }
- deriving (Show,Eq)
-
-data SelectionRangeRegistrationOptions = SelectionRangeRegistrationOptions {  }
- deriving (Show,Eq)
-
-data WorkDoneProgressCreateParams = WorkDoneProgressCreateParams { workDoneProgressCreateParamsToken :: ProgressToken }
- deriving (Show,Eq)
-
-data WorkDoneProgressCancelParams = WorkDoneProgressCancelParams { workDoneProgressCancelParamsToken :: ProgressToken }
- deriving (Show,Eq)
-
-data CallHierarchyPrepareParams = CallHierarchyPrepareParams {  }
- deriving (Show,Eq)
-
-data CallHierarchyItem = CallHierarchyItem { callHierarchyItemName :: String
-                                           , callHierarchyItemKind :: SymbolKind
-                                           , callHierarchyItemTags :: Maybe [SymbolTag]
-                                           , callHierarchyItemDetail :: Maybe String
-                                           , callHierarchyItemUri :: DocumentUri
-                                           , callHierarchyItemRange :: Range
-                                           , callHierarchyItemSelectionRange :: Range
-                                           , callHierarchyItemData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CallHierarchyRegistrationOptions = CallHierarchyRegistrationOptions {  }
- deriving (Show,Eq)
-
-data CallHierarchyIncomingCallsParams = CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem :: CallHierarchyItem }
- deriving (Show,Eq)
-
-data CallHierarchyIncomingCall = CallHierarchyIncomingCall { callHierarchyIncomingCallFrom :: CallHierarchyItem
-                                                           , callHierarchyIncomingCallFromRanges :: [Range] }
- deriving (Show,Eq)
-
-data CallHierarchyOutgoingCallsParams = CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem :: CallHierarchyItem }
- deriving (Show,Eq)
-
-data CallHierarchyOutgoingCall = CallHierarchyOutgoingCall { callHierarchyOutgoingCallTo :: CallHierarchyItem
-                                                           , callHierarchyOutgoingCallFromRanges :: [Range] }
- deriving (Show,Eq)
-
-data SemanticTokensParams = SemanticTokensParams { semanticTokensParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data SemanticTokens = SemanticTokens { semanticTokensResultId :: Maybe String
-                                     , semanticTokensData :: [Int] }
- deriving (Show,Eq)
-
-data SemanticTokensPartialResult = SemanticTokensPartialResult { semanticTokensPartialResultData :: [Int] }
- deriving (Show,Eq)
-
-data SemanticTokensRegistrationOptions = SemanticTokensRegistrationOptions {  }
- deriving (Show,Eq)
-
-data SemanticTokensDeltaParams = SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument :: TextDocumentIdentifier
-                                                           , semanticTokensDeltaParamsPreviousResultId :: String }
- deriving (Show,Eq)
-
-data SemanticTokensDelta = SemanticTokensDelta { semanticTokensDeltaResultId :: Maybe String
-                                               , semanticTokensDeltaEdits :: [SemanticTokensEdit] }
- deriving (Show,Eq)
-
-data SemanticTokensDeltaPartialResult = SemanticTokensDeltaPartialResult { semanticTokensDeltaPartialResultEdits :: [SemanticTokensEdit] }
- deriving (Show,Eq)
-
-data SemanticTokensRangeParams = SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument :: TextDocumentIdentifier
-                                                           , semanticTokensRangeParamsRange :: Range }
- deriving (Show,Eq)
-
-data ShowDocumentParams = ShowDocumentParams { showDocumentParamsUri :: Uri
-                                             , showDocumentParamsExternal :: Maybe Bool
-                                             , showDocumentParamsTakeFocus :: Maybe Bool
-                                             , showDocumentParamsSelection :: Maybe Range }
- deriving (Show,Eq)
-
-data ShowDocumentResult = ShowDocumentResult { showDocumentResultSuccess :: Bool }
- deriving (Show,Eq)
-
-data LinkedEditingRangeParams = LinkedEditingRangeParams {  }
- deriving (Show,Eq)
-
-data LinkedEditingRanges = LinkedEditingRanges { linkedEditingRangesRanges :: [Range]
-                                               , linkedEditingRangesWordPattern :: Maybe String }
- deriving (Show,Eq)
-
-data LinkedEditingRangeRegistrationOptions = LinkedEditingRangeRegistrationOptions {  }
- deriving (Show,Eq)
-
-data CreateFilesParams = CreateFilesParams { createFilesParamsFiles :: [FileCreate] }
- deriving (Show,Eq)
-
-data WorkspaceEdit = WorkspaceEdit { workspaceEditChanges :: Maybe (Map DocumentUri [TextEdit])
-                                   , workspaceEditDocumentChanges :: Maybe [Either (Either (Either TextDocumentEdit CreateFile) RenameFile) DeleteFile]
-                                   , workspaceEditChangeAnnotations :: Maybe (Map ChangeAnnotationIdentifier ChangeAnnotation) }
- deriving (Show,Eq)
-
-data FileOperationRegistrationOptions = FileOperationRegistrationOptions { fileOperationRegistrationOptionsFilters :: [FileOperationFilter] }
- deriving (Show,Eq)
-
-data RenameFilesParams = RenameFilesParams { renameFilesParamsFiles :: [FileRename] }
- deriving (Show,Eq)
-
-data DeleteFilesParams = DeleteFilesParams { deleteFilesParamsFiles :: [FileDelete] }
- deriving (Show,Eq)
-
-data MonikerParams = MonikerParams {  }
- deriving (Show,Eq)
-
-data Moniker = Moniker { monikerScheme :: String
-                       , monikerIdentifier :: String
-                       , monikerUnique :: UniquenessLevel
-                       , monikerKind :: Maybe MonikerKind }
- deriving (Show,Eq)
-
-data MonikerRegistrationOptions = MonikerRegistrationOptions {  }
- deriving (Show,Eq)
-
-data TypeHierarchyPrepareParams = TypeHierarchyPrepareParams {  }
- deriving (Show,Eq)
-
-data TypeHierarchyItem = TypeHierarchyItem { typeHierarchyItemName :: String
-                                           , typeHierarchyItemKind :: SymbolKind
-                                           , typeHierarchyItemTags :: Maybe [SymbolTag]
-                                           , typeHierarchyItemDetail :: Maybe String
-                                           , typeHierarchyItemUri :: DocumentUri
-                                           , typeHierarchyItemRange :: Range
-                                           , typeHierarchyItemSelectionRange :: Range
-                                           , typeHierarchyItemData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data TypeHierarchyRegistrationOptions = TypeHierarchyRegistrationOptions {  }
- deriving (Show,Eq)
-
-data TypeHierarchySupertypesParams = TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem :: TypeHierarchyItem }
- deriving (Show,Eq)
-
-data TypeHierarchySubtypesParams = TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem :: TypeHierarchyItem }
- deriving (Show,Eq)
-
-data InlineValueParams = InlineValueParams { inlineValueParamsTextDocument :: TextDocumentIdentifier
-                                           , inlineValueParamsRange :: Range
-                                           , inlineValueParamsContext :: InlineValueContext }
- deriving (Show,Eq)
-
-data InlineValueRegistrationOptions = InlineValueRegistrationOptions {  }
- deriving (Show,Eq)
-
-data InlayHintParams = InlayHintParams { inlayHintParamsTextDocument :: TextDocumentIdentifier
-                                       , inlayHintParamsRange :: Range }
- deriving (Show,Eq)
-
-data InlayHint = InlayHint { inlayHintPosition :: Position
-                           , inlayHintLabel :: Either String [InlayHintLabelPart]
-                           , inlayHintKind :: Maybe InlayHintKind
-                           , inlayHintTextEdits :: Maybe [TextEdit]
-                           , inlayHintTooltip :: Maybe (Either String MarkupContent)
-                           , inlayHintPaddingLeft :: Maybe Bool
-                           , inlayHintPaddingRight :: Maybe Bool
-                           , inlayHintData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data InlayHintRegistrationOptions = InlayHintRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentDiagnosticParams = DocumentDiagnosticParams { documentDiagnosticParamsTextDocument :: TextDocumentIdentifier
-                                                         , documentDiagnosticParamsIdentifier :: Maybe String
-                                                         , documentDiagnosticParamsPreviousResultId :: Maybe String }
- deriving (Show,Eq)
-
-data DocumentDiagnosticReportPartialResult = DocumentDiagnosticReportPartialResult { documentDiagnosticReportPartialResultRelatedDocuments :: Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport) }
- deriving (Show,Eq)
-
-data DiagnosticServerCancellationData = DiagnosticServerCancellationData { diagnosticServerCancellationDataRetriggerRequest :: Bool }
- deriving (Show,Eq)
-
-data DiagnosticRegistrationOptions = DiagnosticRegistrationOptions {  }
- deriving (Show,Eq)
-
-data WorkspaceDiagnosticParams = WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier :: Maybe String
-                                                           , workspaceDiagnosticParamsPreviousResultIds :: [PreviousResultId] }
- deriving (Show,Eq)
-
-data WorkspaceDiagnosticReport = WorkspaceDiagnosticReport { workspaceDiagnosticReportItems :: [WorkspaceDocumentDiagnosticReport] }
- deriving (Show,Eq)
-
-data WorkspaceDiagnosticReportPartialResult = WorkspaceDiagnosticReportPartialResult { workspaceDiagnosticReportPartialResultItems :: [WorkspaceDocumentDiagnosticReport] }
- deriving (Show,Eq)
-
-data DidOpenNotebookDocumentParams = DidOpenNotebookDocumentParams { didOpenNotebookDocumentParamsNotebookDocument :: NotebookDocument
-                                                                   , didOpenNotebookDocumentParamsCellTextDocuments :: [TextDocumentItem] }
- deriving (Show,Eq)
-
-data NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DidChangeNotebookDocumentParams = DidChangeNotebookDocumentParams { didChangeNotebookDocumentParamsNotebookDocument :: VersionedNotebookDocumentIdentifier
-                                                                       , didChangeNotebookDocumentParamsChange :: NotebookDocumentChangeEvent }
- deriving (Show,Eq)
-
-data DidSaveNotebookDocumentParams = DidSaveNotebookDocumentParams { didSaveNotebookDocumentParamsNotebookDocument :: NotebookDocumentIdentifier }
- deriving (Show,Eq)
-
-data DidCloseNotebookDocumentParams = DidCloseNotebookDocumentParams { didCloseNotebookDocumentParamsNotebookDocument :: NotebookDocumentIdentifier
-                                                                     , didCloseNotebookDocumentParamsCellTextDocuments :: [TextDocumentIdentifier] }
- deriving (Show,Eq)
-
-data InlineCompletionParams = InlineCompletionParams { inlineCompletionParamsContext :: InlineCompletionContext }
- deriving (Show,Eq)
-
-data InlineCompletionList = InlineCompletionList { inlineCompletionListItems :: [InlineCompletionItem] }
- deriving (Show,Eq)
-
-data InlineCompletionItem = InlineCompletionItem { inlineCompletionItemInsertText :: Either String StringValue
-                                                 , inlineCompletionItemFilterText :: Maybe String
-                                                 , inlineCompletionItemRange :: Maybe Range
-                                                 , inlineCompletionItemCommand :: Maybe Command }
- deriving (Show,Eq)
-
-data InlineCompletionRegistrationOptions = InlineCompletionRegistrationOptions {  }
- deriving (Show,Eq)
-
-data RegistrationParams = RegistrationParams { registrationParamsRegistrations :: [Registration] }
- deriving (Show,Eq)
-
-data UnregistrationParams = UnregistrationParams { unregistrationParamsUnregisterations :: [Unregistration] }
- deriving (Show,Eq)
-
-data InitializeParams = InitializeParams {  }
- deriving (Show,Eq)
-
-data InitializeResult = InitializeResult { initializeResultCapabilities :: ServerCapabilities
-                                         , initializeResultServerInfo :: Maybe ServerInfo }
- deriving (Show,Eq)
-
-data InitializeError = InitializeError { initializeErrorRetry :: Bool }
- deriving (Show,Eq)
-
-data InitializedParams = InitializedParams {  }
- deriving (Show,Eq)
-
-data DidChangeConfigurationParams = DidChangeConfigurationParams { didChangeConfigurationParamsSettings :: LSPAny }
- deriving (Show,Eq)
-
-data DidChangeConfigurationRegistrationOptions = DidChangeConfigurationRegistrationOptions { didChangeConfigurationRegistrationOptionsSection :: Maybe (Either String [String]) }
- deriving (Show,Eq)
-
-data ShowMessageParams = ShowMessageParams { showMessageParamsType :: MessageType
-                                           , showMessageParamsMessage :: String }
- deriving (Show,Eq)
-
-data ShowMessageRequestParams = ShowMessageRequestParams { showMessageRequestParamsType :: MessageType
-                                                         , showMessageRequestParamsMessage :: String
-                                                         , showMessageRequestParamsActions :: Maybe [MessageActionItem] }
- deriving (Show,Eq)
-
-data MessageActionItem = MessageActionItem { messageActionItemTitle :: String }
- deriving (Show,Eq)
-
-data LogMessageParams = LogMessageParams { logMessageParamsType :: MessageType
-                                         , logMessageParamsMessage :: String }
- deriving (Show,Eq)
-
-data DidOpenTextDocumentParams = DidOpenTextDocumentParams { didOpenTextDocumentParamsTextDocument :: TextDocumentItem }
- deriving (Show,Eq)
-
-data DidChangeTextDocumentParams = DidChangeTextDocumentParams { didChangeTextDocumentParamsTextDocument :: VersionedTextDocumentIdentifier
-                                                               , didChangeTextDocumentParamsContentChanges :: [TextDocumentContentChangeEvent] }
- deriving (Show,Eq)
-
-data TextDocumentChangeRegistrationOptions = TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind :: TextDocumentSyncKind }
- deriving (Show,Eq)
-
-data DidCloseTextDocumentParams = DidCloseTextDocumentParams { didCloseTextDocumentParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data DidSaveTextDocumentParams = DidSaveTextDocumentParams { didSaveTextDocumentParamsTextDocument :: TextDocumentIdentifier
-                                                           , didSaveTextDocumentParamsText :: Maybe String }
- deriving (Show,Eq)
-
-data TextDocumentSaveRegistrationOptions = TextDocumentSaveRegistrationOptions {  }
- deriving (Show,Eq)
-
-data WillSaveTextDocumentParams = WillSaveTextDocumentParams { willSaveTextDocumentParamsTextDocument :: TextDocumentIdentifier
-                                                             , willSaveTextDocumentParamsReason :: TextDocumentSaveReason }
- deriving (Show,Eq)
-
-data TextEdit = TextEdit { textEditRange :: Range, textEditNewText :: String }
- deriving (Show,Eq)
-
-data DidChangeWatchedFilesParams = DidChangeWatchedFilesParams { didChangeWatchedFilesParamsChanges :: [FileEvent] }
- deriving (Show,Eq)
-
-data DidChangeWatchedFilesRegistrationOptions = DidChangeWatchedFilesRegistrationOptions { didChangeWatchedFilesRegistrationOptionsWatchers :: [FileSystemWatcher] }
- deriving (Show,Eq)
-
-data PublishDiagnosticsParams = PublishDiagnosticsParams { publishDiagnosticsParamsUri :: DocumentUri
-                                                         , publishDiagnosticsParamsVersion :: Maybe Int
-                                                         , publishDiagnosticsParamsDiagnostics :: [Diagnostic] }
- deriving (Show,Eq)
-
-data CompletionParams = CompletionParams { completionParamsContext :: Maybe CompletionContext }
- deriving (Show,Eq)
-
-data CompletionItem = CompletionItem { completionItemLabel :: String
-                                     , completionItemLabelDetails :: Maybe CompletionItemLabelDetails
-                                     , completionItemKind :: Maybe CompletionItemKind
-                                     , completionItemTags :: Maybe [CompletionItemTag]
-                                     , completionItemDetail :: Maybe String
-                                     , completionItemDocumentation :: Maybe (Either String MarkupContent)
-                                     , completionItemDeprecated :: Maybe Bool
-                                     , completionItemPreselect :: Maybe Bool
-                                     , completionItemSortText :: Maybe String
-                                     , completionItemFilterText :: Maybe String
-                                     , completionItemInsertText :: Maybe String
-                                     , completionItemInsertTextFormat :: Maybe InsertTextFormat
-                                     , completionItemInsertTextMode :: Maybe InsertTextMode
-                                     , completionItemTextEdit :: Maybe (Either TextEdit InsertReplaceEdit)
-                                     , completionItemTextEditText :: Maybe String
-                                     , completionItemAdditionalTextEdits :: Maybe [TextEdit]
-                                     , completionItemCommitCharacters :: Maybe [String]
-                                     , completionItemCommand :: Maybe Command
-                                     , completionItemData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CompletionList = CompletionList { completionListIsIncomplete :: Bool
-                                     , completionListItemDefaults :: Maybe CompletionItemDefaults
-                                     , completionListItems :: [CompletionItem] }
- deriving (Show,Eq)
-
-data CompletionRegistrationOptions = CompletionRegistrationOptions {  }
- deriving (Show,Eq)
-
-data HoverParams = HoverParams {  }
- deriving (Show,Eq)
-
-data Hover = Hover { hoverContents :: Either (Either MarkupContent MarkedString) [MarkedString]
-                   , hoverRange :: Maybe Range }
- deriving (Show,Eq)
-
-data HoverRegistrationOptions = HoverRegistrationOptions {  }
- deriving (Show,Eq)
-
-data SignatureHelpParams = SignatureHelpParams { signatureHelpParamsContext :: Maybe SignatureHelpContext }
- deriving (Show,Eq)
-
-data SignatureHelp = SignatureHelp { signatureHelpSignatures :: [SignatureInformation]
-                                   , signatureHelpActiveSignature :: Maybe Int
-                                   , signatureHelpActiveParameter :: Maybe (Either Int ()) }
- deriving (Show,Eq)
-
-data SignatureHelpRegistrationOptions = SignatureHelpRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DefinitionParams = DefinitionParams {  }
- deriving (Show,Eq)
-
-data DefinitionRegistrationOptions = DefinitionRegistrationOptions {  }
- deriving (Show,Eq)
-
-data ReferenceParams = ReferenceParams { referenceParamsContext :: ReferenceContext }
- deriving (Show,Eq)
-
-data ReferenceRegistrationOptions = ReferenceRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentHighlightParams = DocumentHighlightParams {  }
- deriving (Show,Eq)
-
-data DocumentHighlight = DocumentHighlight { documentHighlightRange :: Range
-                                           , documentHighlightKind :: Maybe DocumentHighlightKind }
- deriving (Show,Eq)
-
-data DocumentHighlightRegistrationOptions = DocumentHighlightRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentSymbolParams = DocumentSymbolParams { documentSymbolParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data SymbolInformation = SymbolInformation { symbolInformationDeprecated :: Maybe Bool
-                                           , symbolInformationLocation :: Location }
- deriving (Show,Eq)
-
-data DocumentSymbol = DocumentSymbol { documentSymbolName :: String
-                                     , documentSymbolDetail :: Maybe String
-                                     , documentSymbolKind :: SymbolKind
-                                     , documentSymbolTags :: Maybe [SymbolTag]
-                                     , documentSymbolDeprecated :: Maybe Bool
-                                     , documentSymbolRange :: Range
-                                     , documentSymbolSelectionRange :: Range
-                                     , documentSymbolChildren :: Maybe [DocumentSymbol] }
- deriving (Show,Eq)
-
-data DocumentSymbolRegistrationOptions = DocumentSymbolRegistrationOptions {  }
- deriving (Show,Eq)
-
-data CodeActionParams = CodeActionParams { codeActionParamsTextDocument :: TextDocumentIdentifier
-                                         , codeActionParamsRange :: Range
-                                         , codeActionParamsContext :: CodeActionContext }
- deriving (Show,Eq)
-
-data Command = Command { commandTitle :: String
-                       , commandTooltip :: Maybe String
-                       , commandCommand :: String
-                       , commandArguments :: Maybe [LSPAny] }
- deriving (Show,Eq)
-
-data CodeAction = CodeAction { codeActionTitle :: String
-                             , codeActionKind :: Maybe CodeActionKind
-                             , codeActionDiagnostics :: Maybe [Diagnostic]
-                             , codeActionIsPreferred :: Maybe Bool
-                             , codeActionDisabled :: Maybe CodeActionDisabled
-                             , codeActionEdit :: Maybe WorkspaceEdit
-                             , codeActionCommand :: Maybe Command
-                             , codeActionData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CodeActionRegistrationOptions = CodeActionRegistrationOptions {  }
- deriving (Show,Eq)
-
-data WorkspaceSymbolParams = WorkspaceSymbolParams { workspaceSymbolParamsQuery :: String }
- deriving (Show,Eq)
-
-data WorkspaceSymbol = WorkspaceSymbol { workspaceSymbolLocation :: Either Location LocationUriOnly
-                                       , workspaceSymbolData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data WorkspaceSymbolRegistrationOptions = WorkspaceSymbolRegistrationOptions {  }
- deriving (Show,Eq)
-
-data CodeLensParams = CodeLensParams { codeLensParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data CodeLens = CodeLens { codeLensRange :: Range
-                         , codeLensCommand :: Maybe Command
-                         , codeLensData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CodeLensRegistrationOptions = CodeLensRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentLinkParams = DocumentLinkParams { documentLinkParamsTextDocument :: TextDocumentIdentifier }
- deriving (Show,Eq)
-
-data DocumentLink = DocumentLink { documentLinkRange :: Range
-                                 , documentLinkTarget :: Maybe Uri
-                                 , documentLinkTooltip :: Maybe String
-                                 , documentLinkData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data DocumentLinkRegistrationOptions = DocumentLinkRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentFormattingParams = DocumentFormattingParams { documentFormattingParamsTextDocument :: TextDocumentIdentifier
-                                                         , documentFormattingParamsOptions :: FormattingOptions }
- deriving (Show,Eq)
-
-data DocumentFormattingRegistrationOptions = DocumentFormattingRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentRangeFormattingParams = DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument :: TextDocumentIdentifier
-                                                                   , documentRangeFormattingParamsRange :: Range
-                                                                   , documentRangeFormattingParamsOptions :: FormattingOptions }
- deriving (Show,Eq)
-
-data DocumentRangeFormattingRegistrationOptions = DocumentRangeFormattingRegistrationOptions {  }
- deriving (Show,Eq)
-
-data DocumentRangesFormattingParams = DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument :: TextDocumentIdentifier
-                                                                     , documentRangesFormattingParamsRanges :: [Range]
-                                                                     , documentRangesFormattingParamsOptions :: FormattingOptions }
- deriving (Show,Eq)
-
-data DocumentOnTypeFormattingParams = DocumentOnTypeFormattingParams { documentOnTypeFormattingParamsTextDocument :: TextDocumentIdentifier
-                                                                     , documentOnTypeFormattingParamsPosition :: Position
-                                                                     , documentOnTypeFormattingParamsCh :: String
-                                                                     , documentOnTypeFormattingParamsOptions :: FormattingOptions }
- deriving (Show,Eq)
-
-data DocumentOnTypeFormattingRegistrationOptions = DocumentOnTypeFormattingRegistrationOptions {  }
- deriving (Show,Eq)
-
-data RenameParams = RenameParams { renameParamsTextDocument :: TextDocumentIdentifier
-                                 , renameParamsPosition :: Position
-                                 , renameParamsNewName :: String }
- deriving (Show,Eq)
-
-data RenameRegistrationOptions = RenameRegistrationOptions {  }
- deriving (Show,Eq)
-
-data PrepareRenameParams = PrepareRenameParams {  }
- deriving (Show,Eq)
-
-data ExecuteCommandParams = ExecuteCommandParams { executeCommandParamsCommand :: String
-                                                 , executeCommandParamsArguments :: Maybe [LSPAny] }
- deriving (Show,Eq)
-
-data ExecuteCommandRegistrationOptions = ExecuteCommandRegistrationOptions {  }
- deriving (Show,Eq)
-
-data ApplyWorkspaceEditParams = ApplyWorkspaceEditParams { applyWorkspaceEditParamsLabel :: Maybe String
-                                                         , applyWorkspaceEditParamsEdit :: WorkspaceEdit
-                                                         , applyWorkspaceEditParamsMetadata :: Maybe WorkspaceEditMetadata }
- deriving (Show,Eq)
-
-data ApplyWorkspaceEditResult = ApplyWorkspaceEditResult { applyWorkspaceEditResultApplied :: Bool
-                                                         , applyWorkspaceEditResultFailureReason :: Maybe String
-                                                         , applyWorkspaceEditResultFailedChange :: Maybe Int }
- deriving (Show,Eq)
-
-data WorkDoneProgressBegin = WorkDoneProgressBegin { workDoneProgressBeginKind :: String
-                                                   , workDoneProgressBeginTitle :: String
-                                                   , workDoneProgressBeginCancellable :: Maybe Bool
-                                                   , workDoneProgressBeginMessage :: Maybe String
-                                                   , workDoneProgressBeginPercentage :: Maybe Int }
- deriving (Show,Eq)
-
-data WorkDoneProgressReport = WorkDoneProgressReport { workDoneProgressReportKind :: String
-                                                     , workDoneProgressReportCancellable :: Maybe Bool
-                                                     , workDoneProgressReportMessage :: Maybe String
-                                                     , workDoneProgressReportPercentage :: Maybe Int }
- deriving (Show,Eq)
-
-data WorkDoneProgressEnd = WorkDoneProgressEnd { workDoneProgressEndKind :: String
-                                               , workDoneProgressEndMessage :: Maybe String }
- deriving (Show,Eq)
-
-data SetTraceParams = SetTraceParams { setTraceParamsValue :: TraceValue }
- deriving (Show,Eq)
-
-data LogTraceParams = LogTraceParams { logTraceParamsMessage :: String
-                                     , logTraceParamsVerbose :: Maybe String }
- deriving (Show,Eq)
-
-data CancelParams = CancelParams { cancelParamsId :: Either Int String }
- deriving (Show,Eq)
-
-data ProgressParams = ProgressParams { progressParamsToken :: ProgressToken
-                                     , progressParamsValue :: LSPAny }
- deriving (Show,Eq)
-
-data TextDocumentPositionParams = TextDocumentPositionParams { textDocumentPositionParamsTextDocument :: TextDocumentIdentifier
-                                                             , textDocumentPositionParamsPosition :: Position }
- deriving (Show,Eq)
-
-data WorkDoneProgressParams = WorkDoneProgressParams { workDoneProgressParamsWorkDoneToken :: Maybe ProgressToken }
- deriving (Show,Eq)
-
-data PartialResultParams = PartialResultParams { partialResultParamsPartialResultToken :: Maybe ProgressToken }
- deriving (Show,Eq)
-
-data LocationLink = LocationLink { locationLinkOriginSelectionRange :: Maybe Range
-                                 , locationLinkTargetUri :: DocumentUri
-                                 , locationLinkTargetRange :: Range
-                                 , locationLinkTargetSelectionRange :: Range }
- deriving (Show,Eq)
-
-data Range = Range { rangeStart :: Position, rangeEnd :: Position }
- deriving (Show,Eq)
-
-data ImplementationOptions = ImplementationOptions {  }
- deriving (Show,Eq)
-
-data StaticRegistrationOptions = StaticRegistrationOptions { staticRegistrationOptionsId :: Maybe String }
- deriving (Show,Eq)
-
-data TypeDefinitionOptions = TypeDefinitionOptions {  }
- deriving (Show,Eq)
-
-data WorkspaceFoldersChangeEvent = WorkspaceFoldersChangeEvent { workspaceFoldersChangeEventAdded :: [WorkspaceFolder]
-                                                               , workspaceFoldersChangeEventRemoved :: [WorkspaceFolder] }
- deriving (Show,Eq)
-
-data ConfigurationItem = ConfigurationItem { configurationItemScopeUri :: Maybe Uri
-                                           , configurationItemSection :: Maybe String }
- deriving (Show,Eq)
-
-data TextDocumentIdentifier = TextDocumentIdentifier { textDocumentIdentifierUri :: DocumentUri }
- deriving (Show,Eq)
-
-data Color = Color { colorRed :: Float
-                   , colorGreen :: Float
-                   , colorBlue :: Float
-                   , colorAlpha :: Float }
- deriving (Show,Eq)
-
-data DocumentColorOptions = DocumentColorOptions {  }
- deriving (Show,Eq)
-
-data FoldingRangeOptions = FoldingRangeOptions {  }
- deriving (Show,Eq)
-
-data DeclarationOptions = DeclarationOptions {  }
- deriving (Show,Eq)
-
-data Position = Position { positionLine :: Int, positionCharacter :: Int }
- deriving (Show,Eq)
-
-data SelectionRangeOptions = SelectionRangeOptions {  }
- deriving (Show,Eq)
-
-data CallHierarchyOptions = CallHierarchyOptions {  }
- deriving (Show,Eq)
-
-data SemanticTokensOptions = SemanticTokensOptions { semanticTokensOptionsLegend :: SemanticTokensLegend
-                                                   , semanticTokensOptionsRange :: Maybe (Either Bool ())
-                                                   , semanticTokensOptionsFull :: Maybe (Either Bool SemanticTokensFullDelta) }
- deriving (Show,Eq)
-
-data SemanticTokensEdit = SemanticTokensEdit { semanticTokensEditStart :: Int
-                                             , semanticTokensEditDeleteCount :: Int
-                                             , semanticTokensEditData :: Maybe [Int] }
- deriving (Show,Eq)
-
-data LinkedEditingRangeOptions = LinkedEditingRangeOptions {  }
- deriving (Show,Eq)
-
-data FileCreate = FileCreate { fileCreateUri :: String }
- deriving (Show,Eq)
-
-data TextDocumentEdit = TextDocumentEdit { textDocumentEditTextDocument :: OptionalVersionedTextDocumentIdentifier
-                                         , textDocumentEditEdits :: [Either (Either TextEdit AnnotatedTextEdit) SnippetTextEdit] }
- deriving (Show,Eq)
-
-data CreateFile = CreateFile { createFileKind :: String
-                             , createFileUri :: DocumentUri
-                             , createFileOptions :: Maybe CreateFileOptions }
- deriving (Show,Eq)
-
-data RenameFile = RenameFile { renameFileKind :: String
-                             , renameFileOldUri :: DocumentUri
-                             , renameFileNewUri :: DocumentUri
-                             , renameFileOptions :: Maybe RenameFileOptions }
- deriving (Show,Eq)
-
-data DeleteFile = DeleteFile { deleteFileKind :: String
-                             , deleteFileUri :: DocumentUri
-                             , deleteFileOptions :: Maybe DeleteFileOptions }
- deriving (Show,Eq)
-
-data ChangeAnnotation = ChangeAnnotation { changeAnnotationLabel :: String
-                                         , changeAnnotationNeedsConfirmation :: Maybe Bool
-                                         , changeAnnotationDescription :: Maybe String }
- deriving (Show,Eq)
-
-data FileOperationFilter = FileOperationFilter { fileOperationFilterScheme :: Maybe String
-                                               , fileOperationFilterPattern :: FileOperationPattern }
- deriving (Show,Eq)
-
-data FileRename = FileRename { fileRenameOldUri :: String
-                             , fileRenameNewUri :: String }
- deriving (Show,Eq)
-
-data FileDelete = FileDelete { fileDeleteUri :: String }
- deriving (Show,Eq)
-
-data MonikerOptions = MonikerOptions {  }
- deriving (Show,Eq)
-
-data TypeHierarchyOptions = TypeHierarchyOptions {  }
- deriving (Show,Eq)
-
-data InlineValueContext = InlineValueContext { inlineValueContextFrameId :: Int
-                                             , inlineValueContextStoppedLocation :: Range }
- deriving (Show,Eq)
-
-data InlineValueText = InlineValueText { inlineValueTextRange :: Range
-                                       , inlineValueTextText :: String }
- deriving (Show,Eq)
-
-data InlineValueVariableLookup = InlineValueVariableLookup { inlineValueVariableLookupRange :: Range
-                                                           , inlineValueVariableLookupVariableName :: Maybe String
-                                                           , inlineValueVariableLookupCaseSensitiveLookup :: Bool }
- deriving (Show,Eq)
-
-data InlineValueEvaluatableExpression = InlineValueEvaluatableExpression { inlineValueEvaluatableExpressionRange :: Range
-                                                                         , inlineValueEvaluatableExpressionExpression :: Maybe String }
- deriving (Show,Eq)
-
-data InlineValueOptions = InlineValueOptions {  }
- deriving (Show,Eq)
-
-data InlayHintLabelPart = InlayHintLabelPart { inlayHintLabelPartValue :: String
-                                             , inlayHintLabelPartTooltip :: Maybe (Either String MarkupContent)
-                                             , inlayHintLabelPartLocation :: Maybe Location
-                                             , inlayHintLabelPartCommand :: Maybe Command }
- deriving (Show,Eq)
-
-data MarkupContent = MarkupContent { markupContentKind :: MarkupKind
-                                   , markupContentValue :: String }
- deriving (Show,Eq)
-
-data InlayHintOptions = InlayHintOptions { inlayHintOptionsResolveProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
- deriving (Show,Eq)
-
-data RelatedUnchangedDocumentDiagnosticReport = RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
- deriving (Show,Eq)
-
-data FullDocumentDiagnosticReport = FullDocumentDiagnosticReport { fullDocumentDiagnosticReportKind :: String
-                                                                 , fullDocumentDiagnosticReportResultId :: Maybe String
-                                                                 , fullDocumentDiagnosticReportItems :: [Diagnostic] }
- deriving (Show,Eq)
-
-data UnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnosticReport { unchangedDocumentDiagnosticReportKind :: String
-                                                                           , unchangedDocumentDiagnosticReportResultId :: String }
- deriving (Show,Eq)
-
-data DiagnosticOptions = DiagnosticOptions { diagnosticOptionsIdentifier :: Maybe String
-                                           , diagnosticOptionsInterFileDependencies :: Bool
-                                           , diagnosticOptionsWorkspaceDiagnostics :: Bool }
- deriving (Show,Eq)
-
-data PreviousResultId = PreviousResultId { previousResultIdUri :: DocumentUri
-                                         , previousResultIdValue :: String }
- deriving (Show,Eq)
-
-data NotebookDocument = NotebookDocument { notebookDocumentUri :: Uri
-                                         , notebookDocumentNotebookType :: String
-                                         , notebookDocumentVersion :: Int
-                                         , notebookDocumentMetadata :: Maybe LSPObject
-                                         , notebookDocumentCells :: [NotebookCell] }
- deriving (Show,Eq)
-
-data TextDocumentItem = TextDocumentItem { textDocumentItemUri :: DocumentUri
-                                         , textDocumentItemLanguageId :: LanguageKind
-                                         , textDocumentItemVersion :: Int
-                                         , textDocumentItemText :: String }
- deriving (Show,Eq)
-
-data NotebookDocumentSyncOptions = NotebookDocumentSyncOptions { notebookDocumentSyncOptionsNotebookSelector :: [Either NotebookDocumentFilterWithNotebook NotebookDocumentFilterWithCells]
-                                                               , notebookDocumentSyncOptionsSave :: Maybe Bool }
- deriving (Show,Eq)
-
-data VersionedNotebookDocumentIdentifier = VersionedNotebookDocumentIdentifier { versionedNotebookDocumentIdentifierVersion :: Int
-                                                                               , versionedNotebookDocumentIdentifierUri :: Uri }
- deriving (Show,Eq)
-
-data NotebookDocumentChangeEvent = NotebookDocumentChangeEvent { notebookDocumentChangeEventMetadata :: Maybe LSPObject
-                                                               , notebookDocumentChangeEventCells :: Maybe NotebookDocumentCellChanges }
- deriving (Show,Eq)
-
-data NotebookDocumentIdentifier = NotebookDocumentIdentifier { notebookDocumentIdentifierUri :: Uri }
- deriving (Show,Eq)
-
-data InlineCompletionContext = InlineCompletionContext { inlineCompletionContextTriggerKind :: InlineCompletionTriggerKind
-                                                       , inlineCompletionContextSelectedCompletionInfo :: Maybe SelectedCompletionInfo }
- deriving (Show,Eq)
-
-data StringValue = StringValue { stringValueKind :: String
-                               , stringValueValue :: String }
- deriving (Show,Eq)
-
-data InlineCompletionOptions = InlineCompletionOptions {  }
- deriving (Show,Eq)
-
-data Registration = Registration { registrationId :: String
-                                 , registrationMethod :: String
-                                 , registrationRegisterOptions :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data Unregistration = Unregistration { unregistrationId :: String
-                                     , unregistrationMethod :: String }
- deriving (Show,Eq)
-
-data BaseInitializeParams = BaseInitializeParams { baseInitializeParamsProcessId :: Either Int ()
-                                                 , baseInitializeParamsClientInfo :: Maybe ClientInfo
-                                                 , baseInitializeParamsLocale :: Maybe String
-                                                 , baseInitializeParamsRootPath :: Maybe (Either String ())
-                                                 , baseInitializeParamsRootUri :: Either DocumentUri ()
-                                                 , baseInitializeParamsCapabilities :: ClientCapabilities
-                                                 , baseInitializeParamsInitializationOptions :: Maybe LSPAny
-                                                 , baseInitializeParamsTrace :: Maybe TraceValue }
- deriving (Show,Eq)
-
-data WorkspaceFoldersInitializeParams = WorkspaceFoldersInitializeParams { workspaceFoldersInitializeParamsWorkspaceFolders :: Maybe (Either [WorkspaceFolder] ()) }
- deriving (Show,Eq)
-
-data ServerCapabilities = ServerCapabilities { serverCapabilitiesPositionEncoding :: Maybe PositionEncodingKind
-                                             , serverCapabilitiesTextDocumentSync :: Maybe (Either TextDocumentSyncOptions TextDocumentSyncKind)
-                                             , serverCapabilitiesNotebookDocumentSync :: Maybe (Either NotebookDocumentSyncOptions NotebookDocumentSyncRegistrationOptions)
-                                             , serverCapabilitiesCompletionProvider :: Maybe CompletionOptions
-                                             , serverCapabilitiesHoverProvider :: Maybe (Either Bool HoverOptions)
-                                             , serverCapabilitiesSignatureHelpProvider :: Maybe SignatureHelpOptions
-                                             , serverCapabilitiesDeclarationProvider :: Maybe (Either (Either Bool DeclarationOptions) DeclarationRegistrationOptions)
-                                             , serverCapabilitiesDefinitionProvider :: Maybe (Either Bool DefinitionOptions)
-                                             , serverCapabilitiesTypeDefinitionProvider :: Maybe (Either (Either Bool TypeDefinitionOptions) TypeDefinitionRegistrationOptions)
-                                             , serverCapabilitiesImplementationProvider :: Maybe (Either (Either Bool ImplementationOptions) ImplementationRegistrationOptions)
-                                             , serverCapabilitiesReferencesProvider :: Maybe (Either Bool ReferenceOptions)
-                                             , serverCapabilitiesDocumentHighlightProvider :: Maybe (Either Bool DocumentHighlightOptions)
-                                             , serverCapabilitiesDocumentSymbolProvider :: Maybe (Either Bool DocumentSymbolOptions)
-                                             , serverCapabilitiesCodeActionProvider :: Maybe (Either Bool CodeActionOptions)
-                                             , serverCapabilitiesCodeLensProvider :: Maybe CodeLensOptions
-                                             , serverCapabilitiesDocumentLinkProvider :: Maybe DocumentLinkOptions
-                                             , serverCapabilitiesColorProvider :: Maybe (Either (Either Bool DocumentColorOptions) DocumentColorRegistrationOptions)
-                                             , serverCapabilitiesWorkspaceSymbolProvider :: Maybe (Either Bool WorkspaceSymbolOptions)
-                                             , serverCapabilitiesDocumentFormattingProvider :: Maybe (Either Bool DocumentFormattingOptions)
-                                             , serverCapabilitiesDocumentRangeFormattingProvider :: Maybe (Either Bool DocumentRangeFormattingOptions)
-                                             , serverCapabilitiesDocumentOnTypeFormattingProvider :: Maybe DocumentOnTypeFormattingOptions
-                                             , serverCapabilitiesRenameProvider :: Maybe (Either Bool RenameOptions)
-                                             , serverCapabilitiesFoldingRangeProvider :: Maybe (Either (Either Bool FoldingRangeOptions) FoldingRangeRegistrationOptions)
-                                             , serverCapabilitiesSelectionRangeProvider :: Maybe (Either (Either Bool SelectionRangeOptions) SelectionRangeRegistrationOptions)
-                                             , serverCapabilitiesExecuteCommandProvider :: Maybe ExecuteCommandOptions
-                                             , serverCapabilitiesCallHierarchyProvider :: Maybe (Either (Either Bool CallHierarchyOptions) CallHierarchyRegistrationOptions)
-                                             , serverCapabilitiesLinkedEditingRangeProvider :: Maybe (Either (Either Bool LinkedEditingRangeOptions) LinkedEditingRangeRegistrationOptions)
-                                             , serverCapabilitiesSemanticTokensProvider :: Maybe (Either SemanticTokensOptions SemanticTokensRegistrationOptions)
-                                             , serverCapabilitiesMonikerProvider :: Maybe (Either (Either Bool MonikerOptions) MonikerRegistrationOptions)
-                                             , serverCapabilitiesTypeHierarchyProvider :: Maybe (Either (Either Bool TypeHierarchyOptions) TypeHierarchyRegistrationOptions)
-                                             , serverCapabilitiesInlineValueProvider :: Maybe (Either (Either Bool InlineValueOptions) InlineValueRegistrationOptions)
-                                             , serverCapabilitiesInlayHintProvider :: Maybe (Either (Either Bool InlayHintOptions) InlayHintRegistrationOptions)
-                                             , serverCapabilitiesDiagnosticProvider :: Maybe (Either DiagnosticOptions DiagnosticRegistrationOptions)
-                                             , serverCapabilitiesInlineCompletionProvider :: Maybe (Either Bool InlineCompletionOptions)
-                                             , serverCapabilitiesWorkspace :: Maybe WorkspaceOptions
-                                             , serverCapabilitiesExperimental :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data ServerInfo = ServerInfo { serverInfoName :: String
-                             , serverInfoVersion :: Maybe String }
- deriving (Show,Eq)
-
-data VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion :: Int }
- deriving (Show,Eq)
-
-data SaveOptions = SaveOptions { saveOptionsIncludeText :: Maybe Bool }
- deriving (Show,Eq)
-
-data FileEvent = FileEvent { fileEventUri :: DocumentUri
-                           , fileEventType :: FileChangeType }
- deriving (Show,Eq)
-
-data FileSystemWatcher = FileSystemWatcher { fileSystemWatcherGlobPattern :: GlobPattern
-                                           , fileSystemWatcherKind :: Maybe WatchKind }
- deriving (Show,Eq)
-
-data Diagnostic = Diagnostic { diagnosticRange :: Range
-                             , diagnosticSeverity :: Maybe DiagnosticSeverity
-                             , diagnosticCode :: Maybe (Either Int String)
-                             , diagnosticCodeDescription :: Maybe CodeDescription
-                             , diagnosticSource :: Maybe String
-                             , diagnosticMessage :: String
-                             , diagnosticTags :: Maybe [DiagnosticTag]
-                             , diagnosticRelatedInformation :: Maybe [DiagnosticRelatedInformation]
-                             , diagnosticData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CompletionContext = CompletionContext { completionContextTriggerKind :: CompletionTriggerKind
-                                           , completionContextTriggerCharacter :: Maybe String }
- deriving (Show,Eq)
-
-data CompletionItemLabelDetails = CompletionItemLabelDetails { completionItemLabelDetailsDetail :: Maybe String
-                                                             , completionItemLabelDetailsDescription :: Maybe String }
- deriving (Show,Eq)
-
-data InsertReplaceEdit = InsertReplaceEdit { insertReplaceEditNewText :: String
-                                           , insertReplaceEditInsert :: Range
-                                           , insertReplaceEditReplace :: Range }
- deriving (Show,Eq)
-
-data CompletionItemDefaults = CompletionItemDefaults { completionItemDefaultsCommitCharacters :: Maybe [String]
-                                                     , completionItemDefaultsEditRange :: Maybe (Either Range EditRangeWithInsertReplace)
-                                                     , completionItemDefaultsInsertTextFormat :: Maybe InsertTextFormat
-                                                     , completionItemDefaultsInsertTextMode :: Maybe InsertTextMode
-                                                     , completionItemDefaultsData :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data CompletionOptions = CompletionOptions { completionOptionsTriggerCharacters :: Maybe [String]
-                                           , completionOptionsAllCommitCharacters :: Maybe [String]
-                                           , completionOptionsResolveProvider :: Maybe Bool
-                                           , completionOptionsCompletionItem :: Maybe ServerCompletionItemOptions }
- deriving (Show,Eq)
-
-data HoverOptions = HoverOptions {  }
- deriving (Show,Eq)
-
-data SignatureHelpContext = SignatureHelpContext { signatureHelpContextTriggerKind :: SignatureHelpTriggerKind
-                                                 , signatureHelpContextTriggerCharacter :: Maybe String
-                                                 , signatureHelpContextIsRetrigger :: Bool
-                                                 , signatureHelpContextActiveSignatureHelp :: Maybe SignatureHelp }
- deriving (Show,Eq)
-
-data SignatureInformation = SignatureInformation { signatureInformationLabel :: String
-                                                 , signatureInformationDocumentation :: Maybe (Either String MarkupContent)
-                                                 , signatureInformationParameters :: Maybe [ParameterInformation]
-                                                 , signatureInformationActiveParameter :: Maybe (Either Int ()) }
- deriving (Show,Eq)
-
-data SignatureHelpOptions = SignatureHelpOptions { signatureHelpOptionsTriggerCharacters :: Maybe [String]
-                                                 , signatureHelpOptionsRetriggerCharacters :: Maybe [String] }
- deriving (Show,Eq)
-
-data DefinitionOptions = DefinitionOptions {  }
- deriving (Show,Eq)
-
-data ReferenceContext = ReferenceContext { referenceContextIncludeDeclaration :: Bool }
- deriving (Show,Eq)
-
-data ReferenceOptions = ReferenceOptions {  }
- deriving (Show,Eq)
-
-data DocumentHighlightOptions = DocumentHighlightOptions {  }
- deriving (Show,Eq)
-
-data BaseSymbolInformation = BaseSymbolInformation { baseSymbolInformationName :: String
-                                                   , baseSymbolInformationKind :: SymbolKind
-                                                   , baseSymbolInformationTags :: Maybe [SymbolTag]
-                                                   , baseSymbolInformationContainerName :: Maybe String }
- deriving (Show,Eq)
-
-data DocumentSymbolOptions = DocumentSymbolOptions { documentSymbolOptionsLabel :: Maybe String }
- deriving (Show,Eq)
-
-data CodeActionContext = CodeActionContext { codeActionContextDiagnostics :: [Diagnostic]
-                                           , codeActionContextOnly :: Maybe [CodeActionKind]
-                                           , codeActionContextTriggerKind :: Maybe CodeActionTriggerKind }
- deriving (Show,Eq)
-
-data CodeActionDisabled = CodeActionDisabled { codeActionDisabledReason :: String }
- deriving (Show,Eq)
-
-data CodeActionOptions = CodeActionOptions { codeActionOptionsCodeActionKinds :: Maybe [CodeActionKind]
-                                           , codeActionOptionsDocumentation :: Maybe [CodeActionKindDocumentation]
-                                           , codeActionOptionsResolveProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data LocationUriOnly = LocationUriOnly { locationUriOnlyUri :: DocumentUri }
- deriving (Show,Eq)
-
-data WorkspaceSymbolOptions = WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data CodeLensOptions = CodeLensOptions { codeLensOptionsResolveProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentLinkOptions = DocumentLinkOptions { documentLinkOptionsResolveProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data FormattingOptions = FormattingOptions { formattingOptionsTabSize :: Int
-                                           , formattingOptionsInsertSpaces :: Bool
-                                           , formattingOptionsTrimTrailingWhitespace :: Maybe Bool
-                                           , formattingOptionsInsertFinalNewline :: Maybe Bool
-                                           , formattingOptionsTrimFinalNewlines :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentFormattingOptions = DocumentFormattingOptions {  }
- deriving (Show,Eq)
-
-data DocumentRangeFormattingOptions = DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentOnTypeFormattingOptions = DocumentOnTypeFormattingOptions { documentOnTypeFormattingOptionsFirstTriggerCharacter :: String
-                                                                       , documentOnTypeFormattingOptionsMoreTriggerCharacter :: Maybe [String] }
- deriving (Show,Eq)
-
-data RenameOptions = RenameOptions { renameOptionsPrepareProvider :: Maybe Bool }
- deriving (Show,Eq)
-
-data PrepareRenamePlaceholder = PrepareRenamePlaceholder { prepareRenamePlaceholderRange :: Range
-                                                         , prepareRenamePlaceholderPlaceholder :: String }
- deriving (Show,Eq)
-
-data PrepareRenameDefaultBehavior = PrepareRenameDefaultBehavior { prepareRenameDefaultBehaviorDefaultBehavior :: Bool }
- deriving (Show,Eq)
-
-data ExecuteCommandOptions = ExecuteCommandOptions { executeCommandOptionsCommands :: [String] }
- deriving (Show,Eq)
-
-data WorkspaceEditMetadata = WorkspaceEditMetadata { workspaceEditMetadataIsRefactoring :: Maybe Bool }
- deriving (Show,Eq)
-
-data SemanticTokensLegend = SemanticTokensLegend { semanticTokensLegendTokenTypes :: [String]
-                                                 , semanticTokensLegendTokenModifiers :: [String] }
- deriving (Show,Eq)
-
-data SemanticTokensFullDelta = SemanticTokensFullDelta { semanticTokensFullDeltaDelta :: Maybe Bool }
- deriving (Show,Eq)
-
-data OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion :: Either Int () }
- deriving (Show,Eq)
-
-data AnnotatedTextEdit = AnnotatedTextEdit { annotatedTextEditAnnotationId :: ChangeAnnotationIdentifier }
- deriving (Show,Eq)
-
-data SnippetTextEdit = SnippetTextEdit { snippetTextEditRange :: Range
-                                       , snippetTextEditSnippet :: StringValue
-                                       , snippetTextEditAnnotationId :: Maybe ChangeAnnotationIdentifier }
- deriving (Show,Eq)
-
-data ResourceOperation = ResourceOperation { resourceOperationKind :: String
-                                           , resourceOperationAnnotationId :: Maybe ChangeAnnotationIdentifier }
- deriving (Show,Eq)
-
-data CreateFileOptions = CreateFileOptions { createFileOptionsOverwrite :: Maybe Bool
-                                           , createFileOptionsIgnoreIfExists :: Maybe Bool }
- deriving (Show,Eq)
-
-data RenameFileOptions = RenameFileOptions { renameFileOptionsOverwrite :: Maybe Bool
-                                           , renameFileOptionsIgnoreIfExists :: Maybe Bool }
- deriving (Show,Eq)
-
-data DeleteFileOptions = DeleteFileOptions { deleteFileOptionsRecursive :: Maybe Bool
-                                           , deleteFileOptionsIgnoreIfNotExists :: Maybe Bool }
- deriving (Show,Eq)
-
-data FileOperationPattern = FileOperationPattern { fileOperationPatternGlob :: String
-                                                 , fileOperationPatternMatches :: Maybe FileOperationPatternKind
-                                                 , fileOperationPatternOptions :: Maybe FileOperationPatternOptions }
- deriving (Show,Eq)
-
-data WorkspaceFullDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri :: DocumentUri
-                                                                                   , workspaceFullDocumentDiagnosticReportVersion :: Either Int () }
- deriving (Show,Eq)
-
-data WorkspaceUnchangedDocumentDiagnosticReport = WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri :: DocumentUri
-                                                                                             , workspaceUnchangedDocumentDiagnosticReportVersion :: Either Int () }
- deriving (Show,Eq)
-
-data NotebookCell = NotebookCell { notebookCellKind :: NotebookCellKind
-                                 , notebookCellDocument :: DocumentUri
-                                 , notebookCellMetadata :: Maybe LSPObject
-                                 , notebookCellExecutionSummary :: Maybe ExecutionSummary }
- deriving (Show,Eq)
-
-data NotebookDocumentFilterWithNotebook = NotebookDocumentFilterWithNotebook { notebookDocumentFilterWithNotebookNotebook :: Either String NotebookDocumentFilter
-                                                                             , notebookDocumentFilterWithNotebookCells :: Maybe [NotebookCellLanguage] }
- deriving (Show,Eq)
-
-data NotebookDocumentFilterWithCells = NotebookDocumentFilterWithCells { notebookDocumentFilterWithCellsNotebook :: Maybe (Either String NotebookDocumentFilter)
-                                                                       , notebookDocumentFilterWithCellsCells :: [NotebookCellLanguage] }
- deriving (Show,Eq)
-
-data NotebookDocumentCellChanges = NotebookDocumentCellChanges { notebookDocumentCellChangesStructure :: Maybe NotebookDocumentCellChangeStructure
-                                                               , notebookDocumentCellChangesData :: Maybe [NotebookCell]
-                                                               , notebookDocumentCellChangesTextContent :: Maybe [NotebookDocumentCellContentChanges] }
- deriving (Show,Eq)
-
-data SelectedCompletionInfo = SelectedCompletionInfo { selectedCompletionInfoRange :: Range
-                                                     , selectedCompletionInfoText :: String }
- deriving (Show,Eq)
-
-data ClientInfo = ClientInfo { clientInfoName :: String
-                             , clientInfoVersion :: Maybe String }
- deriving (Show,Eq)
-
-data ClientCapabilities = ClientCapabilities { clientCapabilitiesWorkspace :: Maybe WorkspaceClientCapabilities
-                                             , clientCapabilitiesTextDocument :: Maybe TextDocumentClientCapabilities
-                                             , clientCapabilitiesNotebookDocument :: Maybe NotebookDocumentClientCapabilities
-                                             , clientCapabilitiesWindow :: Maybe WindowClientCapabilities
-                                             , clientCapabilitiesGeneral :: Maybe GeneralClientCapabilities
-                                             , clientCapabilitiesExperimental :: Maybe LSPAny }
- deriving (Show,Eq)
-
-data TextDocumentSyncOptions = TextDocumentSyncOptions { textDocumentSyncOptionsOpenClose :: Maybe Bool
-                                                       , textDocumentSyncOptionsChange :: Maybe TextDocumentSyncKind
-                                                       , textDocumentSyncOptionsWillSave :: Maybe Bool
-                                                       , textDocumentSyncOptionsWillSaveWaitUntil :: Maybe Bool
-                                                       , textDocumentSyncOptionsSave :: Maybe (Either Bool SaveOptions) }
- deriving (Show,Eq)
-
-data WorkspaceOptions = WorkspaceOptions { workspaceOptionsWorkspaceFolders :: Maybe WorkspaceFoldersServerCapabilities
-                                         , workspaceOptionsFileOperations :: Maybe FileOperationOptions }
- deriving (Show,Eq)
-
-data TextDocumentContentChangePartial = TextDocumentContentChangePartial { textDocumentContentChangePartialRange :: Range
-                                                                         , textDocumentContentChangePartialRangeLength :: Maybe Int
-                                                                         , textDocumentContentChangePartialText :: String }
- deriving (Show,Eq)
-
-data TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument { textDocumentContentChangeWholeDocumentText :: String }
- deriving (Show,Eq)
-
-data CodeDescription = CodeDescription { codeDescriptionHref :: Uri }
- deriving (Show,Eq)
-
-data DiagnosticRelatedInformation = DiagnosticRelatedInformation { diagnosticRelatedInformationLocation :: Location
-                                                                 , diagnosticRelatedInformationMessage :: String }
- deriving (Show,Eq)
-
-data EditRangeWithInsertReplace = EditRangeWithInsertReplace { editRangeWithInsertReplaceInsert :: Range
-                                                             , editRangeWithInsertReplaceReplace :: Range }
- deriving (Show,Eq)
-
-data ServerCompletionItemOptions = ServerCompletionItemOptions { serverCompletionItemOptionsLabelDetailsSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data MarkedStringWithLanguage = MarkedStringWithLanguage { markedStringWithLanguageLanguage :: String
-                                                         , markedStringWithLanguageValue :: String }
- deriving (Show,Eq)
-
-data ParameterInformation = ParameterInformation { parameterInformationLabel :: Either String (Int
-                                                                                              ,Int)
-                                                 , parameterInformationDocumentation :: Maybe (Either String MarkupContent) }
- deriving (Show,Eq)
-
-data CodeActionKindDocumentation = CodeActionKindDocumentation { codeActionKindDocumentationKind :: CodeActionKind
-                                                               , codeActionKindDocumentationCommand :: Command }
- deriving (Show,Eq)
-
-data NotebookCellTextDocumentFilter = NotebookCellTextDocumentFilter { notebookCellTextDocumentFilterNotebook :: Either String NotebookDocumentFilter
-                                                                     , notebookCellTextDocumentFilterLanguage :: Maybe String }
- deriving (Show,Eq)
-
-data FileOperationPatternOptions = FileOperationPatternOptions { fileOperationPatternOptionsIgnoreCase :: Maybe Bool }
- deriving (Show,Eq)
-
-data ExecutionSummary = ExecutionSummary { executionSummaryExecutionOrder :: Int
-                                         , executionSummarySuccess :: Maybe Bool }
- deriving (Show,Eq)
-
-data NotebookCellLanguage = NotebookCellLanguage { notebookCellLanguageLanguage :: String }
- deriving (Show,Eq)
-
-data NotebookDocumentCellChangeStructure = NotebookDocumentCellChangeStructure { notebookDocumentCellChangeStructureArray :: NotebookCellArrayChange
-                                                                               , notebookDocumentCellChangeStructureDidOpen :: Maybe [TextDocumentItem]
-                                                                               , notebookDocumentCellChangeStructureDidClose :: Maybe [TextDocumentIdentifier] }
- deriving (Show,Eq)
-
-data NotebookDocumentCellContentChanges = NotebookDocumentCellContentChanges { notebookDocumentCellContentChangesDocument :: VersionedTextDocumentIdentifier
-                                                                             , notebookDocumentCellContentChangesChanges :: [TextDocumentContentChangeEvent] }
- deriving (Show,Eq)
-
-data WorkspaceClientCapabilities = WorkspaceClientCapabilities { workspaceClientCapabilitiesApplyEdit :: Maybe Bool
-                                                               , workspaceClientCapabilitiesWorkspaceEdit :: Maybe WorkspaceEditClientCapabilities
-                                                               , workspaceClientCapabilitiesDidChangeConfiguration :: Maybe DidChangeConfigurationClientCapabilities
-                                                               , workspaceClientCapabilitiesDidChangeWatchedFiles :: Maybe DidChangeWatchedFilesClientCapabilities
-                                                               , workspaceClientCapabilitiesSymbol :: Maybe WorkspaceSymbolClientCapabilities
-                                                               , workspaceClientCapabilitiesExecuteCommand :: Maybe ExecuteCommandClientCapabilities
-                                                               , workspaceClientCapabilitiesWorkspaceFolders :: Maybe Bool
-                                                               , workspaceClientCapabilitiesConfiguration :: Maybe Bool
-                                                               , workspaceClientCapabilitiesSemanticTokens :: Maybe SemanticTokensWorkspaceClientCapabilities
-                                                               , workspaceClientCapabilitiesCodeLens :: Maybe CodeLensWorkspaceClientCapabilities
-                                                               , workspaceClientCapabilitiesFileOperations :: Maybe FileOperationClientCapabilities
-                                                               , workspaceClientCapabilitiesInlineValue :: Maybe InlineValueWorkspaceClientCapabilities
-                                                               , workspaceClientCapabilitiesInlayHint :: Maybe InlayHintWorkspaceClientCapabilities
-                                                               , workspaceClientCapabilitiesDiagnostics :: Maybe DiagnosticWorkspaceClientCapabilities
-                                                               , workspaceClientCapabilitiesFoldingRange :: Maybe FoldingRangeWorkspaceClientCapabilities }
- deriving (Show,Eq)
-
-data TextDocumentClientCapabilities = TextDocumentClientCapabilities { textDocumentClientCapabilitiesSynchronization :: Maybe TextDocumentSyncClientCapabilities
-                                                                     , textDocumentClientCapabilitiesCompletion :: Maybe CompletionClientCapabilities
-                                                                     , textDocumentClientCapabilitiesHover :: Maybe HoverClientCapabilities
-                                                                     , textDocumentClientCapabilitiesSignatureHelp :: Maybe SignatureHelpClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDeclaration :: Maybe DeclarationClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDefinition :: Maybe DefinitionClientCapabilities
-                                                                     , textDocumentClientCapabilitiesTypeDefinition :: Maybe TypeDefinitionClientCapabilities
-                                                                     , textDocumentClientCapabilitiesImplementation :: Maybe ImplementationClientCapabilities
-                                                                     , textDocumentClientCapabilitiesReferences :: Maybe ReferenceClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDocumentHighlight :: Maybe DocumentHighlightClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDocumentSymbol :: Maybe DocumentSymbolClientCapabilities
-                                                                     , textDocumentClientCapabilitiesCodeAction :: Maybe CodeActionClientCapabilities
-                                                                     , textDocumentClientCapabilitiesCodeLens :: Maybe CodeLensClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDocumentLink :: Maybe DocumentLinkClientCapabilities
-                                                                     , textDocumentClientCapabilitiesColorProvider :: Maybe DocumentColorClientCapabilities
-                                                                     , textDocumentClientCapabilitiesFormatting :: Maybe DocumentFormattingClientCapabilities
-                                                                     , textDocumentClientCapabilitiesRangeFormatting :: Maybe DocumentRangeFormattingClientCapabilities
-                                                                     , textDocumentClientCapabilitiesOnTypeFormatting :: Maybe DocumentOnTypeFormattingClientCapabilities
-                                                                     , textDocumentClientCapabilitiesRename :: Maybe RenameClientCapabilities
-                                                                     , textDocumentClientCapabilitiesFoldingRange :: Maybe FoldingRangeClientCapabilities
-                                                                     , textDocumentClientCapabilitiesSelectionRange :: Maybe SelectionRangeClientCapabilities
-                                                                     , textDocumentClientCapabilitiesPublishDiagnostics :: Maybe PublishDiagnosticsClientCapabilities
-                                                                     , textDocumentClientCapabilitiesCallHierarchy :: Maybe CallHierarchyClientCapabilities
-                                                                     , textDocumentClientCapabilitiesSemanticTokens :: Maybe SemanticTokensClientCapabilities
-                                                                     , textDocumentClientCapabilitiesLinkedEditingRange :: Maybe LinkedEditingRangeClientCapabilities
-                                                                     , textDocumentClientCapabilitiesMoniker :: Maybe MonikerClientCapabilities
-                                                                     , textDocumentClientCapabilitiesTypeHierarchy :: Maybe TypeHierarchyClientCapabilities
-                                                                     , textDocumentClientCapabilitiesInlineValue :: Maybe InlineValueClientCapabilities
-                                                                     , textDocumentClientCapabilitiesInlayHint :: Maybe InlayHintClientCapabilities
-                                                                     , textDocumentClientCapabilitiesDiagnostic :: Maybe DiagnosticClientCapabilities
-                                                                     , textDocumentClientCapabilitiesInlineCompletion :: Maybe InlineCompletionClientCapabilities }
- deriving (Show,Eq)
-
-data NotebookDocumentClientCapabilities = NotebookDocumentClientCapabilities { notebookDocumentClientCapabilitiesSynchronization :: NotebookDocumentSyncClientCapabilities }
- deriving (Show,Eq)
-
-data WindowClientCapabilities = WindowClientCapabilities { windowClientCapabilitiesWorkDoneProgress :: Maybe Bool
-                                                         , windowClientCapabilitiesShowMessage :: Maybe ShowMessageRequestClientCapabilities
-                                                         , windowClientCapabilitiesShowDocument :: Maybe ShowDocumentClientCapabilities }
- deriving (Show,Eq)
-
-data GeneralClientCapabilities = GeneralClientCapabilities { generalClientCapabilitiesStaleRequestSupport :: Maybe StaleRequestSupportOptions
-                                                           , generalClientCapabilitiesRegularExpressions :: Maybe RegularExpressionsClientCapabilities
-                                                           , generalClientCapabilitiesMarkdown :: Maybe MarkdownClientCapabilities
-                                                           , generalClientCapabilitiesPositionEncodings :: Maybe [PositionEncodingKind] }
- deriving (Show,Eq)
-
-data WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities { workspaceFoldersServerCapabilitiesSupported :: Maybe Bool
-                                                                             , workspaceFoldersServerCapabilitiesChangeNotifications :: Maybe (Either String Bool) }
- deriving (Show,Eq)
-
-data FileOperationOptions = FileOperationOptions { fileOperationOptionsDidCreate :: Maybe FileOperationRegistrationOptions
-                                                 , fileOperationOptionsWillCreate :: Maybe FileOperationRegistrationOptions
-                                                 , fileOperationOptionsDidRename :: Maybe FileOperationRegistrationOptions
-                                                 , fileOperationOptionsWillRename :: Maybe FileOperationRegistrationOptions
-                                                 , fileOperationOptionsDidDelete :: Maybe FileOperationRegistrationOptions
-                                                 , fileOperationOptionsWillDelete :: Maybe FileOperationRegistrationOptions }
- deriving (Show,Eq)
-
-data RelativePattern = RelativePattern { relativePatternBaseUri :: Either WorkspaceFolder Uri
-                                       , relativePatternPattern :: Pattern }
- deriving (Show,Eq)
-
-data TextDocumentFilterLanguage = TextDocumentFilterLanguage { textDocumentFilterLanguageLanguage :: String
-                                                             , textDocumentFilterLanguageScheme :: Maybe String
-                                                             , textDocumentFilterLanguagePattern :: Maybe GlobPattern }
- deriving (Show,Eq)
-
-data TextDocumentFilterScheme = TextDocumentFilterScheme { textDocumentFilterSchemeLanguage :: Maybe String
-                                                         , textDocumentFilterSchemeScheme :: String
-                                                         , textDocumentFilterSchemePattern :: Maybe GlobPattern }
- deriving (Show,Eq)
-
-data TextDocumentFilterPattern = TextDocumentFilterPattern { textDocumentFilterPatternLanguage :: Maybe String
-                                                           , textDocumentFilterPatternScheme :: Maybe String
-                                                           , textDocumentFilterPatternPattern :: GlobPattern }
- deriving (Show,Eq)
-
-data NotebookDocumentFilterNotebookType = NotebookDocumentFilterNotebookType { notebookDocumentFilterNotebookTypeNotebookType :: String
-                                                                             , notebookDocumentFilterNotebookTypeScheme :: Maybe String
-                                                                             , notebookDocumentFilterNotebookTypePattern :: Maybe GlobPattern }
- deriving (Show,Eq)
-
-data NotebookDocumentFilterScheme = NotebookDocumentFilterScheme { notebookDocumentFilterSchemeNotebookType :: Maybe String
-                                                                 , notebookDocumentFilterSchemeScheme :: String
-                                                                 , notebookDocumentFilterSchemePattern :: Maybe GlobPattern }
- deriving (Show,Eq)
-
-data NotebookDocumentFilterPattern = NotebookDocumentFilterPattern { notebookDocumentFilterPatternNotebookType :: Maybe String
-                                                                   , notebookDocumentFilterPatternScheme :: Maybe String
-                                                                   , notebookDocumentFilterPatternPattern :: GlobPattern }
- deriving (Show,Eq)
-
-data NotebookCellArrayChange = NotebookCellArrayChange { notebookCellArrayChangeStart :: Int
-                                                       , notebookCellArrayChangeDeleteCount :: Int
-                                                       , notebookCellArrayChangeCells :: Maybe [NotebookCell] }
- deriving (Show,Eq)
-
-data WorkspaceEditClientCapabilities = WorkspaceEditClientCapabilities { workspaceEditClientCapabilitiesDocumentChanges :: Maybe Bool
-                                                                       , workspaceEditClientCapabilitiesResourceOperations :: Maybe [ResourceOperationKind]
-                                                                       , workspaceEditClientCapabilitiesFailureHandling :: Maybe FailureHandlingKind
-                                                                       , workspaceEditClientCapabilitiesNormalizesLineEndings :: Maybe Bool
-                                                                       , workspaceEditClientCapabilitiesChangeAnnotationSupport :: Maybe ChangeAnnotationsSupportOptions
-                                                                       , workspaceEditClientCapabilitiesMetadataSupport :: Maybe Bool
-                                                                       , workspaceEditClientCapabilitiesSnippetEditSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DidChangeConfigurationClientCapabilities = DidChangeConfigurationClientCapabilities { didChangeConfigurationClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data DidChangeWatchedFilesClientCapabilities = DidChangeWatchedFilesClientCapabilities { didChangeWatchedFilesClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                                       , didChangeWatchedFilesClientCapabilitiesRelativePatternSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data WorkspaceSymbolClientCapabilities = WorkspaceSymbolClientCapabilities { workspaceSymbolClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                           , workspaceSymbolClientCapabilitiesSymbolKind :: Maybe ClientSymbolKindOptions
-                                                                           , workspaceSymbolClientCapabilitiesTagSupport :: Maybe ClientSymbolTagOptions
-                                                                           , workspaceSymbolClientCapabilitiesResolveSupport :: Maybe ClientSymbolResolveOptions }
- deriving (Show,Eq)
-
-data ExecuteCommandClientCapabilities = ExecuteCommandClientCapabilities { executeCommandClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data SemanticTokensWorkspaceClientCapabilities = SemanticTokensWorkspaceClientCapabilities { semanticTokensWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data CodeLensWorkspaceClientCapabilities = CodeLensWorkspaceClientCapabilities { codeLensWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data FileOperationClientCapabilities = FileOperationClientCapabilities { fileOperationClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesDidCreate :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesWillCreate :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesDidRename :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesWillRename :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesDidDelete :: Maybe Bool
-                                                                       , fileOperationClientCapabilitiesWillDelete :: Maybe Bool }
- deriving (Show,Eq)
-
-data InlineValueWorkspaceClientCapabilities = InlineValueWorkspaceClientCapabilities { inlineValueWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data InlayHintWorkspaceClientCapabilities = InlayHintWorkspaceClientCapabilities { inlayHintWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DiagnosticWorkspaceClientCapabilities = DiagnosticWorkspaceClientCapabilities { diagnosticWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data FoldingRangeWorkspaceClientCapabilities = FoldingRangeWorkspaceClientCapabilities { foldingRangeWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data TextDocumentSyncClientCapabilities = TextDocumentSyncClientCapabilities { textDocumentSyncClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                             , textDocumentSyncClientCapabilitiesWillSave :: Maybe Bool
-                                                                             , textDocumentSyncClientCapabilitiesWillSaveWaitUntil :: Maybe Bool
-                                                                             , textDocumentSyncClientCapabilitiesDidSave :: Maybe Bool }
- deriving (Show,Eq)
-
-data CompletionClientCapabilities = CompletionClientCapabilities { completionClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                 , completionClientCapabilitiesCompletionItem :: Maybe ClientCompletionItemOptions
-                                                                 , completionClientCapabilitiesCompletionItemKind :: Maybe ClientCompletionItemOptionsKind
-                                                                 , completionClientCapabilitiesInsertTextMode :: Maybe InsertTextMode
-                                                                 , completionClientCapabilitiesContextSupport :: Maybe Bool
-                                                                 , completionClientCapabilitiesCompletionList :: Maybe CompletionListCapabilities }
- deriving (Show,Eq)
-
-data HoverClientCapabilities = HoverClientCapabilities { hoverClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                       , hoverClientCapabilitiesContentFormat :: Maybe [MarkupKind] }
- deriving (Show,Eq)
-
-data SignatureHelpClientCapabilities = SignatureHelpClientCapabilities { signatureHelpClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                       , signatureHelpClientCapabilitiesSignatureInformation :: Maybe ClientSignatureInformationOptions
-                                                                       , signatureHelpClientCapabilitiesContextSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DeclarationClientCapabilities = DeclarationClientCapabilities { declarationClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                   , declarationClientCapabilitiesLinkSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DefinitionClientCapabilities = DefinitionClientCapabilities { definitionClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                 , definitionClientCapabilitiesLinkSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data TypeDefinitionClientCapabilities = TypeDefinitionClientCapabilities { typeDefinitionClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                         , typeDefinitionClientCapabilitiesLinkSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ImplementationClientCapabilities = ImplementationClientCapabilities { implementationClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                         , implementationClientCapabilitiesLinkSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ReferenceClientCapabilities = ReferenceClientCapabilities { referenceClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentHighlightClientCapabilities = DocumentHighlightClientCapabilities { documentHighlightClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentSymbolClientCapabilities = DocumentSymbolClientCapabilities { documentSymbolClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                         , documentSymbolClientCapabilitiesSymbolKind :: Maybe ClientSymbolKindOptions
-                                                                         , documentSymbolClientCapabilitiesHierarchicalDocumentSymbolSupport :: Maybe Bool
-                                                                         , documentSymbolClientCapabilitiesTagSupport :: Maybe ClientSymbolTagOptions
-                                                                         , documentSymbolClientCapabilitiesLabelSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data CodeActionClientCapabilities = CodeActionClientCapabilities { codeActionClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                 , codeActionClientCapabilitiesCodeActionLiteralSupport :: Maybe ClientCodeActionLiteralOptions
-                                                                 , codeActionClientCapabilitiesIsPreferredSupport :: Maybe Bool
-                                                                 , codeActionClientCapabilitiesDisabledSupport :: Maybe Bool
-                                                                 , codeActionClientCapabilitiesDataSupport :: Maybe Bool
-                                                                 , codeActionClientCapabilitiesResolveSupport :: Maybe ClientCodeActionResolveOptions
-                                                                 , codeActionClientCapabilitiesHonorsChangeAnnotations :: Maybe Bool
-                                                                 , codeActionClientCapabilitiesDocumentationSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data CodeLensClientCapabilities = CodeLensClientCapabilities { codeLensClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                             , codeLensClientCapabilitiesResolveSupport :: Maybe ClientCodeLensResolveOptions }
- deriving (Show,Eq)
-
-data DocumentLinkClientCapabilities = DocumentLinkClientCapabilities { documentLinkClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                     , documentLinkClientCapabilitiesTooltipSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentColorClientCapabilities = DocumentColorClientCapabilities { documentColorClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentFormattingClientCapabilities = DocumentFormattingClientCapabilities { documentFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentRangeFormattingClientCapabilities = DocumentRangeFormattingClientCapabilities { documentRangeFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                                           , documentRangeFormattingClientCapabilitiesRangesSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data DocumentOnTypeFormattingClientCapabilities = DocumentOnTypeFormattingClientCapabilities { documentOnTypeFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data RenameClientCapabilities = RenameClientCapabilities { renameClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                         , renameClientCapabilitiesPrepareSupport :: Maybe Bool
-                                                         , renameClientCapabilitiesPrepareSupportDefaultBehavior :: Maybe PrepareSupportDefaultBehavior
-                                                         , renameClientCapabilitiesHonorsChangeAnnotations :: Maybe Bool }
- deriving (Show,Eq)
-
-data FoldingRangeClientCapabilities = FoldingRangeClientCapabilities { foldingRangeClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                     , foldingRangeClientCapabilitiesRangeLimit :: Maybe Int
-                                                                     , foldingRangeClientCapabilitiesLineFoldingOnly :: Maybe Bool
-                                                                     , foldingRangeClientCapabilitiesFoldingRangeKind :: Maybe ClientFoldingRangeKindOptions
-                                                                     , foldingRangeClientCapabilitiesFoldingRange :: Maybe ClientFoldingRangeOptions }
- deriving (Show,Eq)
-
-data SelectionRangeClientCapabilities = SelectionRangeClientCapabilities { selectionRangeClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data CallHierarchyClientCapabilities = CallHierarchyClientCapabilities { callHierarchyClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data SemanticTokensClientCapabilities = SemanticTokensClientCapabilities { semanticTokensClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                         , semanticTokensClientCapabilitiesRequests :: ClientSemanticTokensRequestOptions
-                                                                         , semanticTokensClientCapabilitiesTokenTypes :: [String]
-                                                                         , semanticTokensClientCapabilitiesTokenModifiers :: [String]
-                                                                         , semanticTokensClientCapabilitiesFormats :: [TokenFormat]
-                                                                         , semanticTokensClientCapabilitiesOverlappingTokenSupport :: Maybe Bool
-                                                                         , semanticTokensClientCapabilitiesMultilineTokenSupport :: Maybe Bool
-                                                                         , semanticTokensClientCapabilitiesServerCancelSupport :: Maybe Bool
-                                                                         , semanticTokensClientCapabilitiesAugmentsSyntaxTokens :: Maybe Bool }
- deriving (Show,Eq)
-
-data LinkedEditingRangeClientCapabilities = LinkedEditingRangeClientCapabilities { linkedEditingRangeClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data MonikerClientCapabilities = MonikerClientCapabilities { monikerClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data TypeHierarchyClientCapabilities = TypeHierarchyClientCapabilities { typeHierarchyClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data InlineValueClientCapabilities = InlineValueClientCapabilities { inlineValueClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data InlayHintClientCapabilities = InlayHintClientCapabilities { inlayHintClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                               , inlayHintClientCapabilitiesResolveSupport :: Maybe ClientInlayHintResolveOptions }
- deriving (Show,Eq)
-
-data DiagnosticClientCapabilities = DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                 , diagnosticClientCapabilitiesRelatedDocumentSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data InlineCompletionClientCapabilities = InlineCompletionClientCapabilities { inlineCompletionClientCapabilitiesDynamicRegistration :: Maybe Bool }
- deriving (Show,Eq)
-
-data NotebookDocumentSyncClientCapabilities = NotebookDocumentSyncClientCapabilities { notebookDocumentSyncClientCapabilitiesDynamicRegistration :: Maybe Bool
-                                                                                     , notebookDocumentSyncClientCapabilitiesExecutionSummarySupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ShowMessageRequestClientCapabilities = ShowMessageRequestClientCapabilities { showMessageRequestClientCapabilitiesMessageActionItem :: Maybe ClientShowMessageActionItemOptions }
- deriving (Show,Eq)
-
-data ShowDocumentClientCapabilities = ShowDocumentClientCapabilities { showDocumentClientCapabilitiesSupport :: Bool }
- deriving (Show,Eq)
-
-data StaleRequestSupportOptions = StaleRequestSupportOptions { staleRequestSupportOptionsCancel :: Bool
-                                                             , staleRequestSupportOptionsRetryOnContentModified :: [String] }
- deriving (Show,Eq)
-
-data RegularExpressionsClientCapabilities = RegularExpressionsClientCapabilities { regularExpressionsClientCapabilitiesEngine :: RegularExpressionEngineKind
-                                                                                 , regularExpressionsClientCapabilitiesVersion :: Maybe String }
- deriving (Show,Eq)
-
-data MarkdownClientCapabilities = MarkdownClientCapabilities { markdownClientCapabilitiesParser :: String
-                                                             , markdownClientCapabilitiesVersion :: Maybe String
-                                                             , markdownClientCapabilitiesAllowedTags :: Maybe [String] }
- deriving (Show,Eq)
-
-data ChangeAnnotationsSupportOptions = ChangeAnnotationsSupportOptions { changeAnnotationsSupportOptionsGroupsOnLabel :: Maybe Bool }
- deriving (Show,Eq)
-
-data ClientSymbolKindOptions = ClientSymbolKindOptions { clientSymbolKindOptionsValueSet :: Maybe [SymbolKind] }
- deriving (Show,Eq)
-
-data ClientSymbolTagOptions = ClientSymbolTagOptions { clientSymbolTagOptionsValueSet :: [SymbolTag] }
- deriving (Show,Eq)
-
-data ClientSymbolResolveOptions = ClientSymbolResolveOptions { clientSymbolResolveOptionsProperties :: [String] }
- deriving (Show,Eq)
-
-data ClientCompletionItemOptions = ClientCompletionItemOptions { clientCompletionItemOptionsSnippetSupport :: Maybe Bool
-                                                               , clientCompletionItemOptionsCommitCharactersSupport :: Maybe Bool
-                                                               , clientCompletionItemOptionsDocumentationFormat :: Maybe [MarkupKind]
-                                                               , clientCompletionItemOptionsDeprecatedSupport :: Maybe Bool
-                                                               , clientCompletionItemOptionsPreselectSupport :: Maybe Bool
-                                                               , clientCompletionItemOptionsTagSupport :: Maybe CompletionItemTagOptions
-                                                               , clientCompletionItemOptionsInsertReplaceSupport :: Maybe Bool
-                                                               , clientCompletionItemOptionsResolveSupport :: Maybe ClientCompletionItemResolveOptions
-                                                               , clientCompletionItemOptionsInsertTextModeSupport :: Maybe ClientCompletionItemInsertTextModeOptions
-                                                               , clientCompletionItemOptionsLabelDetailsSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ClientCompletionItemOptionsKind = ClientCompletionItemOptionsKind { clientCompletionItemOptionsKindValueSet :: Maybe [CompletionItemKind] }
- deriving (Show,Eq)
-
-data CompletionListCapabilities = CompletionListCapabilities { completionListCapabilitiesItemDefaults :: Maybe [String] }
- deriving (Show,Eq)
-
-data ClientSignatureInformationOptions = ClientSignatureInformationOptions { clientSignatureInformationOptionsDocumentationFormat :: Maybe [MarkupKind]
-                                                                           , clientSignatureInformationOptionsParameterInformation :: Maybe ClientSignatureParameterInformationOptions
-                                                                           , clientSignatureInformationOptionsActiveParameterSupport :: Maybe Bool
-                                                                           , clientSignatureInformationOptionsNoActiveParameterSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ClientCodeActionLiteralOptions = ClientCodeActionLiteralOptions { clientCodeActionLiteralOptionsCodeActionKind :: ClientCodeActionKindOptions }
- deriving (Show,Eq)
-
-data ClientCodeActionResolveOptions = ClientCodeActionResolveOptions { clientCodeActionResolveOptionsProperties :: [String] }
- deriving (Show,Eq)
-
-data ClientCodeLensResolveOptions = ClientCodeLensResolveOptions { clientCodeLensResolveOptionsProperties :: [String] }
- deriving (Show,Eq)
-
-data ClientFoldingRangeKindOptions = ClientFoldingRangeKindOptions { clientFoldingRangeKindOptionsValueSet :: Maybe [FoldingRangeKind] }
- deriving (Show,Eq)
-
-data ClientFoldingRangeOptions = ClientFoldingRangeOptions { clientFoldingRangeOptionsCollapsedText :: Maybe Bool }
- deriving (Show,Eq)
-
-data DiagnosticsCapabilities = DiagnosticsCapabilities { diagnosticsCapabilitiesRelatedInformation :: Maybe Bool
-                                                       , diagnosticsCapabilitiesTagSupport :: Maybe ClientDiagnosticsTagOptions
-                                                       , diagnosticsCapabilitiesCodeDescriptionSupport :: Maybe Bool
-                                                       , diagnosticsCapabilitiesDataSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ClientSemanticTokensRequestOptions = ClientSemanticTokensRequestOptions { clientSemanticTokensRequestOptionsRange :: Maybe (Either Bool ())
-                                                                             , clientSemanticTokensRequestOptionsFull :: Maybe (Either Bool ClientSemanticTokensRequestFullDelta) }
- deriving (Show,Eq)
-
-data ClientInlayHintResolveOptions = ClientInlayHintResolveOptions { clientInlayHintResolveOptionsProperties :: [String] }
- deriving (Show,Eq)
-
-data ClientShowMessageActionItemOptions = ClientShowMessageActionItemOptions { clientShowMessageActionItemOptionsAdditionalPropertiesSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data CompletionItemTagOptions = CompletionItemTagOptions { completionItemTagOptionsValueSet :: [CompletionItemTag] }
- deriving (Show,Eq)
-
-data ClientCompletionItemResolveOptions = ClientCompletionItemResolveOptions { clientCompletionItemResolveOptionsProperties :: [String] }
- deriving (Show,Eq)
-
-data ClientCompletionItemInsertTextModeOptions = ClientCompletionItemInsertTextModeOptions { clientCompletionItemInsertTextModeOptionsValueSet :: [InsertTextMode] }
- deriving (Show,Eq)
-
-data ClientSignatureParameterInformationOptions = ClientSignatureParameterInformationOptions { clientSignatureParameterInformationOptionsLabelOffsetSupport :: Maybe Bool }
- deriving (Show,Eq)
-
-data ClientCodeActionKindOptions = ClientCodeActionKindOptions { clientCodeActionKindOptionsValueSet :: [CodeActionKind] }
- deriving (Show,Eq)
-
-data ClientDiagnosticsTagOptions = ClientDiagnosticsTagOptions { clientDiagnosticsTagOptionsValueSet :: [DiagnosticTag] }
- deriving (Show,Eq)
-
-data ClientSemanticTokensRequestFullDelta = ClientSemanticTokensRequestFullDelta { clientSemanticTokensRequestFullDeltaDelta :: Maybe Bool }
- deriving (Show,Eq)
-
-data SemanticTokenTypes = SemanticTokenTypesNamespace
-                        | SemanticTokenTypesType
-                        | SemanticTokenTypesClass
-                        | SemanticTokenTypesEnum
-                        | SemanticTokenTypesInterface
-                        | SemanticTokenTypesStruct
-                        | SemanticTokenTypesTypeParameter
-                        | SemanticTokenTypesParameter
-                        | SemanticTokenTypesVariable
-                        | SemanticTokenTypesProperty
-                        | SemanticTokenTypesEnumMember
-                        | SemanticTokenTypesEvent
-                        | SemanticTokenTypesFunction
-                        | SemanticTokenTypesMethod
-                        | SemanticTokenTypesMacro
-                        | SemanticTokenTypesKeyword
-                        | SemanticTokenTypesModifier
-                        | SemanticTokenTypesComment
-                        | SemanticTokenTypesString
-                        | SemanticTokenTypesNumber
-                        | SemanticTokenTypesRegexp
-                        | SemanticTokenTypesOperator
-                        | SemanticTokenTypesDecorator
-                        | SemanticTokenTypesLabel
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data SemanticTokenModifiers = SemanticTokenModifiersDeclaration
-                            | SemanticTokenModifiersDefinition
-                            | SemanticTokenModifiersReadonly
-                            | SemanticTokenModifiersStatic
-                            | SemanticTokenModifiersDeprecated
-                            | SemanticTokenModifiersAbstract
-                            | SemanticTokenModifiersAsync
-                            | SemanticTokenModifiersModification
-                            | SemanticTokenModifiersDocumentation
-                            | SemanticTokenModifiersDefaultLibrary
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data DocumentDiagnosticReportKind = DocumentDiagnosticReportKindFull
-                                  | DocumentDiagnosticReportKindUnchanged
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data ErrorCodes = ErrorCodesParseError
-                | ErrorCodesInvalidRequest
-                | ErrorCodesMethodNotFound
-                | ErrorCodesInvalidParams
-                | ErrorCodesInternalError
-                | ErrorCodesServerNotInitialized
-                | ErrorCodesUnknownErrorCode
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data LSPErrorCodes = LSPErrorCodesRequestFailed
-                   | LSPErrorCodesServerCancelled
-                   | LSPErrorCodesContentModified
-                   | LSPErrorCodesRequestCancelled
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data FoldingRangeKind = FoldingRangeKindComment
-                      | FoldingRangeKindImports
-                      | FoldingRangeKindRegion
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data SymbolKind = SymbolKindFile
-                | SymbolKindModule
-                | SymbolKindNamespace
-                | SymbolKindPackage
-                | SymbolKindClass
-                | SymbolKindMethod
-                | SymbolKindProperty
-                | SymbolKindField
-                | SymbolKindConstructor
-                | SymbolKindEnum
-                | SymbolKindInterface
-                | SymbolKindFunction
-                | SymbolKindVariable
-                | SymbolKindConstant
-                | SymbolKindString
-                | SymbolKindNumber
-                | SymbolKindBoolean
-                | SymbolKindArray
-                | SymbolKindObject
-                | SymbolKindKey
-                | SymbolKindNull
-                | SymbolKindEnumMember
-                | SymbolKindStruct
-                | SymbolKindEvent
-                | SymbolKindOperator
-                | SymbolKindTypeParameter
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data SymbolTag = SymbolTagDeprecated
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data UniquenessLevel = UniquenessLevelDocument
-                     | UniquenessLevelProject
-                     | UniquenessLevelGroup
-                     | UniquenessLevelScheme
-                     | UniquenessLevelGlobal
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data MonikerKind = MonikerKindImport | MonikerKindExport | MonikerKindLocal
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data InlayHintKind = InlayHintKindType | InlayHintKindParameter
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data MessageType = MessageTypeError
-                 | MessageTypeWarning
-                 | MessageTypeInfo
-                 | MessageTypeLog
-                 | MessageTypeDebug
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data TextDocumentSyncKind = TextDocumentSyncKindNone
-                          | TextDocumentSyncKindFull
-                          | TextDocumentSyncKindIncremental
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data TextDocumentSaveReason = TextDocumentSaveReasonManual
-                            | TextDocumentSaveReasonAfterDelay
-                            | TextDocumentSaveReasonFocusOut
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data CompletionItemKind = CompletionItemKindText
-                        | CompletionItemKindMethod
-                        | CompletionItemKindFunction
-                        | CompletionItemKindConstructor
-                        | CompletionItemKindField
-                        | CompletionItemKindVariable
-                        | CompletionItemKindClass
-                        | CompletionItemKindInterface
-                        | CompletionItemKindModule
-                        | CompletionItemKindProperty
-                        | CompletionItemKindUnit
-                        | CompletionItemKindValue
-                        | CompletionItemKindEnum
-                        | CompletionItemKindKeyword
-                        | CompletionItemKindSnippet
-                        | CompletionItemKindColor
-                        | CompletionItemKindFile
-                        | CompletionItemKindReference
-                        | CompletionItemKindFolder
-                        | CompletionItemKindEnumMember
-                        | CompletionItemKindConstant
-                        | CompletionItemKindStruct
-                        | CompletionItemKindEvent
-                        | CompletionItemKindOperator
-                        | CompletionItemKindTypeParameter
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data CompletionItemTag = CompletionItemTagDeprecated
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data InsertTextFormat = InsertTextFormatPlainText | InsertTextFormatSnippet
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data InsertTextMode = InsertTextModeAsIs | InsertTextModeAdjustIndentation
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data DocumentHighlightKind = DocumentHighlightKindText
-                           | DocumentHighlightKindRead
-                           | DocumentHighlightKindWrite
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data CodeActionKind = CodeActionKindEmpty
-                    | CodeActionKindQuickFix
-                    | CodeActionKindRefactor
-                    | CodeActionKindRefactorExtract
-                    | CodeActionKindRefactorInline
-                    | CodeActionKindRefactorMove
-                    | CodeActionKindRefactorRewrite
-                    | CodeActionKindSource
-                    | CodeActionKindSourceOrganizeImports
-                    | CodeActionKindSourceFixAll
-                    | CodeActionKindNotebook
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data TraceValue = TraceValueOff | TraceValueMessages | TraceValueVerbose
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data MarkupKind = MarkupKindPlainText | MarkupKindMarkdown
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data LanguageKind = LanguageKindABAP
-                  | LanguageKindWindowsBat
-                  | LanguageKindBibTeX
-                  | LanguageKindClojure
-                  | LanguageKindCoffeescript
-                  | LanguageKindC
-                  | LanguageKindCPP
-                  | LanguageKindCSharp
-                  | LanguageKindCSS
-                  | LanguageKindD
-                  | LanguageKindDelphi
-                  | LanguageKindDiff
-                  | LanguageKindDart
-                  | LanguageKindDockerfile
-                  | LanguageKindElixir
-                  | LanguageKindErlang
-                  | LanguageKindFSharp
-                  | LanguageKindGitCommit
-                  | LanguageKindGitRebase
-                  | LanguageKindGo
-                  | LanguageKindGroovy
-                  | LanguageKindHandlebars
-                  | LanguageKindHaskell
-                  | LanguageKindHTML
-                  | LanguageKindIni
-                  | LanguageKindJava
-                  | LanguageKindJavaScript
-                  | LanguageKindJavaScriptReact
-                  | LanguageKindJSON
-                  | LanguageKindLaTeX
-                  | LanguageKindLess
-                  | LanguageKindLua
-                  | LanguageKindMakefile
-                  | LanguageKindMarkdown
-                  | LanguageKindObjectiveC
-                  | LanguageKindObjectiveCPP
-                  | LanguageKindPascal
-                  | LanguageKindPerl
-                  | LanguageKindPerl6
-                  | LanguageKindPHP
-                  | LanguageKindPowershell
-                  | LanguageKindPug
-                  | LanguageKindPython
-                  | LanguageKindR
-                  | LanguageKindRazor
-                  | LanguageKindRuby
-                  | LanguageKindRust
-                  | LanguageKindSCSS
-                  | LanguageKindSASS
-                  | LanguageKindScala
-                  | LanguageKindShaderLab
-                  | LanguageKindShellScript
-                  | LanguageKindSQL
-                  | LanguageKindSwift
-                  | LanguageKindTypeScript
-                  | LanguageKindTypeScriptReact
-                  | LanguageKindTeX
-                  | LanguageKindVisualBasic
-                  | LanguageKindXML
-                  | LanguageKindXSL
-                  | LanguageKindYAML
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data InlineCompletionTriggerKind = InlineCompletionTriggerKindInvoked
-                                 | InlineCompletionTriggerKindAutomatic
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data PositionEncodingKind = PositionEncodingKindUTF8
-                          | PositionEncodingKindUTF16
-                          | PositionEncodingKindUTF32
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data FileChangeType = FileChangeTypeCreated
-                    | FileChangeTypeChanged
-                    | FileChangeTypeDeleted
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data WatchKind = WatchKindCreate | WatchKindChange | WatchKindDelete
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data DiagnosticSeverity = DiagnosticSeverityError
-                        | DiagnosticSeverityWarning
-                        | DiagnosticSeverityInformation
-                        | DiagnosticSeverityHint
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data DiagnosticTag = DiagnosticTagUnnecessary | DiagnosticTagDeprecated
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data CompletionTriggerKind = CompletionTriggerKindInvoked
-                           | CompletionTriggerKindTriggerCharacter
-                           | CompletionTriggerKindTriggerForIncompleteCompletions
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data SignatureHelpTriggerKind = SignatureHelpTriggerKindInvoked
-                              | SignatureHelpTriggerKindTriggerCharacter
-                              | SignatureHelpTriggerKindContentChange
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data CodeActionTriggerKind = CodeActionTriggerKindInvoked
-                           | CodeActionTriggerKindAutomatic
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data FileOperationPatternKind = FileOperationPatternKindFile
-                              | FileOperationPatternKindFolder
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data NotebookCellKind = NotebookCellKindMarkup | NotebookCellKindCode
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data ResourceOperationKind = ResourceOperationKindCreate
-                           | ResourceOperationKindRename
-                           | ResourceOperationKindDelete
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data FailureHandlingKind = FailureHandlingKindAbort
-                         | FailureHandlingKindTransactional
-                         | FailureHandlingKindTextOnlyTransactional
-                         | FailureHandlingKindUndo
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data PrepareSupportDefaultBehavior = PrepareSupportDefaultBehaviorIdentifier
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-data TokenFormat = TokenFormatRelative
- deriving (Show,Eq,Enum,Bounded,Ord)
-
-type Definition = Either Location [Location]
-
-type DefinitionLink = LocationLink
-
-type LSPArray = [LSPAny]
-
-type Declaration = Either Location [Location]
-
-type DeclarationLink = LocationLink
-
-type InlineValue = Either (Either InlineValueText InlineValueVariableLookup) InlineValueEvaluatableExpression
-
-type DocumentDiagnosticReport = Either RelatedFullDocumentDiagnosticReport RelatedUnchangedDocumentDiagnosticReport
-
-type PrepareRenameResult = Either (Either Range PrepareRenamePlaceholder) PrepareRenameDefaultBehavior
-
-type DocumentSelector = [DocumentFilter]
-
-type ProgressToken = Either Int String
-
-type ChangeAnnotationIdentifier = String
-
-type WorkspaceDocumentDiagnosticReport = Either WorkspaceFullDocumentDiagnosticReport WorkspaceUnchangedDocumentDiagnosticReport
-
-type TextDocumentContentChangeEvent = Either TextDocumentContentChangePartial TextDocumentContentChangeWholeDocument
-
-type MarkedString = Either String MarkedStringWithLanguage
-
-type DocumentFilter = Either TextDocumentFilter NotebookCellTextDocumentFilter
-
-type LSPObject = Map String LSPAny
-
-type GlobPattern = Either Pattern RelativePattern
-
-type TextDocumentFilter = Either (Either TextDocumentFilterLanguage TextDocumentFilterScheme) TextDocumentFilterPattern
-
-type NotebookDocumentFilter = Either (Either NotebookDocumentFilterNotebookType NotebookDocumentFilterScheme) NotebookDocumentFilterPattern
-
-type Pattern = String
-
-type RegularExpressionEngineKind = String
+module LSP.Protocol.Types
+  ( module LSP.Protocol.Types.ImplementationParams
+  , module LSP.Protocol.Types.Location
+  , module LSP.Protocol.Types.ImplementationRegistrationOptions
+  , module LSP.Protocol.Types.TypeDefinitionParams
+  , module LSP.Protocol.Types.TypeDefinitionRegistrationOptions
+  , module LSP.Protocol.Types.WorkspaceFolder
+  , module LSP.Protocol.Types.DidChangeWorkspaceFoldersParams
+  , module LSP.Protocol.Types.ConfigurationParams
+  , module LSP.Protocol.Types.DocumentColorParams
+  , module LSP.Protocol.Types.ColorInformation
+  , module LSP.Protocol.Types.DocumentColorRegistrationOptions
+  , module LSP.Protocol.Types.ColorPresentationParams
+  , module LSP.Protocol.Types.ColorPresentation
+  , module LSP.Protocol.Types.WorkDoneProgressOptions
+  , module LSP.Protocol.Types.TextDocumentRegistrationOptions
+  , module LSP.Protocol.Types.FoldingRangeParams
+  , module LSP.Protocol.Types.FoldingRange
+  , module LSP.Protocol.Types.FoldingRangeRegistrationOptions
+  , module LSP.Protocol.Types.DeclarationParams
+  , module LSP.Protocol.Types.DeclarationRegistrationOptions
+  , module LSP.Protocol.Types.SelectionRangeParams
+  , module LSP.Protocol.Types.SelectionRange
+  , module LSP.Protocol.Types.SelectionRangeRegistrationOptions
+  , module LSP.Protocol.Types.WorkDoneProgressCreateParams
+  , module LSP.Protocol.Types.WorkDoneProgressCancelParams
+  , module LSP.Protocol.Types.CallHierarchyPrepareParams
+  , module LSP.Protocol.Types.CallHierarchyItem
+  , module LSP.Protocol.Types.CallHierarchyRegistrationOptions
+  , module LSP.Protocol.Types.CallHierarchyIncomingCallsParams
+  , module LSP.Protocol.Types.CallHierarchyIncomingCall
+  , module LSP.Protocol.Types.CallHierarchyOutgoingCallsParams
+  , module LSP.Protocol.Types.CallHierarchyOutgoingCall
+  , module LSP.Protocol.Types.SemanticTokensParams
+  , module LSP.Protocol.Types.SemanticTokens
+  , module LSP.Protocol.Types.SemanticTokensPartialResult
+  , module LSP.Protocol.Types.SemanticTokensRegistrationOptions
+  , module LSP.Protocol.Types.SemanticTokensDeltaParams
+  , module LSP.Protocol.Types.SemanticTokensDelta
+  , module LSP.Protocol.Types.SemanticTokensDeltaPartialResult
+  , module LSP.Protocol.Types.SemanticTokensRangeParams
+  , module LSP.Protocol.Types.ShowDocumentParams
+  , module LSP.Protocol.Types.ShowDocumentResult
+  , module LSP.Protocol.Types.LinkedEditingRangeParams
+  , module LSP.Protocol.Types.LinkedEditingRanges
+  , module LSP.Protocol.Types.LinkedEditingRangeRegistrationOptions
+  , module LSP.Protocol.Types.CreateFilesParams
+  , module LSP.Protocol.Types.WorkspaceEdit
+  , module LSP.Protocol.Types.FileOperationRegistrationOptions
+  , module LSP.Protocol.Types.RenameFilesParams
+  , module LSP.Protocol.Types.DeleteFilesParams
+  , module LSP.Protocol.Types.MonikerParams, module LSP.Protocol.Types.Moniker
+  , module LSP.Protocol.Types.MonikerRegistrationOptions
+  , module LSP.Protocol.Types.TypeHierarchyPrepareParams
+  , module LSP.Protocol.Types.TypeHierarchyItem
+  , module LSP.Protocol.Types.TypeHierarchyRegistrationOptions
+  , module LSP.Protocol.Types.TypeHierarchySupertypesParams
+  , module LSP.Protocol.Types.TypeHierarchySubtypesParams
+  , module LSP.Protocol.Types.InlineValueParams
+  , module LSP.Protocol.Types.InlineValueRegistrationOptions
+  , module LSP.Protocol.Types.InlayHintParams
+  , module LSP.Protocol.Types.InlayHint
+  , module LSP.Protocol.Types.InlayHintRegistrationOptions
+  , module LSP.Protocol.Types.DocumentDiagnosticParams
+  , module LSP.Protocol.Types.DocumentDiagnosticReportPartialResult
+  , module LSP.Protocol.Types.DiagnosticServerCancellationData
+  , module LSP.Protocol.Types.DiagnosticRegistrationOptions
+  , module LSP.Protocol.Types.WorkspaceDiagnosticParams
+  , module LSP.Protocol.Types.WorkspaceDiagnosticReport
+  , module LSP.Protocol.Types.WorkspaceDiagnosticReportPartialResult
+  , module LSP.Protocol.Types.DidOpenNotebookDocumentParams
+  , module LSP.Protocol.Types.NotebookDocumentSyncRegistrationOptions
+  , module LSP.Protocol.Types.DidChangeNotebookDocumentParams
+  , module LSP.Protocol.Types.DidSaveNotebookDocumentParams
+  , module LSP.Protocol.Types.DidCloseNotebookDocumentParams
+  , module LSP.Protocol.Types.InlineCompletionParams
+  , module LSP.Protocol.Types.InlineCompletionList
+  , module LSP.Protocol.Types.InlineCompletionItem
+  , module LSP.Protocol.Types.InlineCompletionRegistrationOptions
+  , module LSP.Protocol.Types.RegistrationParams
+  , module LSP.Protocol.Types.UnregistrationParams
+  , module LSP.Protocol.Types.InitializeParams
+  , module LSP.Protocol.Types.InitializeResult
+  , module LSP.Protocol.Types.InitializeError
+  , module LSP.Protocol.Types.InitializedParams
+  , module LSP.Protocol.Types.DidChangeConfigurationParams
+  , module LSP.Protocol.Types.DidChangeConfigurationRegistrationOptions
+  , module LSP.Protocol.Types.ShowMessageParams
+  , module LSP.Protocol.Types.ShowMessageRequestParams
+  , module LSP.Protocol.Types.MessageActionItem
+  , module LSP.Protocol.Types.LogMessageParams
+  , module LSP.Protocol.Types.DidOpenTextDocumentParams
+  , module LSP.Protocol.Types.DidChangeTextDocumentParams
+  , module LSP.Protocol.Types.TextDocumentChangeRegistrationOptions
+  , module LSP.Protocol.Types.DidCloseTextDocumentParams
+  , module LSP.Protocol.Types.DidSaveTextDocumentParams
+  , module LSP.Protocol.Types.TextDocumentSaveRegistrationOptions
+  , module LSP.Protocol.Types.WillSaveTextDocumentParams
+  , module LSP.Protocol.Types.TextEdit
+  , module LSP.Protocol.Types.DidChangeWatchedFilesParams
+  , module LSP.Protocol.Types.DidChangeWatchedFilesRegistrationOptions
+  , module LSP.Protocol.Types.PublishDiagnosticsParams
+  , module LSP.Protocol.Types.CompletionParams
+  , module LSP.Protocol.Types.CompletionItem
+  , module LSP.Protocol.Types.CompletionList
+  , module LSP.Protocol.Types.CompletionRegistrationOptions
+  , module LSP.Protocol.Types.HoverParams, module LSP.Protocol.Types.Hover
+  , module LSP.Protocol.Types.HoverRegistrationOptions
+  , module LSP.Protocol.Types.SignatureHelpParams
+  , module LSP.Protocol.Types.SignatureHelp
+  , module LSP.Protocol.Types.SignatureHelpRegistrationOptions
+  , module LSP.Protocol.Types.DefinitionParams
+  , module LSP.Protocol.Types.DefinitionRegistrationOptions
+  , module LSP.Protocol.Types.ReferenceParams
+  , module LSP.Protocol.Types.ReferenceRegistrationOptions
+  , module LSP.Protocol.Types.DocumentHighlightParams
+  , module LSP.Protocol.Types.DocumentHighlight
+  , module LSP.Protocol.Types.DocumentHighlightRegistrationOptions
+  , module LSP.Protocol.Types.DocumentSymbolParams
+  , module LSP.Protocol.Types.SymbolInformation
+  , module LSP.Protocol.Types.DocumentSymbol
+  , module LSP.Protocol.Types.DocumentSymbolRegistrationOptions
+  , module LSP.Protocol.Types.CodeActionParams
+  , module LSP.Protocol.Types.Command, module LSP.Protocol.Types.CodeAction
+  , module LSP.Protocol.Types.CodeActionRegistrationOptions
+  , module LSP.Protocol.Types.WorkspaceSymbolParams
+  , module LSP.Protocol.Types.WorkspaceSymbol
+  , module LSP.Protocol.Types.WorkspaceSymbolRegistrationOptions
+  , module LSP.Protocol.Types.CodeLensParams
+  , module LSP.Protocol.Types.CodeLens
+  , module LSP.Protocol.Types.CodeLensRegistrationOptions
+  , module LSP.Protocol.Types.DocumentLinkParams
+  , module LSP.Protocol.Types.DocumentLink
+  , module LSP.Protocol.Types.DocumentLinkRegistrationOptions
+  , module LSP.Protocol.Types.DocumentFormattingParams
+  , module LSP.Protocol.Types.DocumentFormattingRegistrationOptions
+  , module LSP.Protocol.Types.DocumentRangeFormattingParams
+  , module LSP.Protocol.Types.DocumentRangeFormattingRegistrationOptions
+  , module LSP.Protocol.Types.DocumentRangesFormattingParams
+  , module LSP.Protocol.Types.DocumentOnTypeFormattingParams
+  , module LSP.Protocol.Types.DocumentOnTypeFormattingRegistrationOptions
+  , module LSP.Protocol.Types.RenameParams
+  , module LSP.Protocol.Types.RenameRegistrationOptions
+  , module LSP.Protocol.Types.PrepareRenameParams
+  , module LSP.Protocol.Types.ExecuteCommandParams
+  , module LSP.Protocol.Types.ExecuteCommandRegistrationOptions
+  , module LSP.Protocol.Types.ApplyWorkspaceEditParams
+  , module LSP.Protocol.Types.ApplyWorkspaceEditResult
+  , module LSP.Protocol.Types.WorkDoneProgressBegin
+  , module LSP.Protocol.Types.WorkDoneProgressReport
+  , module LSP.Protocol.Types.WorkDoneProgressEnd
+  , module LSP.Protocol.Types.SetTraceParams
+  , module LSP.Protocol.Types.LogTraceParams
+  , module LSP.Protocol.Types.CancelParams
+  , module LSP.Protocol.Types.ProgressParams
+  , module LSP.Protocol.Types.TextDocumentPositionParams
+  , module LSP.Protocol.Types.WorkDoneProgressParams
+  , module LSP.Protocol.Types.PartialResultParams
+  , module LSP.Protocol.Types.LocationLink, module LSP.Protocol.Types.Range
+  , module LSP.Protocol.Types.ImplementationOptions
+  , module LSP.Protocol.Types.StaticRegistrationOptions
+  , module LSP.Protocol.Types.TypeDefinitionOptions
+  , module LSP.Protocol.Types.WorkspaceFoldersChangeEvent
+  , module LSP.Protocol.Types.ConfigurationItem
+  , module LSP.Protocol.Types.TextDocumentIdentifier
+  , module LSP.Protocol.Types.Color
+  , module LSP.Protocol.Types.DocumentColorOptions
+  , module LSP.Protocol.Types.FoldingRangeOptions
+  , module LSP.Protocol.Types.DeclarationOptions
+  , module LSP.Protocol.Types.Position
+  , module LSP.Protocol.Types.SelectionRangeOptions
+  , module LSP.Protocol.Types.CallHierarchyOptions
+  , module LSP.Protocol.Types.SemanticTokensOptions
+  , module LSP.Protocol.Types.SemanticTokensEdit
+  , module LSP.Protocol.Types.LinkedEditingRangeOptions
+  , module LSP.Protocol.Types.FileCreate
+  , module LSP.Protocol.Types.TextDocumentEdit
+  , module LSP.Protocol.Types.CreateFile, module LSP.Protocol.Types.RenameFile
+  , module LSP.Protocol.Types.DeleteFile
+  , module LSP.Protocol.Types.ChangeAnnotation
+  , module LSP.Protocol.Types.FileOperationFilter
+  , module LSP.Protocol.Types.FileRename, module LSP.Protocol.Types.FileDelete
+  , module LSP.Protocol.Types.MonikerOptions
+  , module LSP.Protocol.Types.TypeHierarchyOptions
+  , module LSP.Protocol.Types.InlineValueContext
+  , module LSP.Protocol.Types.InlineValueText
+  , module LSP.Protocol.Types.InlineValueVariableLookup
+  , module LSP.Protocol.Types.InlineValueEvaluatableExpression
+  , module LSP.Protocol.Types.InlineValueOptions
+  , module LSP.Protocol.Types.InlayHintLabelPart
+  , module LSP.Protocol.Types.MarkupContent
+  , module LSP.Protocol.Types.InlayHintOptions
+  , module LSP.Protocol.Types.RelatedFullDocumentDiagnosticReport
+  , module LSP.Protocol.Types.RelatedUnchangedDocumentDiagnosticReport
+  , module LSP.Protocol.Types.FullDocumentDiagnosticReport
+  , module LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
+  , module LSP.Protocol.Types.DiagnosticOptions
+  , module LSP.Protocol.Types.PreviousResultId
+  , module LSP.Protocol.Types.NotebookDocument
+  , module LSP.Protocol.Types.TextDocumentItem
+  , module LSP.Protocol.Types.NotebookDocumentSyncOptions
+  , module LSP.Protocol.Types.VersionedNotebookDocumentIdentifier
+  , module LSP.Protocol.Types.NotebookDocumentChangeEvent
+  , module LSP.Protocol.Types.NotebookDocumentIdentifier
+  , module LSP.Protocol.Types.InlineCompletionContext
+  , module LSP.Protocol.Types.StringValue
+  , module LSP.Protocol.Types.InlineCompletionOptions
+  , module LSP.Protocol.Types.Registration
+  , module LSP.Protocol.Types.Unregistration
+  , module LSP.Protocol.Types.BaseInitializeParams
+  , module LSP.Protocol.Types.WorkspaceFoldersInitializeParams
+  , module LSP.Protocol.Types.ServerCapabilities
+  , module LSP.Protocol.Types.ServerInfo
+  , module LSP.Protocol.Types.VersionedTextDocumentIdentifier
+  , module LSP.Protocol.Types.SaveOptions, module LSP.Protocol.Types.FileEvent
+  , module LSP.Protocol.Types.FileSystemWatcher
+  , module LSP.Protocol.Types.Diagnostic
+  , module LSP.Protocol.Types.CompletionContext
+  , module LSP.Protocol.Types.CompletionItemLabelDetails
+  , module LSP.Protocol.Types.InsertReplaceEdit
+  , module LSP.Protocol.Types.CompletionItemDefaults
+  , module LSP.Protocol.Types.CompletionOptions
+  , module LSP.Protocol.Types.HoverOptions
+  , module LSP.Protocol.Types.SignatureHelpContext
+  , module LSP.Protocol.Types.SignatureInformation
+  , module LSP.Protocol.Types.SignatureHelpOptions
+  , module LSP.Protocol.Types.DefinitionOptions
+  , module LSP.Protocol.Types.ReferenceContext
+  , module LSP.Protocol.Types.ReferenceOptions
+  , module LSP.Protocol.Types.DocumentHighlightOptions
+  , module LSP.Protocol.Types.BaseSymbolInformation
+  , module LSP.Protocol.Types.DocumentSymbolOptions
+  , module LSP.Protocol.Types.CodeActionContext
+  , module LSP.Protocol.Types.CodeActionDisabled
+  , module LSP.Protocol.Types.CodeActionOptions
+  , module LSP.Protocol.Types.LocationUriOnly
+  , module LSP.Protocol.Types.WorkspaceSymbolOptions
+  , module LSP.Protocol.Types.CodeLensOptions
+  , module LSP.Protocol.Types.DocumentLinkOptions
+  , module LSP.Protocol.Types.FormattingOptions
+  , module LSP.Protocol.Types.DocumentFormattingOptions
+  , module LSP.Protocol.Types.DocumentRangeFormattingOptions
+  , module LSP.Protocol.Types.DocumentOnTypeFormattingOptions
+  , module LSP.Protocol.Types.RenameOptions
+  , module LSP.Protocol.Types.PrepareRenamePlaceholder
+  , module LSP.Protocol.Types.PrepareRenameDefaultBehavior
+  , module LSP.Protocol.Types.ExecuteCommandOptions
+  , module LSP.Protocol.Types.WorkspaceEditMetadata
+  , module LSP.Protocol.Types.SemanticTokensLegend
+  , module LSP.Protocol.Types.SemanticTokensFullDelta
+  , module LSP.Protocol.Types.OptionalVersionedTextDocumentIdentifier
+  , module LSP.Protocol.Types.AnnotatedTextEdit
+  , module LSP.Protocol.Types.SnippetTextEdit
+  , module LSP.Protocol.Types.ResourceOperation
+  , module LSP.Protocol.Types.CreateFileOptions
+  , module LSP.Protocol.Types.RenameFileOptions
+  , module LSP.Protocol.Types.DeleteFileOptions
+  , module LSP.Protocol.Types.FileOperationPattern
+  , module LSP.Protocol.Types.WorkspaceFullDocumentDiagnosticReport
+  , module LSP.Protocol.Types.WorkspaceUnchangedDocumentDiagnosticReport
+  , module LSP.Protocol.Types.NotebookCell
+  , module LSP.Protocol.Types.NotebookDocumentFilterWithNotebook
+  , module LSP.Protocol.Types.NotebookDocumentFilterWithCells
+  , module LSP.Protocol.Types.NotebookDocumentCellChanges
+  , module LSP.Protocol.Types.SelectedCompletionInfo
+  , module LSP.Protocol.Types.ClientInfo
+  , module LSP.Protocol.Types.ClientCapabilities
+  , module LSP.Protocol.Types.TextDocumentSyncOptions
+  , module LSP.Protocol.Types.WorkspaceOptions
+  , module LSP.Protocol.Types.TextDocumentContentChangePartial
+  , module LSP.Protocol.Types.TextDocumentContentChangeWholeDocument
+  , module LSP.Protocol.Types.CodeDescription
+  , module LSP.Protocol.Types.DiagnosticRelatedInformation
+  , module LSP.Protocol.Types.EditRangeWithInsertReplace
+  , module LSP.Protocol.Types.ServerCompletionItemOptions
+  , module LSP.Protocol.Types.MarkedStringWithLanguage
+  , module LSP.Protocol.Types.ParameterInformation
+  , module LSP.Protocol.Types.CodeActionKindDocumentation
+  , module LSP.Protocol.Types.NotebookCellTextDocumentFilter
+  , module LSP.Protocol.Types.FileOperationPatternOptions
+  , module LSP.Protocol.Types.ExecutionSummary
+  , module LSP.Protocol.Types.NotebookCellLanguage
+  , module LSP.Protocol.Types.NotebookDocumentCellChangeStructure
+  , module LSP.Protocol.Types.NotebookDocumentCellContentChanges
+  , module LSP.Protocol.Types.WorkspaceClientCapabilities
+  , module LSP.Protocol.Types.TextDocumentClientCapabilities
+  , module LSP.Protocol.Types.NotebookDocumentClientCapabilities
+  , module LSP.Protocol.Types.WindowClientCapabilities
+  , module LSP.Protocol.Types.GeneralClientCapabilities
+  , module LSP.Protocol.Types.WorkspaceFoldersServerCapabilities
+  , module LSP.Protocol.Types.FileOperationOptions
+  , module LSP.Protocol.Types.RelativePattern
+  , module LSP.Protocol.Types.TextDocumentFilterLanguage
+  , module LSP.Protocol.Types.TextDocumentFilterScheme
+  , module LSP.Protocol.Types.TextDocumentFilterPattern
+  , module LSP.Protocol.Types.NotebookDocumentFilterNotebookType
+  , module LSP.Protocol.Types.NotebookDocumentFilterScheme
+  , module LSP.Protocol.Types.NotebookDocumentFilterPattern
+  , module LSP.Protocol.Types.NotebookCellArrayChange
+  , module LSP.Protocol.Types.WorkspaceEditClientCapabilities
+  , module LSP.Protocol.Types.DidChangeConfigurationClientCapabilities
+  , module LSP.Protocol.Types.DidChangeWatchedFilesClientCapabilities
+  , module LSP.Protocol.Types.WorkspaceSymbolClientCapabilities
+  , module LSP.Protocol.Types.ExecuteCommandClientCapabilities
+  , module LSP.Protocol.Types.SemanticTokensWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.CodeLensWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.FileOperationClientCapabilities
+  , module LSP.Protocol.Types.InlineValueWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.InlayHintWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.DiagnosticWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.FoldingRangeWorkspaceClientCapabilities
+  , module LSP.Protocol.Types.TextDocumentSyncClientCapabilities
+  , module LSP.Protocol.Types.CompletionClientCapabilities
+  , module LSP.Protocol.Types.HoverClientCapabilities
+  , module LSP.Protocol.Types.SignatureHelpClientCapabilities
+  , module LSP.Protocol.Types.DeclarationClientCapabilities
+  , module LSP.Protocol.Types.DefinitionClientCapabilities
+  , module LSP.Protocol.Types.TypeDefinitionClientCapabilities
+  , module LSP.Protocol.Types.ImplementationClientCapabilities
+  , module LSP.Protocol.Types.ReferenceClientCapabilities
+  , module LSP.Protocol.Types.DocumentHighlightClientCapabilities
+  , module LSP.Protocol.Types.DocumentSymbolClientCapabilities
+  , module LSP.Protocol.Types.CodeActionClientCapabilities
+  , module LSP.Protocol.Types.CodeLensClientCapabilities
+  , module LSP.Protocol.Types.DocumentLinkClientCapabilities
+  , module LSP.Protocol.Types.DocumentColorClientCapabilities
+  , module LSP.Protocol.Types.DocumentFormattingClientCapabilities
+  , module LSP.Protocol.Types.DocumentRangeFormattingClientCapabilities
+  , module LSP.Protocol.Types.DocumentOnTypeFormattingClientCapabilities
+  , module LSP.Protocol.Types.RenameClientCapabilities
+  , module LSP.Protocol.Types.FoldingRangeClientCapabilities
+  , module LSP.Protocol.Types.SelectionRangeClientCapabilities
+  , module LSP.Protocol.Types.PublishDiagnosticsClientCapabilities
+  , module LSP.Protocol.Types.CallHierarchyClientCapabilities
+  , module LSP.Protocol.Types.SemanticTokensClientCapabilities
+  , module LSP.Protocol.Types.LinkedEditingRangeClientCapabilities
+  , module LSP.Protocol.Types.MonikerClientCapabilities
+  , module LSP.Protocol.Types.TypeHierarchyClientCapabilities
+  , module LSP.Protocol.Types.InlineValueClientCapabilities
+  , module LSP.Protocol.Types.InlayHintClientCapabilities
+  , module LSP.Protocol.Types.DiagnosticClientCapabilities
+  , module LSP.Protocol.Types.InlineCompletionClientCapabilities
+  , module LSP.Protocol.Types.NotebookDocumentSyncClientCapabilities
+  , module LSP.Protocol.Types.ShowMessageRequestClientCapabilities
+  , module LSP.Protocol.Types.ShowDocumentClientCapabilities
+  , module LSP.Protocol.Types.StaleRequestSupportOptions
+  , module LSP.Protocol.Types.RegularExpressionsClientCapabilities
+  , module LSP.Protocol.Types.MarkdownClientCapabilities
+  , module LSP.Protocol.Types.ChangeAnnotationsSupportOptions
+  , module LSP.Protocol.Types.ClientSymbolKindOptions
+  , module LSP.Protocol.Types.ClientSymbolTagOptions
+  , module LSP.Protocol.Types.ClientSymbolResolveOptions
+  , module LSP.Protocol.Types.ClientCompletionItemOptions
+  , module LSP.Protocol.Types.ClientCompletionItemOptionsKind
+  , module LSP.Protocol.Types.CompletionListCapabilities
+  , module LSP.Protocol.Types.ClientSignatureInformationOptions
+  , module LSP.Protocol.Types.ClientCodeActionLiteralOptions
+  , module LSP.Protocol.Types.ClientCodeActionResolveOptions
+  , module LSP.Protocol.Types.ClientCodeLensResolveOptions
+  , module LSP.Protocol.Types.ClientFoldingRangeKindOptions
+  , module LSP.Protocol.Types.ClientFoldingRangeOptions
+  , module LSP.Protocol.Types.DiagnosticsCapabilities
+  , module LSP.Protocol.Types.ClientSemanticTokensRequestOptions
+  , module LSP.Protocol.Types.ClientInlayHintResolveOptions
+  , module LSP.Protocol.Types.ClientShowMessageActionItemOptions
+  , module LSP.Protocol.Types.CompletionItemTagOptions
+  , module LSP.Protocol.Types.ClientCompletionItemResolveOptions
+  , module LSP.Protocol.Types.ClientCompletionItemInsertTextModeOptions
+  , module LSP.Protocol.Types.ClientSignatureParameterInformationOptions
+  , module LSP.Protocol.Types.ClientCodeActionKindOptions
+  , module LSP.Protocol.Types.ClientDiagnosticsTagOptions
+  , module LSP.Protocol.Types.ClientSemanticTokensRequestFullDelta
+  , module LSP.Protocol.Types.SemanticTokenTypes
+  , module LSP.Protocol.Types.SemanticTokenModifiers
+  , module LSP.Protocol.Types.DocumentDiagnosticReportKind
+  , module LSP.Protocol.Types.ErrorCodes
+  , module LSP.Protocol.Types.LSPErrorCodes
+  , module LSP.Protocol.Types.FoldingRangeKind
+  , module LSP.Protocol.Types.SymbolKind, module LSP.Protocol.Types.SymbolTag
+  , module LSP.Protocol.Types.UniquenessLevel
+  , module LSP.Protocol.Types.MonikerKind
+  , module LSP.Protocol.Types.InlayHintKind
+  , module LSP.Protocol.Types.MessageType
+  , module LSP.Protocol.Types.TextDocumentSyncKind
+  , module LSP.Protocol.Types.TextDocumentSaveReason
+  , module LSP.Protocol.Types.CompletionItemKind
+  , module LSP.Protocol.Types.CompletionItemTag
+  , module LSP.Protocol.Types.InsertTextFormat
+  , module LSP.Protocol.Types.InsertTextMode
+  , module LSP.Protocol.Types.DocumentHighlightKind
+  , module LSP.Protocol.Types.CodeActionKind
+  , module LSP.Protocol.Types.TraceValue, module LSP.Protocol.Types.MarkupKind
+  , module LSP.Protocol.Types.LanguageKind
+  , module LSP.Protocol.Types.InlineCompletionTriggerKind
+  , module LSP.Protocol.Types.PositionEncodingKind
+  , module LSP.Protocol.Types.FileChangeType
+  , module LSP.Protocol.Types.WatchKind
+  , module LSP.Protocol.Types.DiagnosticSeverity
+  , module LSP.Protocol.Types.DiagnosticTag
+  , module LSP.Protocol.Types.CompletionTriggerKind
+  , module LSP.Protocol.Types.SignatureHelpTriggerKind
+  , module LSP.Protocol.Types.CodeActionTriggerKind
+  , module LSP.Protocol.Types.FileOperationPatternKind
+  , module LSP.Protocol.Types.NotebookCellKind
+  , module LSP.Protocol.Types.ResourceOperationKind
+  , module LSP.Protocol.Types.FailureHandlingKind
+  , module LSP.Protocol.Types.PrepareSupportDefaultBehavior
+  , module LSP.Protocol.Types.TokenFormat
+  , module LSP.Protocol.Types.Definition
+  , module LSP.Protocol.Types.DefinitionLink
+  , module LSP.Protocol.Types.LSPArray, module LSP.Protocol.Types.Declaration
+  , module LSP.Protocol.Types.DeclarationLink
+  , module LSP.Protocol.Types.InlineValue
+  , module LSP.Protocol.Types.DocumentDiagnosticReport
+  , module LSP.Protocol.Types.PrepareRenameResult
+  , module LSP.Protocol.Types.DocumentSelector
+  , module LSP.Protocol.Types.ProgressToken
+  , module LSP.Protocol.Types.ChangeAnnotationIdentifier
+  , module LSP.Protocol.Types.WorkspaceDocumentDiagnosticReport
+  , module LSP.Protocol.Types.TextDocumentContentChangeEvent
+  , module LSP.Protocol.Types.MarkedString
+  , module LSP.Protocol.Types.DocumentFilter
+  , module LSP.Protocol.Types.LSPObject, module LSP.Protocol.Types.GlobPattern
+  , module LSP.Protocol.Types.TextDocumentFilter
+  , module LSP.Protocol.Types.NotebookDocumentFilter
+  , module LSP.Protocol.Types.Pattern
+  , module LSP.Protocol.Types.RegularExpressionEngineKind ) where
+
+import LSP.Protocol.Types.ImplementationParams
+import LSP.Protocol.Types.Location
+import LSP.Protocol.Types.ImplementationRegistrationOptions
+import LSP.Protocol.Types.TypeDefinitionParams
+import LSP.Protocol.Types.TypeDefinitionRegistrationOptions
+import LSP.Protocol.Types.WorkspaceFolder
+import LSP.Protocol.Types.DidChangeWorkspaceFoldersParams
+import LSP.Protocol.Types.ConfigurationParams
+import LSP.Protocol.Types.DocumentColorParams
+import LSP.Protocol.Types.ColorInformation
+import LSP.Protocol.Types.DocumentColorRegistrationOptions
+import LSP.Protocol.Types.ColorPresentationParams
+import LSP.Protocol.Types.ColorPresentation
+import LSP.Protocol.Types.WorkDoneProgressOptions
+import LSP.Protocol.Types.TextDocumentRegistrationOptions
+import LSP.Protocol.Types.FoldingRangeParams
+import LSP.Protocol.Types.FoldingRange
+import LSP.Protocol.Types.FoldingRangeRegistrationOptions
+import LSP.Protocol.Types.DeclarationParams
+import LSP.Protocol.Types.DeclarationRegistrationOptions
+import LSP.Protocol.Types.SelectionRangeParams
+import LSP.Protocol.Types.SelectionRange
+import LSP.Protocol.Types.SelectionRangeRegistrationOptions
+import LSP.Protocol.Types.WorkDoneProgressCreateParams
+import LSP.Protocol.Types.WorkDoneProgressCancelParams
+import LSP.Protocol.Types.CallHierarchyPrepareParams
+import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Protocol.Types.CallHierarchyRegistrationOptions
+import LSP.Protocol.Types.CallHierarchyIncomingCallsParams
+import LSP.Protocol.Types.CallHierarchyIncomingCall
+import LSP.Protocol.Types.CallHierarchyOutgoingCallsParams
+import LSP.Protocol.Types.CallHierarchyOutgoingCall
+import LSP.Protocol.Types.SemanticTokensParams
+import LSP.Protocol.Types.SemanticTokens
+import LSP.Protocol.Types.SemanticTokensPartialResult
+import LSP.Protocol.Types.SemanticTokensRegistrationOptions
+import LSP.Protocol.Types.SemanticTokensDeltaParams
+import LSP.Protocol.Types.SemanticTokensDelta
+import LSP.Protocol.Types.SemanticTokensDeltaPartialResult
+import LSP.Protocol.Types.SemanticTokensRangeParams
+import LSP.Protocol.Types.ShowDocumentParams
+import LSP.Protocol.Types.ShowDocumentResult
+import LSP.Protocol.Types.LinkedEditingRangeParams
+import LSP.Protocol.Types.LinkedEditingRanges
+import LSP.Protocol.Types.LinkedEditingRangeRegistrationOptions
+import LSP.Protocol.Types.CreateFilesParams
+import LSP.Protocol.Types.WorkspaceEdit
+import LSP.Protocol.Types.FileOperationRegistrationOptions
+import LSP.Protocol.Types.RenameFilesParams
+import LSP.Protocol.Types.DeleteFilesParams
+import LSP.Protocol.Types.MonikerParams
+import LSP.Protocol.Types.Moniker
+import LSP.Protocol.Types.MonikerRegistrationOptions
+import LSP.Protocol.Types.TypeHierarchyPrepareParams
+import LSP.Protocol.Types.TypeHierarchyItem
+import LSP.Protocol.Types.TypeHierarchyRegistrationOptions
+import LSP.Protocol.Types.TypeHierarchySupertypesParams
+import LSP.Protocol.Types.TypeHierarchySubtypesParams
+import LSP.Protocol.Types.InlineValueParams
+import LSP.Protocol.Types.InlineValueRegistrationOptions
+import LSP.Protocol.Types.InlayHintParams
+import LSP.Protocol.Types.InlayHint
+import LSP.Protocol.Types.InlayHintRegistrationOptions
+import LSP.Protocol.Types.DocumentDiagnosticParams
+import LSP.Protocol.Types.DocumentDiagnosticReportPartialResult
+import LSP.Protocol.Types.DiagnosticServerCancellationData
+import LSP.Protocol.Types.DiagnosticRegistrationOptions
+import LSP.Protocol.Types.WorkspaceDiagnosticParams
+import LSP.Protocol.Types.WorkspaceDiagnosticReport
+import LSP.Protocol.Types.WorkspaceDiagnosticReportPartialResult
+import LSP.Protocol.Types.DidOpenNotebookDocumentParams
+import LSP.Protocol.Types.NotebookDocumentSyncRegistrationOptions
+import LSP.Protocol.Types.DidChangeNotebookDocumentParams
+import LSP.Protocol.Types.DidSaveNotebookDocumentParams
+import LSP.Protocol.Types.DidCloseNotebookDocumentParams
+import LSP.Protocol.Types.InlineCompletionParams
+import LSP.Protocol.Types.InlineCompletionList
+import LSP.Protocol.Types.InlineCompletionItem
+import LSP.Protocol.Types.InlineCompletionRegistrationOptions
+import LSP.Protocol.Types.RegistrationParams
+import LSP.Protocol.Types.UnregistrationParams
+import LSP.Protocol.Types.InitializeParams
+import LSP.Protocol.Types.InitializeResult
+import LSP.Protocol.Types.InitializeError
+import LSP.Protocol.Types.InitializedParams
+import LSP.Protocol.Types.DidChangeConfigurationParams
+import LSP.Protocol.Types.DidChangeConfigurationRegistrationOptions
+import LSP.Protocol.Types.ShowMessageParams
+import LSP.Protocol.Types.ShowMessageRequestParams
+import LSP.Protocol.Types.MessageActionItem
+import LSP.Protocol.Types.LogMessageParams
+import LSP.Protocol.Types.DidOpenTextDocumentParams
+import LSP.Protocol.Types.DidChangeTextDocumentParams
+import LSP.Protocol.Types.TextDocumentChangeRegistrationOptions
+import LSP.Protocol.Types.DidCloseTextDocumentParams
+import LSP.Protocol.Types.DidSaveTextDocumentParams
+import LSP.Protocol.Types.TextDocumentSaveRegistrationOptions
+import LSP.Protocol.Types.WillSaveTextDocumentParams
+import LSP.Protocol.Types.TextEdit
+import LSP.Protocol.Types.DidChangeWatchedFilesParams
+import LSP.Protocol.Types.DidChangeWatchedFilesRegistrationOptions
+import LSP.Protocol.Types.PublishDiagnosticsParams
+import LSP.Protocol.Types.CompletionParams
+import LSP.Protocol.Types.CompletionItem
+import LSP.Protocol.Types.CompletionList
+import LSP.Protocol.Types.CompletionRegistrationOptions
+import LSP.Protocol.Types.HoverParams
+import LSP.Protocol.Types.Hover
+import LSP.Protocol.Types.HoverRegistrationOptions
+import LSP.Protocol.Types.SignatureHelpParams
+import LSP.Protocol.Types.SignatureHelp
+import LSP.Protocol.Types.SignatureHelpRegistrationOptions
+import LSP.Protocol.Types.DefinitionParams
+import LSP.Protocol.Types.DefinitionRegistrationOptions
+import LSP.Protocol.Types.ReferenceParams
+import LSP.Protocol.Types.ReferenceRegistrationOptions
+import LSP.Protocol.Types.DocumentHighlightParams
+import LSP.Protocol.Types.DocumentHighlight
+import LSP.Protocol.Types.DocumentHighlightRegistrationOptions
+import LSP.Protocol.Types.DocumentSymbolParams
+import LSP.Protocol.Types.SymbolInformation
+import LSP.Protocol.Types.DocumentSymbol
+import LSP.Protocol.Types.DocumentSymbolRegistrationOptions
+import LSP.Protocol.Types.CodeActionParams
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.CodeAction
+import LSP.Protocol.Types.CodeActionRegistrationOptions
+import LSP.Protocol.Types.WorkspaceSymbolParams
+import LSP.Protocol.Types.WorkspaceSymbol
+import LSP.Protocol.Types.WorkspaceSymbolRegistrationOptions
+import LSP.Protocol.Types.CodeLensParams
+import LSP.Protocol.Types.CodeLens
+import LSP.Protocol.Types.CodeLensRegistrationOptions
+import LSP.Protocol.Types.DocumentLinkParams
+import LSP.Protocol.Types.DocumentLink
+import LSP.Protocol.Types.DocumentLinkRegistrationOptions
+import LSP.Protocol.Types.DocumentFormattingParams
+import LSP.Protocol.Types.DocumentFormattingRegistrationOptions
+import LSP.Protocol.Types.DocumentRangeFormattingParams
+import LSP.Protocol.Types.DocumentRangeFormattingRegistrationOptions
+import LSP.Protocol.Types.DocumentRangesFormattingParams
+import LSP.Protocol.Types.DocumentOnTypeFormattingParams
+import LSP.Protocol.Types.DocumentOnTypeFormattingRegistrationOptions
+import LSP.Protocol.Types.RenameParams
+import LSP.Protocol.Types.RenameRegistrationOptions
+import LSP.Protocol.Types.PrepareRenameParams
+import LSP.Protocol.Types.ExecuteCommandParams
+import LSP.Protocol.Types.ExecuteCommandRegistrationOptions
+import LSP.Protocol.Types.ApplyWorkspaceEditParams
+import LSP.Protocol.Types.ApplyWorkspaceEditResult
+import LSP.Protocol.Types.WorkDoneProgressBegin
+import LSP.Protocol.Types.WorkDoneProgressReport
+import LSP.Protocol.Types.WorkDoneProgressEnd
+import LSP.Protocol.Types.SetTraceParams
+import LSP.Protocol.Types.LogTraceParams
+import LSP.Protocol.Types.CancelParams
+import LSP.Protocol.Types.ProgressParams
+import LSP.Protocol.Types.TextDocumentPositionParams
+import LSP.Protocol.Types.WorkDoneProgressParams
+import LSP.Protocol.Types.PartialResultParams
+import LSP.Protocol.Types.LocationLink
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.ImplementationOptions
+import LSP.Protocol.Types.StaticRegistrationOptions
+import LSP.Protocol.Types.TypeDefinitionOptions
+import LSP.Protocol.Types.WorkspaceFoldersChangeEvent
+import LSP.Protocol.Types.ConfigurationItem
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Protocol.Types.Color
+import LSP.Protocol.Types.DocumentColorOptions
+import LSP.Protocol.Types.FoldingRangeOptions
+import LSP.Protocol.Types.DeclarationOptions
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.SelectionRangeOptions
+import LSP.Protocol.Types.CallHierarchyOptions
+import LSP.Protocol.Types.SemanticTokensOptions
+import LSP.Protocol.Types.SemanticTokensEdit
+import LSP.Protocol.Types.LinkedEditingRangeOptions
+import LSP.Protocol.Types.FileCreate
+import LSP.Protocol.Types.TextDocumentEdit
+import LSP.Protocol.Types.CreateFile
+import LSP.Protocol.Types.RenameFile
+import LSP.Protocol.Types.DeleteFile
+import LSP.Protocol.Types.ChangeAnnotation
+import LSP.Protocol.Types.FileOperationFilter
+import LSP.Protocol.Types.FileRename
+import LSP.Protocol.Types.FileDelete
+import LSP.Protocol.Types.MonikerOptions
+import LSP.Protocol.Types.TypeHierarchyOptions
+import LSP.Protocol.Types.InlineValueContext
+import LSP.Protocol.Types.InlineValueText
+import LSP.Protocol.Types.InlineValueVariableLookup
+import LSP.Protocol.Types.InlineValueEvaluatableExpression
+import LSP.Protocol.Types.InlineValueOptions
+import LSP.Protocol.Types.InlayHintLabelPart
+import LSP.Protocol.Types.MarkupContent
+import LSP.Protocol.Types.InlayHintOptions
+import LSP.Protocol.Types.RelatedFullDocumentDiagnosticReport
+import LSP.Protocol.Types.RelatedUnchangedDocumentDiagnosticReport
+import LSP.Protocol.Types.FullDocumentDiagnosticReport
+import LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
+import LSP.Protocol.Types.DiagnosticOptions
+import LSP.Protocol.Types.PreviousResultId
+import LSP.Protocol.Types.NotebookDocument
+import LSP.Protocol.Types.TextDocumentItem
+import LSP.Protocol.Types.NotebookDocumentSyncOptions
+import LSP.Protocol.Types.VersionedNotebookDocumentIdentifier
+import LSP.Protocol.Types.NotebookDocumentChangeEvent
+import LSP.Protocol.Types.NotebookDocumentIdentifier
+import LSP.Protocol.Types.InlineCompletionContext
+import LSP.Protocol.Types.StringValue
+import LSP.Protocol.Types.InlineCompletionOptions
+import LSP.Protocol.Types.Registration
+import LSP.Protocol.Types.Unregistration
+import LSP.Protocol.Types.BaseInitializeParams
+import LSP.Protocol.Types.WorkspaceFoldersInitializeParams
+import LSP.Protocol.Types.ServerCapabilities
+import LSP.Protocol.Types.ServerInfo
+import LSP.Protocol.Types.VersionedTextDocumentIdentifier
+import LSP.Protocol.Types.SaveOptions
+import LSP.Protocol.Types.FileEvent
+import LSP.Protocol.Types.FileSystemWatcher
+import LSP.Protocol.Types.Diagnostic
+import LSP.Protocol.Types.CompletionContext
+import LSP.Protocol.Types.CompletionItemLabelDetails
+import LSP.Protocol.Types.InsertReplaceEdit
+import LSP.Protocol.Types.CompletionItemDefaults
+import LSP.Protocol.Types.CompletionOptions
+import LSP.Protocol.Types.HoverOptions
+import LSP.Protocol.Types.SignatureHelpContext
+import LSP.Protocol.Types.SignatureInformation
+import LSP.Protocol.Types.SignatureHelpOptions
+import LSP.Protocol.Types.DefinitionOptions
+import LSP.Protocol.Types.ReferenceContext
+import LSP.Protocol.Types.ReferenceOptions
+import LSP.Protocol.Types.DocumentHighlightOptions
+import LSP.Protocol.Types.BaseSymbolInformation
+import LSP.Protocol.Types.DocumentSymbolOptions
+import LSP.Protocol.Types.CodeActionContext
+import LSP.Protocol.Types.CodeActionDisabled
+import LSP.Protocol.Types.CodeActionOptions
+import LSP.Protocol.Types.LocationUriOnly
+import LSP.Protocol.Types.WorkspaceSymbolOptions
+import LSP.Protocol.Types.CodeLensOptions
+import LSP.Protocol.Types.DocumentLinkOptions
+import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.DocumentFormattingOptions
+import LSP.Protocol.Types.DocumentRangeFormattingOptions
+import LSP.Protocol.Types.DocumentOnTypeFormattingOptions
+import LSP.Protocol.Types.RenameOptions
+import LSP.Protocol.Types.PrepareRenamePlaceholder
+import LSP.Protocol.Types.PrepareRenameDefaultBehavior
+import LSP.Protocol.Types.ExecuteCommandOptions
+import LSP.Protocol.Types.WorkspaceEditMetadata
+import LSP.Protocol.Types.SemanticTokensLegend
+import LSP.Protocol.Types.SemanticTokensFullDelta
+import LSP.Protocol.Types.OptionalVersionedTextDocumentIdentifier
+import LSP.Protocol.Types.AnnotatedTextEdit
+import LSP.Protocol.Types.SnippetTextEdit
+import LSP.Protocol.Types.ResourceOperation
+import LSP.Protocol.Types.CreateFileOptions
+import LSP.Protocol.Types.RenameFileOptions
+import LSP.Protocol.Types.DeleteFileOptions
+import LSP.Protocol.Types.FileOperationPattern
+import LSP.Protocol.Types.WorkspaceFullDocumentDiagnosticReport
+import LSP.Protocol.Types.WorkspaceUnchangedDocumentDiagnosticReport
+import LSP.Protocol.Types.NotebookCell
+import LSP.Protocol.Types.NotebookDocumentFilterWithNotebook
+import LSP.Protocol.Types.NotebookDocumentFilterWithCells
+import LSP.Protocol.Types.NotebookDocumentCellChanges
+import LSP.Protocol.Types.SelectedCompletionInfo
+import LSP.Protocol.Types.ClientInfo
+import LSP.Protocol.Types.ClientCapabilities
+import LSP.Protocol.Types.TextDocumentSyncOptions
+import LSP.Protocol.Types.WorkspaceOptions
+import LSP.Protocol.Types.TextDocumentContentChangePartial
+import LSP.Protocol.Types.TextDocumentContentChangeWholeDocument
+import LSP.Protocol.Types.CodeDescription
+import LSP.Protocol.Types.DiagnosticRelatedInformation
+import LSP.Protocol.Types.EditRangeWithInsertReplace
+import LSP.Protocol.Types.ServerCompletionItemOptions
+import LSP.Protocol.Types.MarkedStringWithLanguage
+import LSP.Protocol.Types.ParameterInformation
+import LSP.Protocol.Types.CodeActionKindDocumentation
+import LSP.Protocol.Types.NotebookCellTextDocumentFilter
+import LSP.Protocol.Types.FileOperationPatternOptions
+import LSP.Protocol.Types.ExecutionSummary
+import LSP.Protocol.Types.NotebookCellLanguage
+import LSP.Protocol.Types.NotebookDocumentCellChangeStructure
+import LSP.Protocol.Types.NotebookDocumentCellContentChanges
+import LSP.Protocol.Types.WorkspaceClientCapabilities
+import LSP.Protocol.Types.TextDocumentClientCapabilities
+import LSP.Protocol.Types.NotebookDocumentClientCapabilities
+import LSP.Protocol.Types.WindowClientCapabilities
+import LSP.Protocol.Types.GeneralClientCapabilities
+import LSP.Protocol.Types.WorkspaceFoldersServerCapabilities
+import LSP.Protocol.Types.FileOperationOptions
+import LSP.Protocol.Types.RelativePattern
+import LSP.Protocol.Types.TextDocumentFilterLanguage
+import LSP.Protocol.Types.TextDocumentFilterScheme
+import LSP.Protocol.Types.TextDocumentFilterPattern
+import LSP.Protocol.Types.NotebookDocumentFilterNotebookType
+import LSP.Protocol.Types.NotebookDocumentFilterScheme
+import LSP.Protocol.Types.NotebookDocumentFilterPattern
+import LSP.Protocol.Types.NotebookCellArrayChange
+import LSP.Protocol.Types.WorkspaceEditClientCapabilities
+import LSP.Protocol.Types.DidChangeConfigurationClientCapabilities
+import LSP.Protocol.Types.DidChangeWatchedFilesClientCapabilities
+import LSP.Protocol.Types.WorkspaceSymbolClientCapabilities
+import LSP.Protocol.Types.ExecuteCommandClientCapabilities
+import LSP.Protocol.Types.SemanticTokensWorkspaceClientCapabilities
+import LSP.Protocol.Types.CodeLensWorkspaceClientCapabilities
+import LSP.Protocol.Types.FileOperationClientCapabilities
+import LSP.Protocol.Types.InlineValueWorkspaceClientCapabilities
+import LSP.Protocol.Types.InlayHintWorkspaceClientCapabilities
+import LSP.Protocol.Types.DiagnosticWorkspaceClientCapabilities
+import LSP.Protocol.Types.FoldingRangeWorkspaceClientCapabilities
+import LSP.Protocol.Types.TextDocumentSyncClientCapabilities
+import LSP.Protocol.Types.CompletionClientCapabilities
+import LSP.Protocol.Types.HoverClientCapabilities
+import LSP.Protocol.Types.SignatureHelpClientCapabilities
+import LSP.Protocol.Types.DeclarationClientCapabilities
+import LSP.Protocol.Types.DefinitionClientCapabilities
+import LSP.Protocol.Types.TypeDefinitionClientCapabilities
+import LSP.Protocol.Types.ImplementationClientCapabilities
+import LSP.Protocol.Types.ReferenceClientCapabilities
+import LSP.Protocol.Types.DocumentHighlightClientCapabilities
+import LSP.Protocol.Types.DocumentSymbolClientCapabilities
+import LSP.Protocol.Types.CodeActionClientCapabilities
+import LSP.Protocol.Types.CodeLensClientCapabilities
+import LSP.Protocol.Types.DocumentLinkClientCapabilities
+import LSP.Protocol.Types.DocumentColorClientCapabilities
+import LSP.Protocol.Types.DocumentFormattingClientCapabilities
+import LSP.Protocol.Types.DocumentRangeFormattingClientCapabilities
+import LSP.Protocol.Types.DocumentOnTypeFormattingClientCapabilities
+import LSP.Protocol.Types.RenameClientCapabilities
+import LSP.Protocol.Types.FoldingRangeClientCapabilities
+import LSP.Protocol.Types.SelectionRangeClientCapabilities
+import LSP.Protocol.Types.PublishDiagnosticsClientCapabilities
+import LSP.Protocol.Types.CallHierarchyClientCapabilities
+import LSP.Protocol.Types.SemanticTokensClientCapabilities
+import LSP.Protocol.Types.LinkedEditingRangeClientCapabilities
+import LSP.Protocol.Types.MonikerClientCapabilities
+import LSP.Protocol.Types.TypeHierarchyClientCapabilities
+import LSP.Protocol.Types.InlineValueClientCapabilities
+import LSP.Protocol.Types.InlayHintClientCapabilities
+import LSP.Protocol.Types.DiagnosticClientCapabilities
+import LSP.Protocol.Types.InlineCompletionClientCapabilities
+import LSP.Protocol.Types.NotebookDocumentSyncClientCapabilities
+import LSP.Protocol.Types.ShowMessageRequestClientCapabilities
+import LSP.Protocol.Types.ShowDocumentClientCapabilities
+import LSP.Protocol.Types.StaleRequestSupportOptions
+import LSP.Protocol.Types.RegularExpressionsClientCapabilities
+import LSP.Protocol.Types.MarkdownClientCapabilities
+import LSP.Protocol.Types.ChangeAnnotationsSupportOptions
+import LSP.Protocol.Types.ClientSymbolKindOptions
+import LSP.Protocol.Types.ClientSymbolTagOptions
+import LSP.Protocol.Types.ClientSymbolResolveOptions
+import LSP.Protocol.Types.ClientCompletionItemOptions
+import LSP.Protocol.Types.ClientCompletionItemOptionsKind
+import LSP.Protocol.Types.CompletionListCapabilities
+import LSP.Protocol.Types.ClientSignatureInformationOptions
+import LSP.Protocol.Types.ClientCodeActionLiteralOptions
+import LSP.Protocol.Types.ClientCodeActionResolveOptions
+import LSP.Protocol.Types.ClientCodeLensResolveOptions
+import LSP.Protocol.Types.ClientFoldingRangeKindOptions
+import LSP.Protocol.Types.ClientFoldingRangeOptions
+import LSP.Protocol.Types.DiagnosticsCapabilities
+import LSP.Protocol.Types.ClientSemanticTokensRequestOptions
+import LSP.Protocol.Types.ClientInlayHintResolveOptions
+import LSP.Protocol.Types.ClientShowMessageActionItemOptions
+import LSP.Protocol.Types.CompletionItemTagOptions
+import LSP.Protocol.Types.ClientCompletionItemResolveOptions
+import LSP.Protocol.Types.ClientCompletionItemInsertTextModeOptions
+import LSP.Protocol.Types.ClientSignatureParameterInformationOptions
+import LSP.Protocol.Types.ClientCodeActionKindOptions
+import LSP.Protocol.Types.ClientDiagnosticsTagOptions
+import LSP.Protocol.Types.ClientSemanticTokensRequestFullDelta
+import LSP.Protocol.Types.SemanticTokenTypes
+import LSP.Protocol.Types.SemanticTokenModifiers
+import LSP.Protocol.Types.DocumentDiagnosticReportKind
+import LSP.Protocol.Types.ErrorCodes
+import LSP.Protocol.Types.LSPErrorCodes
+import LSP.Protocol.Types.FoldingRangeKind
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
+import LSP.Protocol.Types.UniquenessLevel
+import LSP.Protocol.Types.MonikerKind
+import LSP.Protocol.Types.InlayHintKind
+import LSP.Protocol.Types.MessageType
+import LSP.Protocol.Types.TextDocumentSyncKind
+import LSP.Protocol.Types.TextDocumentSaveReason
+import LSP.Protocol.Types.CompletionItemKind
+import LSP.Protocol.Types.CompletionItemTag
+import LSP.Protocol.Types.InsertTextFormat
+import LSP.Protocol.Types.InsertTextMode
+import LSP.Protocol.Types.DocumentHighlightKind
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.TraceValue
+import LSP.Protocol.Types.MarkupKind
+import LSP.Protocol.Types.LanguageKind
+import LSP.Protocol.Types.InlineCompletionTriggerKind
+import LSP.Protocol.Types.PositionEncodingKind
+import LSP.Protocol.Types.FileChangeType
+import LSP.Protocol.Types.WatchKind
+import LSP.Protocol.Types.DiagnosticSeverity
+import LSP.Protocol.Types.DiagnosticTag
+import LSP.Protocol.Types.CompletionTriggerKind
+import LSP.Protocol.Types.SignatureHelpTriggerKind
+import LSP.Protocol.Types.CodeActionTriggerKind
+import LSP.Protocol.Types.FileOperationPatternKind
+import LSP.Protocol.Types.NotebookCellKind
+import LSP.Protocol.Types.ResourceOperationKind
+import LSP.Protocol.Types.FailureHandlingKind
+import LSP.Protocol.Types.PrepareSupportDefaultBehavior
+import LSP.Protocol.Types.TokenFormat
+import LSP.Protocol.Types.Definition
+import LSP.Protocol.Types.DefinitionLink
+import LSP.Protocol.Types.LSPArray
+import LSP.Protocol.Types.Declaration
+import LSP.Protocol.Types.DeclarationLink
+import LSP.Protocol.Types.InlineValue
+import LSP.Protocol.Types.DocumentDiagnosticReport
+import LSP.Protocol.Types.PrepareRenameResult
+import LSP.Protocol.Types.DocumentSelector
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Protocol.Types.WorkspaceDocumentDiagnosticReport
+import LSP.Protocol.Types.TextDocumentContentChangeEvent
+import LSP.Protocol.Types.MarkedString
+import LSP.Protocol.Types.DocumentFilter
+import LSP.Protocol.Types.LSPObject
+import LSP.Protocol.Types.GlobPattern
+import LSP.Protocol.Types.TextDocumentFilter
+import LSP.Protocol.Types.NotebookDocumentFilter
+import LSP.Protocol.Types.Pattern
+import LSP.Protocol.Types.RegularExpressionEngineKind
 

--- a/src/LSP/Protocol/Types/AnnotatedTextEdit.curry
+++ b/src/LSP/Protocol/Types/AnnotatedTextEdit.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.AnnotatedTextEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON AnnotatedTextEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedAnnotationId <- lookupFromJSON "annotationId" vs
+           return
+            AnnotatedTextEdit { annotatedTextEditAnnotationId = parsedAnnotationId }
+      _ -> Left ("Unrecognized AnnotatedTextEdit value: " ++ ppJSON j)
+
+data AnnotatedTextEdit = AnnotatedTextEdit { annotatedTextEditAnnotationId :: ChangeAnnotationIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ApplyWorkspaceEditParams.curry
+++ b/src/LSP/Protocol/Types/ApplyWorkspaceEditParams.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ApplyWorkspaceEditParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceEdit
+import LSP.Protocol.Types.WorkspaceEditMetadata
+import LSP.Utils.JSON
+
+instance FromJSON ApplyWorkspaceEditParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupMaybeFromJSON "label" vs
+           parsedEdit <- lookupFromJSON "edit" vs
+           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
+           return
+            ApplyWorkspaceEditParams { applyWorkspaceEditParamsLabel = parsedLabel
+                                     , applyWorkspaceEditParamsEdit = parsedEdit
+                                     , applyWorkspaceEditParamsMetadata = parsedMetadata }
+      _ -> Left ("Unrecognized ApplyWorkspaceEditParams value: " ++ ppJSON j)
+
+data ApplyWorkspaceEditParams = ApplyWorkspaceEditParams { applyWorkspaceEditParamsLabel :: Maybe String
+                                                         , applyWorkspaceEditParamsEdit :: WorkspaceEdit
+                                                         , applyWorkspaceEditParamsMetadata :: Maybe WorkspaceEditMetadata }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ApplyWorkspaceEditResult.curry
+++ b/src/LSP/Protocol/Types/ApplyWorkspaceEditResult.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ApplyWorkspaceEditResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ApplyWorkspaceEditResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedApplied <- lookupFromJSON "applied" vs
+           parsedFailureReason <- lookupMaybeFromJSON "failureReason" vs
+           parsedFailedChange <- lookupMaybeFromJSON "failedChange" vs
+           return
+            ApplyWorkspaceEditResult { applyWorkspaceEditResultApplied = parsedApplied
+                                     , applyWorkspaceEditResultFailureReason = parsedFailureReason
+                                     , applyWorkspaceEditResultFailedChange = parsedFailedChange }
+      _ -> Left ("Unrecognized ApplyWorkspaceEditResult value: " ++ ppJSON j)
+
+data ApplyWorkspaceEditResult = ApplyWorkspaceEditResult { applyWorkspaceEditResultApplied :: Bool
+                                                         , applyWorkspaceEditResultFailureReason :: Maybe String
+                                                         , applyWorkspaceEditResultFailedChange :: Maybe Int }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/BaseInitializeParams.curry
+++ b/src/LSP/Protocol/Types/BaseInitializeParams.curry
@@ -1,0 +1,47 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.BaseInitializeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.ClientCapabilities
+import LSP.Protocol.Types.ClientInfo
+import LSP.Protocol.Types.TraceValue
+import LSP.Utils.JSON
+
+instance FromJSON BaseInitializeParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProcessId <- lookupFromJSON "processId" vs
+           parsedClientInfo <- lookupMaybeFromJSON "clientInfo" vs
+           parsedLocale <- lookupMaybeFromJSON "locale" vs
+           parsedRootPath <- lookupMaybeFromJSON "rootPath" vs
+           parsedRootUri <- lookupFromJSON "rootUri" vs
+           parsedCapabilities <- lookupFromJSON "capabilities" vs
+           parsedInitializationOptions <- lookupMaybeFromJSON
+                                           "initializationOptions"
+                                           vs
+           parsedTrace <- lookupMaybeFromJSON "trace" vs
+           return
+            BaseInitializeParams { baseInitializeParamsProcessId = parsedProcessId
+                                 , baseInitializeParamsClientInfo = parsedClientInfo
+                                 , baseInitializeParamsLocale = parsedLocale
+                                 , baseInitializeParamsRootPath = parsedRootPath
+                                 , baseInitializeParamsRootUri = parsedRootUri
+                                 , baseInitializeParamsCapabilities = parsedCapabilities
+                                 , baseInitializeParamsInitializationOptions = parsedInitializationOptions
+                                 , baseInitializeParamsTrace = parsedTrace }
+      _ -> Left ("Unrecognized BaseInitializeParams value: " ++ ppJSON j)
+
+data BaseInitializeParams = BaseInitializeParams { baseInitializeParamsProcessId :: Either Int ()
+                                                 , baseInitializeParamsClientInfo :: Maybe ClientInfo
+                                                 , baseInitializeParamsLocale :: Maybe String
+                                                 , baseInitializeParamsRootPath :: Maybe (Either String ())
+                                                 , baseInitializeParamsRootUri :: Either DocumentUri ()
+                                                 , baseInitializeParamsCapabilities :: ClientCapabilities
+                                                 , baseInitializeParamsInitializationOptions :: Maybe LSPAny
+                                                 , baseInitializeParamsTrace :: Maybe TraceValue }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/BaseSymbolInformation.curry
+++ b/src/LSP/Protocol/Types/BaseSymbolInformation.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.BaseSymbolInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
+import LSP.Utils.JSON
+
+instance FromJSON BaseSymbolInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedContainerName <- lookupMaybeFromJSON "containerName" vs
+           return
+            BaseSymbolInformation { baseSymbolInformationName = parsedName
+                                  , baseSymbolInformationKind = parsedKind
+                                  , baseSymbolInformationTags = parsedTags
+                                  , baseSymbolInformationContainerName = parsedContainerName }
+      _ -> Left ("Unrecognized BaseSymbolInformation value: " ++ ppJSON j)
+
+data BaseSymbolInformation = BaseSymbolInformation { baseSymbolInformationName :: String
+                                                   , baseSymbolInformationKind :: SymbolKind
+                                                   , baseSymbolInformationTags :: Maybe [SymbolTag]
+                                                   , baseSymbolInformationContainerName :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            CallHierarchyClientCapabilities { callHierarchyClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized CallHierarchyClientCapabilities value: " ++ ppJSON j)
+
+data CallHierarchyClientCapabilities = CallHierarchyClientCapabilities { callHierarchyClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyIncomingCall.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyIncomingCall.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyIncomingCall where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyIncomingCall where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFrom <- lookupFromJSON "from" vs
+           parsedFromRanges <- lookupFromJSON "fromRanges" vs
+           return
+            CallHierarchyIncomingCall { callHierarchyIncomingCallFrom = parsedFrom
+                                      , callHierarchyIncomingCallFromRanges = parsedFromRanges }
+      _ -> Left ("Unrecognized CallHierarchyIncomingCall value: " ++ ppJSON j)
+
+data CallHierarchyIncomingCall = CallHierarchyIncomingCall { callHierarchyIncomingCallFrom :: CallHierarchyItem
+                                                           , callHierarchyIncomingCallFromRanges :: [Range] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyIncomingCallsParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyIncomingCallsParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyIncomingCallsParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyIncomingCallsParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItem <- lookupFromJSON "item" vs
+           return
+            CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem = parsedItem }
+      _ ->
+        Left
+         ("Unrecognized CallHierarchyIncomingCallsParams value: " ++ ppJSON j)
+
+data CallHierarchyIncomingCallsParams = CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem :: CallHierarchyItem }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyItem.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyItem.curry
@@ -1,0 +1,45 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedDetail <- lookupMaybeFromJSON "detail" vs
+           parsedUri <- lookupFromJSON "uri" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            CallHierarchyItem { callHierarchyItemName = parsedName
+                              , callHierarchyItemKind = parsedKind
+                              , callHierarchyItemTags = parsedTags
+                              , callHierarchyItemDetail = parsedDetail
+                              , callHierarchyItemUri = parsedUri
+                              , callHierarchyItemRange = parsedRange
+                              , callHierarchyItemSelectionRange = parsedSelectionRange
+                              , callHierarchyItemData = parsedData }
+      _ -> Left ("Unrecognized CallHierarchyItem value: " ++ ppJSON j)
+
+data CallHierarchyItem = CallHierarchyItem { callHierarchyItemName :: String
+                                           , callHierarchyItemKind :: SymbolKind
+                                           , callHierarchyItemTags :: Maybe [SymbolTag]
+                                           , callHierarchyItemDetail :: Maybe String
+                                           , callHierarchyItemUri :: DocumentUri
+                                           , callHierarchyItemRange :: Range
+                                           , callHierarchyItemSelectionRange :: Range
+                                           , callHierarchyItemData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyOptions.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CallHierarchyOptions {  }
+      _ -> Left ("Unrecognized CallHierarchyOptions value: " ++ ppJSON j)
+
+data CallHierarchyOptions = CallHierarchyOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyOutgoingCall.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyOutgoingCall.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyOutgoingCall where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyOutgoingCall where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTo <- lookupFromJSON "to" vs
+           parsedFromRanges <- lookupFromJSON "fromRanges" vs
+           return
+            CallHierarchyOutgoingCall { callHierarchyOutgoingCallTo = parsedTo
+                                      , callHierarchyOutgoingCallFromRanges = parsedFromRanges }
+      _ -> Left ("Unrecognized CallHierarchyOutgoingCall value: " ++ ppJSON j)
+
+data CallHierarchyOutgoingCall = CallHierarchyOutgoingCall { callHierarchyOutgoingCallTo :: CallHierarchyItem
+                                                           , callHierarchyOutgoingCallFromRanges :: [Range] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyOutgoingCallsParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyOutgoingCallsParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyOutgoingCallsParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyOutgoingCallsParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItem <- lookupFromJSON "item" vs
+           return
+            CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem = parsedItem }
+      _ ->
+        Left
+         ("Unrecognized CallHierarchyOutgoingCallsParams value: " ++ ppJSON j)
+
+data CallHierarchyOutgoingCallsParams = CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem :: CallHierarchyItem }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyPrepareParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyPrepareParams.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyPrepareParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyPrepareParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CallHierarchyPrepareParams {  }
+      _ ->
+        Left ("Unrecognized CallHierarchyPrepareParams value: " ++ ppJSON j)
+
+data CallHierarchyPrepareParams = CallHierarchyPrepareParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CallHierarchyRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CallHierarchyRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CallHierarchyRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CallHierarchyRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized CallHierarchyRegistrationOptions value: " ++ ppJSON j)
+
+data CallHierarchyRegistrationOptions = CallHierarchyRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CancelParams.curry
+++ b/src/LSP/Protocol/Types/CancelParams.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CancelParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CancelParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedId <- lookupFromJSON "id" vs
+           return CancelParams { cancelParamsId = parsedId }
+      _ -> Left ("Unrecognized CancelParams value: " ++ ppJSON j)
+
+data CancelParams = CancelParams { cancelParamsId :: Either Int String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ChangeAnnotation.curry
+++ b/src/LSP/Protocol/Types/ChangeAnnotation.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ChangeAnnotation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ChangeAnnotation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupFromJSON "label" vs
+           parsedNeedsConfirmation <- lookupMaybeFromJSON "needsConfirmation"
+                                       vs
+           parsedDescription <- lookupMaybeFromJSON "description" vs
+           return
+            ChangeAnnotation { changeAnnotationLabel = parsedLabel
+                             , changeAnnotationNeedsConfirmation = parsedNeedsConfirmation
+                             , changeAnnotationDescription = parsedDescription }
+      _ -> Left ("Unrecognized ChangeAnnotation value: " ++ ppJSON j)
+
+data ChangeAnnotation = ChangeAnnotation { changeAnnotationLabel :: String
+                                         , changeAnnotationNeedsConfirmation :: Maybe Bool
+                                         , changeAnnotationDescription :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ChangeAnnotationIdentifier.curry
+++ b/src/LSP/Protocol/Types/ChangeAnnotationIdentifier.curry
@@ -1,0 +1,6 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ChangeAnnotationIdentifier where
+
+type ChangeAnnotationIdentifier = String
+

--- a/src/LSP/Protocol/Types/ChangeAnnotationsSupportOptions.curry
+++ b/src/LSP/Protocol/Types/ChangeAnnotationsSupportOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ChangeAnnotationsSupportOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ChangeAnnotationsSupportOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedGroupsOnLabel <- lookupMaybeFromJSON "groupsOnLabel" vs
+           return
+            ChangeAnnotationsSupportOptions { changeAnnotationsSupportOptionsGroupsOnLabel = parsedGroupsOnLabel }
+      _ ->
+        Left
+         ("Unrecognized ChangeAnnotationsSupportOptions value: " ++ ppJSON j)
+
+data ChangeAnnotationsSupportOptions = ChangeAnnotationsSupportOptions { changeAnnotationsSupportOptionsGroupsOnLabel :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ClientCapabilities.curry
@@ -1,0 +1,41 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.GeneralClientCapabilities
+import LSP.Protocol.Types.NotebookDocumentClientCapabilities
+import LSP.Protocol.Types.TextDocumentClientCapabilities
+import LSP.Protocol.Types.WindowClientCapabilities
+import LSP.Protocol.Types.WorkspaceClientCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON ClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkspace <- lookupMaybeFromJSON "workspace" vs
+           parsedTextDocument <- lookupMaybeFromJSON "textDocument" vs
+           parsedNotebookDocument <- lookupMaybeFromJSON "notebookDocument" vs
+           parsedWindow <- lookupMaybeFromJSON "window" vs
+           parsedGeneral <- lookupMaybeFromJSON "general" vs
+           parsedExperimental <- lookupMaybeFromJSON "experimental" vs
+           return
+            ClientCapabilities { clientCapabilitiesWorkspace = parsedWorkspace
+                               , clientCapabilitiesTextDocument = parsedTextDocument
+                               , clientCapabilitiesNotebookDocument = parsedNotebookDocument
+                               , clientCapabilitiesWindow = parsedWindow
+                               , clientCapabilitiesGeneral = parsedGeneral
+                               , clientCapabilitiesExperimental = parsedExperimental }
+      _ -> Left ("Unrecognized ClientCapabilities value: " ++ ppJSON j)
+
+data ClientCapabilities = ClientCapabilities { clientCapabilitiesWorkspace :: Maybe WorkspaceClientCapabilities
+                                             , clientCapabilitiesTextDocument :: Maybe TextDocumentClientCapabilities
+                                             , clientCapabilitiesNotebookDocument :: Maybe NotebookDocumentClientCapabilities
+                                             , clientCapabilitiesWindow :: Maybe WindowClientCapabilities
+                                             , clientCapabilitiesGeneral :: Maybe GeneralClientCapabilities
+                                             , clientCapabilitiesExperimental :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCodeActionKindOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCodeActionKindOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCodeActionKindOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientCodeActionKindOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupFromJSON "valueSet" vs
+           return
+            ClientCodeActionKindOptions { clientCodeActionKindOptionsValueSet = parsedValueSet }
+      _ ->
+        Left ("Unrecognized ClientCodeActionKindOptions value: " ++ ppJSON j)
+
+data ClientCodeActionKindOptions = ClientCodeActionKindOptions { clientCodeActionKindOptionsValueSet :: [CodeActionKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCodeActionLiteralOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCodeActionLiteralOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCodeActionLiteralOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientCodeActionKindOptions
+import LSP.Utils.JSON
+
+instance FromJSON ClientCodeActionLiteralOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCodeActionKind <- lookupFromJSON "codeActionKind" vs
+           return
+            ClientCodeActionLiteralOptions { clientCodeActionLiteralOptionsCodeActionKind = parsedCodeActionKind }
+      _ ->
+        Left
+         ("Unrecognized ClientCodeActionLiteralOptions value: " ++ ppJSON j)
+
+data ClientCodeActionLiteralOptions = ClientCodeActionLiteralOptions { clientCodeActionLiteralOptionsCodeActionKind :: ClientCodeActionKindOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCodeActionResolveOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCodeActionResolveOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCodeActionResolveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientCodeActionResolveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProperties <- lookupFromJSON "properties" vs
+           return
+            ClientCodeActionResolveOptions { clientCodeActionResolveOptionsProperties = parsedProperties }
+      _ ->
+        Left
+         ("Unrecognized ClientCodeActionResolveOptions value: " ++ ppJSON j)
+
+data ClientCodeActionResolveOptions = ClientCodeActionResolveOptions { clientCodeActionResolveOptionsProperties :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCodeLensResolveOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCodeLensResolveOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCodeLensResolveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientCodeLensResolveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProperties <- lookupFromJSON "properties" vs
+           return
+            ClientCodeLensResolveOptions { clientCodeLensResolveOptionsProperties = parsedProperties }
+      _ ->
+        Left ("Unrecognized ClientCodeLensResolveOptions value: " ++ ppJSON j)
+
+data ClientCodeLensResolveOptions = ClientCodeLensResolveOptions { clientCodeLensResolveOptionsProperties :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCompletionItemInsertTextModeOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCompletionItemInsertTextModeOptions.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCompletionItemInsertTextModeOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.InsertTextMode
+import LSP.Utils.JSON
+
+instance FromJSON ClientCompletionItemInsertTextModeOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupFromJSON "valueSet" vs
+           return
+            ClientCompletionItemInsertTextModeOptions { clientCompletionItemInsertTextModeOptionsValueSet = parsedValueSet }
+      _ ->
+        Left
+         ("Unrecognized ClientCompletionItemInsertTextModeOptions value: "
+           ++ ppJSON j)
+
+data ClientCompletionItemInsertTextModeOptions = ClientCompletionItemInsertTextModeOptions { clientCompletionItemInsertTextModeOptionsValueSet :: [InsertTextMode] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCompletionItemOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCompletionItemOptions.curry
@@ -1,0 +1,63 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCompletionItemOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientCompletionItemInsertTextModeOptions
+import LSP.Protocol.Types.ClientCompletionItemResolveOptions
+import LSP.Protocol.Types.CompletionItemTagOptions
+import LSP.Protocol.Types.MarkupKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientCompletionItemOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSnippetSupport <- lookupMaybeFromJSON "snippetSupport" vs
+           parsedCommitCharactersSupport <- lookupMaybeFromJSON
+                                             "commitCharactersSupport"
+                                             vs
+           parsedDocumentationFormat <- lookupMaybeFromJSON
+                                         "documentationFormat"
+                                         vs
+           parsedDeprecatedSupport <- lookupMaybeFromJSON "deprecatedSupport"
+                                       vs
+           parsedPreselectSupport <- lookupMaybeFromJSON "preselectSupport" vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedInsertReplaceSupport <- lookupMaybeFromJSON
+                                          "insertReplaceSupport"
+                                          vs
+           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
+           parsedInsertTextModeSupport <- lookupMaybeFromJSON
+                                           "insertTextModeSupport"
+                                           vs
+           parsedLabelDetailsSupport <- lookupMaybeFromJSON
+                                         "labelDetailsSupport"
+                                         vs
+           return
+            ClientCompletionItemOptions { clientCompletionItemOptionsSnippetSupport = parsedSnippetSupport
+                                        , clientCompletionItemOptionsCommitCharactersSupport = parsedCommitCharactersSupport
+                                        , clientCompletionItemOptionsDocumentationFormat = parsedDocumentationFormat
+                                        , clientCompletionItemOptionsDeprecatedSupport = parsedDeprecatedSupport
+                                        , clientCompletionItemOptionsPreselectSupport = parsedPreselectSupport
+                                        , clientCompletionItemOptionsTagSupport = parsedTagSupport
+                                        , clientCompletionItemOptionsInsertReplaceSupport = parsedInsertReplaceSupport
+                                        , clientCompletionItemOptionsResolveSupport = parsedResolveSupport
+                                        , clientCompletionItemOptionsInsertTextModeSupport = parsedInsertTextModeSupport
+                                        , clientCompletionItemOptionsLabelDetailsSupport = parsedLabelDetailsSupport }
+      _ ->
+        Left ("Unrecognized ClientCompletionItemOptions value: " ++ ppJSON j)
+
+data ClientCompletionItemOptions = ClientCompletionItemOptions { clientCompletionItemOptionsSnippetSupport :: Maybe Bool
+                                                               , clientCompletionItemOptionsCommitCharactersSupport :: Maybe Bool
+                                                               , clientCompletionItemOptionsDocumentationFormat :: Maybe [MarkupKind]
+                                                               , clientCompletionItemOptionsDeprecatedSupport :: Maybe Bool
+                                                               , clientCompletionItemOptionsPreselectSupport :: Maybe Bool
+                                                               , clientCompletionItemOptionsTagSupport :: Maybe CompletionItemTagOptions
+                                                               , clientCompletionItemOptionsInsertReplaceSupport :: Maybe Bool
+                                                               , clientCompletionItemOptionsResolveSupport :: Maybe ClientCompletionItemResolveOptions
+                                                               , clientCompletionItemOptionsInsertTextModeSupport :: Maybe ClientCompletionItemInsertTextModeOptions
+                                                               , clientCompletionItemOptionsLabelDetailsSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCompletionItemOptionsKind.curry
+++ b/src/LSP/Protocol/Types/ClientCompletionItemOptionsKind.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCompletionItemOptionsKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CompletionItemKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientCompletionItemOptionsKind where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
+           return
+            ClientCompletionItemOptionsKind { clientCompletionItemOptionsKindValueSet = parsedValueSet }
+      _ ->
+        Left
+         ("Unrecognized ClientCompletionItemOptionsKind value: " ++ ppJSON j)
+
+data ClientCompletionItemOptionsKind = ClientCompletionItemOptionsKind { clientCompletionItemOptionsKindValueSet :: Maybe [CompletionItemKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientCompletionItemResolveOptions.curry
+++ b/src/LSP/Protocol/Types/ClientCompletionItemResolveOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientCompletionItemResolveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientCompletionItemResolveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProperties <- lookupFromJSON "properties" vs
+           return
+            ClientCompletionItemResolveOptions { clientCompletionItemResolveOptionsProperties = parsedProperties }
+      _ ->
+        Left
+         ("Unrecognized ClientCompletionItemResolveOptions value: "
+           ++ ppJSON j)
+
+data ClientCompletionItemResolveOptions = ClientCompletionItemResolveOptions { clientCompletionItemResolveOptionsProperties :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientDiagnosticsTagOptions.curry
+++ b/src/LSP/Protocol/Types/ClientDiagnosticsTagOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientDiagnosticsTagOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.DiagnosticTag
+import LSP.Utils.JSON
+
+instance FromJSON ClientDiagnosticsTagOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupFromJSON "valueSet" vs
+           return
+            ClientDiagnosticsTagOptions { clientDiagnosticsTagOptionsValueSet = parsedValueSet }
+      _ ->
+        Left ("Unrecognized ClientDiagnosticsTagOptions value: " ++ ppJSON j)
+
+data ClientDiagnosticsTagOptions = ClientDiagnosticsTagOptions { clientDiagnosticsTagOptionsValueSet :: [DiagnosticTag] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientFoldingRangeKindOptions.curry
+++ b/src/LSP/Protocol/Types/ClientFoldingRangeKindOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientFoldingRangeKindOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FoldingRangeKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientFoldingRangeKindOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
+           return
+            ClientFoldingRangeKindOptions { clientFoldingRangeKindOptionsValueSet = parsedValueSet }
+      _ ->
+        Left
+         ("Unrecognized ClientFoldingRangeKindOptions value: " ++ ppJSON j)
+
+data ClientFoldingRangeKindOptions = ClientFoldingRangeKindOptions { clientFoldingRangeKindOptionsValueSet :: Maybe [FoldingRangeKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientFoldingRangeOptions.curry
+++ b/src/LSP/Protocol/Types/ClientFoldingRangeOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientFoldingRangeOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientFoldingRangeOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCollapsedText <- lookupMaybeFromJSON "collapsedText" vs
+           return
+            ClientFoldingRangeOptions { clientFoldingRangeOptionsCollapsedText = parsedCollapsedText }
+      _ -> Left ("Unrecognized ClientFoldingRangeOptions value: " ++ ppJSON j)
+
+data ClientFoldingRangeOptions = ClientFoldingRangeOptions { clientFoldingRangeOptionsCollapsedText :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientInfo.curry
+++ b/src/LSP/Protocol/Types/ClientInfo.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientInfo where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientInfo where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedVersion <- lookupMaybeFromJSON "version" vs
+           return
+            ClientInfo { clientInfoName = parsedName
+                       , clientInfoVersion = parsedVersion }
+      _ -> Left ("Unrecognized ClientInfo value: " ++ ppJSON j)
+
+data ClientInfo = ClientInfo { clientInfoName :: String
+                             , clientInfoVersion :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientInlayHintResolveOptions.curry
+++ b/src/LSP/Protocol/Types/ClientInlayHintResolveOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientInlayHintResolveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientInlayHintResolveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProperties <- lookupFromJSON "properties" vs
+           return
+            ClientInlayHintResolveOptions { clientInlayHintResolveOptionsProperties = parsedProperties }
+      _ ->
+        Left
+         ("Unrecognized ClientInlayHintResolveOptions value: " ++ ppJSON j)
+
+data ClientInlayHintResolveOptions = ClientInlayHintResolveOptions { clientInlayHintResolveOptionsProperties :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSemanticTokensRequestFullDelta.curry
+++ b/src/LSP/Protocol/Types/ClientSemanticTokensRequestFullDelta.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSemanticTokensRequestFullDelta where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientSemanticTokensRequestFullDelta where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDelta <- lookupMaybeFromJSON "delta" vs
+           return
+            ClientSemanticTokensRequestFullDelta { clientSemanticTokensRequestFullDeltaDelta = parsedDelta }
+      _ ->
+        Left
+         ("Unrecognized ClientSemanticTokensRequestFullDelta value: "
+           ++ ppJSON j)
+
+data ClientSemanticTokensRequestFullDelta = ClientSemanticTokensRequestFullDelta { clientSemanticTokensRequestFullDeltaDelta :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSemanticTokensRequestOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSemanticTokensRequestOptions.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSemanticTokensRequestOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSemanticTokensRequestFullDelta
+import LSP.Utils.JSON
+
+instance FromJSON ClientSemanticTokensRequestOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupMaybeFromJSON "range" vs
+           parsedFull <- lookupMaybeFromJSON "full" vs
+           return
+            ClientSemanticTokensRequestOptions { clientSemanticTokensRequestOptionsRange = parsedRange
+                                               , clientSemanticTokensRequestOptionsFull = parsedFull }
+      _ ->
+        Left
+         ("Unrecognized ClientSemanticTokensRequestOptions value: "
+           ++ ppJSON j)
+
+data ClientSemanticTokensRequestOptions = ClientSemanticTokensRequestOptions { clientSemanticTokensRequestOptionsRange :: Maybe (Either Bool ())
+                                                                             , clientSemanticTokensRequestOptionsFull :: Maybe (Either Bool ClientSemanticTokensRequestFullDelta) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientShowMessageActionItemOptions.curry
+++ b/src/LSP/Protocol/Types/ClientShowMessageActionItemOptions.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientShowMessageActionItemOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientShowMessageActionItemOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedAdditionalPropertiesSupport <- lookupMaybeFromJSON
+                                                 "additionalPropertiesSupport"
+                                                 vs
+           return
+            ClientShowMessageActionItemOptions { clientShowMessageActionItemOptionsAdditionalPropertiesSupport = parsedAdditionalPropertiesSupport }
+      _ ->
+        Left
+         ("Unrecognized ClientShowMessageActionItemOptions value: "
+           ++ ppJSON j)
+
+data ClientShowMessageActionItemOptions = ClientShowMessageActionItemOptions { clientShowMessageActionItemOptionsAdditionalPropertiesSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSignatureInformationOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSignatureInformationOptions.curry
@@ -1,0 +1,42 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSignatureInformationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSignatureParameterInformationOptions
+import LSP.Protocol.Types.MarkupKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientSignatureInformationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDocumentationFormat <- lookupMaybeFromJSON
+                                         "documentationFormat"
+                                         vs
+           parsedParameterInformation <- lookupMaybeFromJSON
+                                          "parameterInformation"
+                                          vs
+           parsedActiveParameterSupport <- lookupMaybeFromJSON
+                                            "activeParameterSupport"
+                                            vs
+           parsedNoActiveParameterSupport <- lookupMaybeFromJSON
+                                              "noActiveParameterSupport"
+                                              vs
+           return
+            ClientSignatureInformationOptions { clientSignatureInformationOptionsDocumentationFormat = parsedDocumentationFormat
+                                              , clientSignatureInformationOptionsParameterInformation = parsedParameterInformation
+                                              , clientSignatureInformationOptionsActiveParameterSupport = parsedActiveParameterSupport
+                                              , clientSignatureInformationOptionsNoActiveParameterSupport = parsedNoActiveParameterSupport }
+      _ ->
+        Left
+         ("Unrecognized ClientSignatureInformationOptions value: "
+           ++ ppJSON j)
+
+data ClientSignatureInformationOptions = ClientSignatureInformationOptions { clientSignatureInformationOptionsDocumentationFormat :: Maybe [MarkupKind]
+                                                                           , clientSignatureInformationOptionsParameterInformation :: Maybe ClientSignatureParameterInformationOptions
+                                                                           , clientSignatureInformationOptionsActiveParameterSupport :: Maybe Bool
+                                                                           , clientSignatureInformationOptionsNoActiveParameterSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSignatureParameterInformationOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSignatureParameterInformationOptions.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSignatureParameterInformationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientSignatureParameterInformationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabelOffsetSupport <- lookupMaybeFromJSON
+                                        "labelOffsetSupport"
+                                        vs
+           return
+            ClientSignatureParameterInformationOptions { clientSignatureParameterInformationOptionsLabelOffsetSupport = parsedLabelOffsetSupport }
+      _ ->
+        Left
+         ("Unrecognized ClientSignatureParameterInformationOptions value: "
+           ++ ppJSON j)
+
+data ClientSignatureParameterInformationOptions = ClientSignatureParameterInformationOptions { clientSignatureParameterInformationOptionsLabelOffsetSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSymbolKindOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSymbolKindOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSymbolKindOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SymbolKind
+import LSP.Utils.JSON
+
+instance FromJSON ClientSymbolKindOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupMaybeFromJSON "valueSet" vs
+           return
+            ClientSymbolKindOptions { clientSymbolKindOptionsValueSet = parsedValueSet }
+      _ -> Left ("Unrecognized ClientSymbolKindOptions value: " ++ ppJSON j)
+
+data ClientSymbolKindOptions = ClientSymbolKindOptions { clientSymbolKindOptionsValueSet :: Maybe [SymbolKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSymbolResolveOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSymbolResolveOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSymbolResolveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ClientSymbolResolveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedProperties <- lookupFromJSON "properties" vs
+           return
+            ClientSymbolResolveOptions { clientSymbolResolveOptionsProperties = parsedProperties }
+      _ ->
+        Left ("Unrecognized ClientSymbolResolveOptions value: " ++ ppJSON j)
+
+data ClientSymbolResolveOptions = ClientSymbolResolveOptions { clientSymbolResolveOptionsProperties :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ClientSymbolTagOptions.curry
+++ b/src/LSP/Protocol/Types/ClientSymbolTagOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ClientSymbolTagOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SymbolTag
+import LSP.Utils.JSON
+
+instance FromJSON ClientSymbolTagOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupFromJSON "valueSet" vs
+           return
+            ClientSymbolTagOptions { clientSymbolTagOptionsValueSet = parsedValueSet }
+      _ -> Left ("Unrecognized ClientSymbolTagOptions value: " ++ ppJSON j)
+
+data ClientSymbolTagOptions = ClientSymbolTagOptions { clientSymbolTagOptionsValueSet :: [SymbolTag] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeAction.curry
+++ b/src/LSP/Protocol/Types/CodeAction.curry
@@ -1,0 +1,47 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeAction where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.CodeActionDisabled
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.Diagnostic
+import LSP.Protocol.Types.WorkspaceEdit
+import LSP.Utils.JSON
+
+instance FromJSON CodeAction where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTitle <- lookupFromJSON "title" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           parsedDiagnostics <- lookupMaybeFromJSON "diagnostics" vs
+           parsedIsPreferred <- lookupMaybeFromJSON "isPreferred" vs
+           parsedDisabled <- lookupMaybeFromJSON "disabled" vs
+           parsedEdit <- lookupMaybeFromJSON "edit" vs
+           parsedCommand <- lookupMaybeFromJSON "command" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            CodeAction { codeActionTitle = parsedTitle
+                       , codeActionKind = parsedKind
+                       , codeActionDiagnostics = parsedDiagnostics
+                       , codeActionIsPreferred = parsedIsPreferred
+                       , codeActionDisabled = parsedDisabled
+                       , codeActionEdit = parsedEdit
+                       , codeActionCommand = parsedCommand
+                       , codeActionData = parsedData }
+      _ -> Left ("Unrecognized CodeAction value: " ++ ppJSON j)
+
+data CodeAction = CodeAction { codeActionTitle :: String
+                             , codeActionKind :: Maybe CodeActionKind
+                             , codeActionDiagnostics :: Maybe [Diagnostic]
+                             , codeActionIsPreferred :: Maybe Bool
+                             , codeActionDisabled :: Maybe CodeActionDisabled
+                             , codeActionEdit :: Maybe WorkspaceEdit
+                             , codeActionCommand :: Maybe Command
+                             , codeActionData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/CodeActionClientCapabilities.curry
@@ -1,0 +1,54 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientCodeActionLiteralOptions
+import LSP.Protocol.Types.ClientCodeActionResolveOptions
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedCodeActionLiteralSupport <- lookupMaybeFromJSON
+                                              "codeActionLiteralSupport"
+                                              vs
+           parsedIsPreferredSupport <- lookupMaybeFromJSON
+                                        "isPreferredSupport"
+                                        vs
+           parsedDisabledSupport <- lookupMaybeFromJSON "disabledSupport" vs
+           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
+           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
+           parsedHonorsChangeAnnotations <- lookupMaybeFromJSON
+                                             "honorsChangeAnnotations"
+                                             vs
+           parsedDocumentationSupport <- lookupMaybeFromJSON
+                                          "documentationSupport"
+                                          vs
+           return
+            CodeActionClientCapabilities { codeActionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                         , codeActionClientCapabilitiesCodeActionLiteralSupport = parsedCodeActionLiteralSupport
+                                         , codeActionClientCapabilitiesIsPreferredSupport = parsedIsPreferredSupport
+                                         , codeActionClientCapabilitiesDisabledSupport = parsedDisabledSupport
+                                         , codeActionClientCapabilitiesDataSupport = parsedDataSupport
+                                         , codeActionClientCapabilitiesResolveSupport = parsedResolveSupport
+                                         , codeActionClientCapabilitiesHonorsChangeAnnotations = parsedHonorsChangeAnnotations
+                                         , codeActionClientCapabilitiesDocumentationSupport = parsedDocumentationSupport }
+      _ ->
+        Left ("Unrecognized CodeActionClientCapabilities value: " ++ ppJSON j)
+
+data CodeActionClientCapabilities = CodeActionClientCapabilities { codeActionClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                 , codeActionClientCapabilitiesCodeActionLiteralSupport :: Maybe ClientCodeActionLiteralOptions
+                                                                 , codeActionClientCapabilitiesIsPreferredSupport :: Maybe Bool
+                                                                 , codeActionClientCapabilitiesDisabledSupport :: Maybe Bool
+                                                                 , codeActionClientCapabilitiesDataSupport :: Maybe Bool
+                                                                 , codeActionClientCapabilitiesResolveSupport :: Maybe ClientCodeActionResolveOptions
+                                                                 , codeActionClientCapabilitiesHonorsChangeAnnotations :: Maybe Bool
+                                                                 , codeActionClientCapabilitiesDocumentationSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionContext.curry
+++ b/src/LSP/Protocol/Types/CodeActionContext.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.CodeActionTriggerKind
+import LSP.Protocol.Types.Diagnostic
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDiagnostics <- lookupFromJSON "diagnostics" vs
+           parsedOnly <- lookupMaybeFromJSON "only" vs
+           parsedTriggerKind <- lookupMaybeFromJSON "triggerKind" vs
+           return
+            CodeActionContext { codeActionContextDiagnostics = parsedDiagnostics
+                              , codeActionContextOnly = parsedOnly
+                              , codeActionContextTriggerKind = parsedTriggerKind }
+      _ -> Left ("Unrecognized CodeActionContext value: " ++ ppJSON j)
+
+data CodeActionContext = CodeActionContext { codeActionContextDiagnostics :: [Diagnostic]
+                                           , codeActionContextOnly :: Maybe [CodeActionKind]
+                                           , codeActionContextTriggerKind :: Maybe CodeActionTriggerKind }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionDisabled.curry
+++ b/src/LSP/Protocol/Types/CodeActionDisabled.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionDisabled where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionDisabled where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedReason <- lookupFromJSON "reason" vs
+           return
+            CodeActionDisabled { codeActionDisabledReason = parsedReason }
+      _ -> Left ("Unrecognized CodeActionDisabled value: " ++ ppJSON j)
+
+data CodeActionDisabled = CodeActionDisabled { codeActionDisabledReason :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionKind.curry
+++ b/src/LSP/Protocol/Types/CodeActionKind.curry
@@ -1,0 +1,38 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "" -> Right CodeActionKindEmpty
+         "quickfix" -> Right CodeActionKindQuickFix
+         "refactor" -> Right CodeActionKindRefactor
+         "refactor.extract" -> Right CodeActionKindRefactorExtract
+         "refactor.inline" -> Right CodeActionKindRefactorInline
+         "refactor.move" -> Right CodeActionKindRefactorMove
+         "refactor.rewrite" -> Right CodeActionKindRefactorRewrite
+         "source" -> Right CodeActionKindSource
+         "source.organizeImports" -> Right CodeActionKindSourceOrganizeImports
+         "source.fixAll" -> Right CodeActionKindSourceFixAll
+         "notebook" -> Right CodeActionKindNotebook
+         _ -> Left ("Unrecognized CodeActionKind value: " ++ ppJSON j)
+
+data CodeActionKind = CodeActionKindEmpty
+                    | CodeActionKindQuickFix
+                    | CodeActionKindRefactor
+                    | CodeActionKindRefactorExtract
+                    | CodeActionKindRefactorInline
+                    | CodeActionKindRefactorMove
+                    | CodeActionKindRefactorRewrite
+                    | CodeActionKindSource
+                    | CodeActionKindSourceOrganizeImports
+                    | CodeActionKindSourceFixAll
+                    | CodeActionKindNotebook
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/CodeActionKindDocumentation.curry
+++ b/src/LSP/Protocol/Types/CodeActionKindDocumentation.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionKindDocumentation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.Command
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionKindDocumentation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedCommand <- lookupFromJSON "command" vs
+           return
+            CodeActionKindDocumentation { codeActionKindDocumentationKind = parsedKind
+                                        , codeActionKindDocumentationCommand = parsedCommand }
+      _ ->
+        Left ("Unrecognized CodeActionKindDocumentation value: " ++ ppJSON j)
+
+data CodeActionKindDocumentation = CodeActionKindDocumentation { codeActionKindDocumentationKind :: CodeActionKind
+                                                               , codeActionKindDocumentationCommand :: Command }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionOptions.curry
+++ b/src/LSP/Protocol/Types/CodeActionOptions.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.CodeActionKindDocumentation
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCodeActionKinds <- lookupMaybeFromJSON "codeActionKinds" vs
+           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            CodeActionOptions { codeActionOptionsCodeActionKinds = parsedCodeActionKinds
+                              , codeActionOptionsDocumentation = parsedDocumentation
+                              , codeActionOptionsResolveProvider = parsedResolveProvider }
+      _ -> Left ("Unrecognized CodeActionOptions value: " ++ ppJSON j)
+
+data CodeActionOptions = CodeActionOptions { codeActionOptionsCodeActionKinds :: Maybe [CodeActionKind]
+                                           , codeActionOptionsDocumentation :: Maybe [CodeActionKindDocumentation]
+                                           , codeActionOptionsResolveProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionParams.curry
+++ b/src/LSP/Protocol/Types/CodeActionParams.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeActionContext
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedContext <- lookupFromJSON "context" vs
+           return
+            CodeActionParams { codeActionParamsTextDocument = parsedTextDocument
+                             , codeActionParamsRange = parsedRange
+                             , codeActionParamsContext = parsedContext }
+      _ -> Left ("Unrecognized CodeActionParams value: " ++ ppJSON j)
+
+data CodeActionParams = CodeActionParams { codeActionParamsTextDocument :: TextDocumentIdentifier
+                                         , codeActionParamsRange :: Range
+                                         , codeActionParamsContext :: CodeActionContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CodeActionRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CodeActionRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized CodeActionRegistrationOptions value: " ++ ppJSON j)
+
+data CodeActionRegistrationOptions = CodeActionRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeActionTriggerKind.curry
+++ b/src/LSP/Protocol/Types/CodeActionTriggerKind.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeActionTriggerKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeActionTriggerKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right CodeActionTriggerKindInvoked
+         2 -> Right CodeActionTriggerKindAutomatic
+         _ -> Left ("Unrecognized CodeActionTriggerKind value: " ++ ppJSON j)
+
+data CodeActionTriggerKind = CodeActionTriggerKindInvoked
+                           | CodeActionTriggerKindAutomatic
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/CodeDescription.curry
+++ b/src/LSP/Protocol/Types/CodeDescription.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeDescription where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON CodeDescription where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedHref <- lookupFromJSON "href" vs
+           return CodeDescription { codeDescriptionHref = parsedHref }
+      _ -> Left ("Unrecognized CodeDescription value: " ++ ppJSON j)
+
+data CodeDescription = CodeDescription { codeDescriptionHref :: Uri }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLens.curry
+++ b/src/LSP/Protocol/Types/CodeLens.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLens where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON CodeLens where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedCommand <- lookupMaybeFromJSON "command" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            CodeLens { codeLensRange = parsedRange
+                     , codeLensCommand = parsedCommand
+                     , codeLensData = parsedData }
+      _ -> Left ("Unrecognized CodeLens value: " ++ ppJSON j)
+
+data CodeLens = CodeLens { codeLensRange :: Range
+                         , codeLensCommand :: Maybe Command
+                         , codeLensData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLensClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/CodeLensClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLensClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientCodeLensResolveOptions
+import LSP.Utils.JSON
+
+instance FromJSON CodeLensClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
+           return
+            CodeLensClientCapabilities { codeLensClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                       , codeLensClientCapabilitiesResolveSupport = parsedResolveSupport }
+      _ ->
+        Left ("Unrecognized CodeLensClientCapabilities value: " ++ ppJSON j)
+
+data CodeLensClientCapabilities = CodeLensClientCapabilities { codeLensClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                             , codeLensClientCapabilitiesResolveSupport :: Maybe ClientCodeLensResolveOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLensOptions.curry
+++ b/src/LSP/Protocol/Types/CodeLensOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLensOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeLensOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            CodeLensOptions { codeLensOptionsResolveProvider = parsedResolveProvider }
+      _ -> Left ("Unrecognized CodeLensOptions value: " ++ ppJSON j)
+
+data CodeLensOptions = CodeLensOptions { codeLensOptionsResolveProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLensParams.curry
+++ b/src/LSP/Protocol/Types/CodeLensParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLensParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON CodeLensParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            CodeLensParams { codeLensParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized CodeLensParams value: " ++ ppJSON j)
+
+data CodeLensParams = CodeLensParams { codeLensParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLensRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CodeLensRegistrationOptions.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLensRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeLensRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CodeLensRegistrationOptions {  }
+      _ ->
+        Left ("Unrecognized CodeLensRegistrationOptions value: " ++ ppJSON j)
+
+data CodeLensRegistrationOptions = CodeLensRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CodeLensWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/CodeLensWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CodeLensWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CodeLensWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            CodeLensWorkspaceClientCapabilities { codeLensWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized CodeLensWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data CodeLensWorkspaceClientCapabilities = CodeLensWorkspaceClientCapabilities { codeLensWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Color.curry
+++ b/src/LSP/Protocol/Types/Color.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Color where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON Color where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRed <- lookupFromJSON "red" vs
+           parsedGreen <- lookupFromJSON "green" vs
+           parsedBlue <- lookupFromJSON "blue" vs
+           parsedAlpha <- lookupFromJSON "alpha" vs
+           return
+            Color { colorRed = parsedRed
+                  , colorGreen = parsedGreen
+                  , colorBlue = parsedBlue
+                  , colorAlpha = parsedAlpha }
+      _ -> Left ("Unrecognized Color value: " ++ ppJSON j)
+
+data Color = Color { colorRed :: Float
+                   , colorGreen :: Float
+                   , colorBlue :: Float
+                   , colorAlpha :: Float }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ColorInformation.curry
+++ b/src/LSP/Protocol/Types/ColorInformation.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ColorInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Color
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON ColorInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedColor <- lookupFromJSON "color" vs
+           return
+            ColorInformation { colorInformationRange = parsedRange
+                             , colorInformationColor = parsedColor }
+      _ -> Left ("Unrecognized ColorInformation value: " ++ ppJSON j)
+
+data ColorInformation = ColorInformation { colorInformationRange :: Range
+                                         , colorInformationColor :: Color }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ColorPresentation.curry
+++ b/src/LSP/Protocol/Types/ColorPresentation.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ColorPresentation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextEdit
+import LSP.Utils.JSON
+
+instance FromJSON ColorPresentation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupFromJSON "label" vs
+           parsedTextEdit <- lookupMaybeFromJSON "textEdit" vs
+           parsedAdditionalTextEdits <- lookupMaybeFromJSON
+                                         "additionalTextEdits"
+                                         vs
+           return
+            ColorPresentation { colorPresentationLabel = parsedLabel
+                              , colorPresentationTextEdit = parsedTextEdit
+                              , colorPresentationAdditionalTextEdits = parsedAdditionalTextEdits }
+      _ -> Left ("Unrecognized ColorPresentation value: " ++ ppJSON j)
+
+data ColorPresentation = ColorPresentation { colorPresentationLabel :: String
+                                           , colorPresentationTextEdit :: Maybe TextEdit
+                                           , colorPresentationAdditionalTextEdits :: Maybe [TextEdit] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ColorPresentationParams.curry
+++ b/src/LSP/Protocol/Types/ColorPresentationParams.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ColorPresentationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Color
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON ColorPresentationParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedColor <- lookupFromJSON "color" vs
+           parsedRange <- lookupFromJSON "range" vs
+           return
+            ColorPresentationParams { colorPresentationParamsTextDocument = parsedTextDocument
+                                    , colorPresentationParamsColor = parsedColor
+                                    , colorPresentationParamsRange = parsedRange }
+      _ -> Left ("Unrecognized ColorPresentationParams value: " ++ ppJSON j)
+
+data ColorPresentationParams = ColorPresentationParams { colorPresentationParamsTextDocument :: TextDocumentIdentifier
+                                                       , colorPresentationParamsColor :: Color
+                                                       , colorPresentationParamsRange :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Command.curry
+++ b/src/LSP/Protocol/Types/Command.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Command where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON Command where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTitle <- lookupFromJSON "title" vs
+           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
+           parsedCommand <- lookupFromJSON "command" vs
+           parsedArguments <- lookupMaybeFromJSON "arguments" vs
+           return
+            Command { commandTitle = parsedTitle
+                    , commandTooltip = parsedTooltip
+                    , commandCommand = parsedCommand
+                    , commandArguments = parsedArguments }
+      _ -> Left ("Unrecognized Command value: " ++ ppJSON j)
+
+data Command = Command { commandTitle :: String
+                       , commandTooltip :: Maybe String
+                       , commandCommand :: String
+                       , commandArguments :: Maybe [LSPAny] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/CompletionClientCapabilities.curry
@@ -1,0 +1,44 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientCompletionItemOptions
+import LSP.Protocol.Types.ClientCompletionItemOptionsKind
+import LSP.Protocol.Types.CompletionListCapabilities
+import LSP.Protocol.Types.InsertTextMode
+import LSP.Utils.JSON
+
+instance FromJSON CompletionClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
+           parsedCompletionItemKind <- lookupMaybeFromJSON
+                                        "completionItemKind"
+                                        vs
+           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
+           parsedContextSupport <- lookupMaybeFromJSON "contextSupport" vs
+           parsedCompletionList <- lookupMaybeFromJSON "completionList" vs
+           return
+            CompletionClientCapabilities { completionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                         , completionClientCapabilitiesCompletionItem = parsedCompletionItem
+                                         , completionClientCapabilitiesCompletionItemKind = parsedCompletionItemKind
+                                         , completionClientCapabilitiesInsertTextMode = parsedInsertTextMode
+                                         , completionClientCapabilitiesContextSupport = parsedContextSupport
+                                         , completionClientCapabilitiesCompletionList = parsedCompletionList }
+      _ ->
+        Left ("Unrecognized CompletionClientCapabilities value: " ++ ppJSON j)
+
+data CompletionClientCapabilities = CompletionClientCapabilities { completionClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                 , completionClientCapabilitiesCompletionItem :: Maybe ClientCompletionItemOptions
+                                                                 , completionClientCapabilitiesCompletionItemKind :: Maybe ClientCompletionItemOptionsKind
+                                                                 , completionClientCapabilitiesInsertTextMode :: Maybe InsertTextMode
+                                                                 , completionClientCapabilitiesContextSupport :: Maybe Bool
+                                                                 , completionClientCapabilitiesCompletionList :: Maybe CompletionListCapabilities }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionContext.curry
+++ b/src/LSP/Protocol/Types/CompletionContext.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CompletionTriggerKind
+import LSP.Utils.JSON
+
+instance FromJSON CompletionContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
+           parsedTriggerCharacter <- lookupMaybeFromJSON "triggerCharacter" vs
+           return
+            CompletionContext { completionContextTriggerKind = parsedTriggerKind
+                              , completionContextTriggerCharacter = parsedTriggerCharacter }
+      _ -> Left ("Unrecognized CompletionContext value: " ++ ppJSON j)
+
+data CompletionContext = CompletionContext { completionContextTriggerKind :: CompletionTriggerKind
+                                           , completionContextTriggerCharacter :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionItem.curry
+++ b/src/LSP/Protocol/Types/CompletionItem.curry
@@ -1,0 +1,86 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.CompletionItemKind
+import LSP.Protocol.Types.CompletionItemLabelDetails
+import LSP.Protocol.Types.CompletionItemTag
+import LSP.Protocol.Types.InsertReplaceEdit
+import LSP.Protocol.Types.InsertTextFormat
+import LSP.Protocol.Types.InsertTextMode
+import LSP.Protocol.Types.MarkupContent
+import LSP.Protocol.Types.TextEdit
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupFromJSON "label" vs
+           parsedLabelDetails <- lookupMaybeFromJSON "labelDetails" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedDetail <- lookupMaybeFromJSON "detail" vs
+           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
+           parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
+           parsedPreselect <- lookupMaybeFromJSON "preselect" vs
+           parsedSortText <- lookupMaybeFromJSON "sortText" vs
+           parsedFilterText <- lookupMaybeFromJSON "filterText" vs
+           parsedInsertText <- lookupMaybeFromJSON "insertText" vs
+           parsedInsertTextFormat <- lookupMaybeFromJSON "insertTextFormat" vs
+           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
+           parsedTextEdit <- lookupMaybeFromJSON "textEdit" vs
+           parsedTextEditText <- lookupMaybeFromJSON "textEditText" vs
+           parsedAdditionalTextEdits <- lookupMaybeFromJSON
+                                         "additionalTextEdits"
+                                         vs
+           parsedCommitCharacters <- lookupMaybeFromJSON "commitCharacters" vs
+           parsedCommand <- lookupMaybeFromJSON "command" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            CompletionItem { completionItemLabel = parsedLabel
+                           , completionItemLabelDetails = parsedLabelDetails
+                           , completionItemKind = parsedKind
+                           , completionItemTags = parsedTags
+                           , completionItemDetail = parsedDetail
+                           , completionItemDocumentation = parsedDocumentation
+                           , completionItemDeprecated = parsedDeprecated
+                           , completionItemPreselect = parsedPreselect
+                           , completionItemSortText = parsedSortText
+                           , completionItemFilterText = parsedFilterText
+                           , completionItemInsertText = parsedInsertText
+                           , completionItemInsertTextFormat = parsedInsertTextFormat
+                           , completionItemInsertTextMode = parsedInsertTextMode
+                           , completionItemTextEdit = parsedTextEdit
+                           , completionItemTextEditText = parsedTextEditText
+                           , completionItemAdditionalTextEdits = parsedAdditionalTextEdits
+                           , completionItemCommitCharacters = parsedCommitCharacters
+                           , completionItemCommand = parsedCommand
+                           , completionItemData = parsedData }
+      _ -> Left ("Unrecognized CompletionItem value: " ++ ppJSON j)
+
+data CompletionItem = CompletionItem { completionItemLabel :: String
+                                     , completionItemLabelDetails :: Maybe CompletionItemLabelDetails
+                                     , completionItemKind :: Maybe CompletionItemKind
+                                     , completionItemTags :: Maybe [CompletionItemTag]
+                                     , completionItemDetail :: Maybe String
+                                     , completionItemDocumentation :: Maybe (Either String MarkupContent)
+                                     , completionItemDeprecated :: Maybe Bool
+                                     , completionItemPreselect :: Maybe Bool
+                                     , completionItemSortText :: Maybe String
+                                     , completionItemFilterText :: Maybe String
+                                     , completionItemInsertText :: Maybe String
+                                     , completionItemInsertTextFormat :: Maybe InsertTextFormat
+                                     , completionItemInsertTextMode :: Maybe InsertTextMode
+                                     , completionItemTextEdit :: Maybe (Either TextEdit InsertReplaceEdit)
+                                     , completionItemTextEditText :: Maybe String
+                                     , completionItemAdditionalTextEdits :: Maybe [TextEdit]
+                                     , completionItemCommitCharacters :: Maybe [String]
+                                     , completionItemCommand :: Maybe Command
+                                     , completionItemData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionItemDefaults.curry
+++ b/src/LSP/Protocol/Types/CompletionItemDefaults.curry
@@ -1,0 +1,37 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItemDefaults where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.EditRangeWithInsertReplace
+import LSP.Protocol.Types.InsertTextFormat
+import LSP.Protocol.Types.InsertTextMode
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItemDefaults where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCommitCharacters <- lookupMaybeFromJSON "commitCharacters" vs
+           parsedEditRange <- lookupMaybeFromJSON "editRange" vs
+           parsedInsertTextFormat <- lookupMaybeFromJSON "insertTextFormat" vs
+           parsedInsertTextMode <- lookupMaybeFromJSON "insertTextMode" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            CompletionItemDefaults { completionItemDefaultsCommitCharacters = parsedCommitCharacters
+                                   , completionItemDefaultsEditRange = parsedEditRange
+                                   , completionItemDefaultsInsertTextFormat = parsedInsertTextFormat
+                                   , completionItemDefaultsInsertTextMode = parsedInsertTextMode
+                                   , completionItemDefaultsData = parsedData }
+      _ -> Left ("Unrecognized CompletionItemDefaults value: " ++ ppJSON j)
+
+data CompletionItemDefaults = CompletionItemDefaults { completionItemDefaultsCommitCharacters :: Maybe [String]
+                                                     , completionItemDefaultsEditRange :: Maybe (Either Range EditRangeWithInsertReplace)
+                                                     , completionItemDefaultsInsertTextFormat :: Maybe InsertTextFormat
+                                                     , completionItemDefaultsInsertTextMode :: Maybe InsertTextMode
+                                                     , completionItemDefaultsData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionItemKind.curry
+++ b/src/LSP/Protocol/Types/CompletionItemKind.curry
@@ -1,0 +1,66 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItemKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItemKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right CompletionItemKindText
+         2 -> Right CompletionItemKindMethod
+         3 -> Right CompletionItemKindFunction
+         4 -> Right CompletionItemKindConstructor
+         5 -> Right CompletionItemKindField
+         6 -> Right CompletionItemKindVariable
+         7 -> Right CompletionItemKindClass
+         8 -> Right CompletionItemKindInterface
+         9 -> Right CompletionItemKindModule
+         10 -> Right CompletionItemKindProperty
+         11 -> Right CompletionItemKindUnit
+         12 -> Right CompletionItemKindValue
+         13 -> Right CompletionItemKindEnum
+         14 -> Right CompletionItemKindKeyword
+         15 -> Right CompletionItemKindSnippet
+         16 -> Right CompletionItemKindColor
+         17 -> Right CompletionItemKindFile
+         18 -> Right CompletionItemKindReference
+         19 -> Right CompletionItemKindFolder
+         20 -> Right CompletionItemKindEnumMember
+         21 -> Right CompletionItemKindConstant
+         22 -> Right CompletionItemKindStruct
+         23 -> Right CompletionItemKindEvent
+         24 -> Right CompletionItemKindOperator
+         25 -> Right CompletionItemKindTypeParameter
+         _ -> Left ("Unrecognized CompletionItemKind value: " ++ ppJSON j)
+
+data CompletionItemKind = CompletionItemKindText
+                        | CompletionItemKindMethod
+                        | CompletionItemKindFunction
+                        | CompletionItemKindConstructor
+                        | CompletionItemKindField
+                        | CompletionItemKindVariable
+                        | CompletionItemKindClass
+                        | CompletionItemKindInterface
+                        | CompletionItemKindModule
+                        | CompletionItemKindProperty
+                        | CompletionItemKindUnit
+                        | CompletionItemKindValue
+                        | CompletionItemKindEnum
+                        | CompletionItemKindKeyword
+                        | CompletionItemKindSnippet
+                        | CompletionItemKindColor
+                        | CompletionItemKindFile
+                        | CompletionItemKindReference
+                        | CompletionItemKindFolder
+                        | CompletionItemKindEnumMember
+                        | CompletionItemKindConstant
+                        | CompletionItemKindStruct
+                        | CompletionItemKindEvent
+                        | CompletionItemKindOperator
+                        | CompletionItemKindTypeParameter
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/CompletionItemLabelDetails.curry
+++ b/src/LSP/Protocol/Types/CompletionItemLabelDetails.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItemLabelDetails where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItemLabelDetails where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDetail <- lookupMaybeFromJSON "detail" vs
+           parsedDescription <- lookupMaybeFromJSON "description" vs
+           return
+            CompletionItemLabelDetails { completionItemLabelDetailsDetail = parsedDetail
+                                       , completionItemLabelDetailsDescription = parsedDescription }
+      _ ->
+        Left ("Unrecognized CompletionItemLabelDetails value: " ++ ppJSON j)
+
+data CompletionItemLabelDetails = CompletionItemLabelDetails { completionItemLabelDetailsDetail :: Maybe String
+                                                             , completionItemLabelDetailsDescription :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionItemTag.curry
+++ b/src/LSP/Protocol/Types/CompletionItemTag.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItemTag where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItemTag where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right CompletionItemTagDeprecated
+         _ -> Left ("Unrecognized CompletionItemTag value: " ++ ppJSON j)
+
+data CompletionItemTag = CompletionItemTagDeprecated
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/CompletionItemTagOptions.curry
+++ b/src/LSP/Protocol/Types/CompletionItemTagOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionItemTagOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CompletionItemTag
+import LSP.Utils.JSON
+
+instance FromJSON CompletionItemTagOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValueSet <- lookupFromJSON "valueSet" vs
+           return
+            CompletionItemTagOptions { completionItemTagOptionsValueSet = parsedValueSet }
+      _ -> Left ("Unrecognized CompletionItemTagOptions value: " ++ ppJSON j)
+
+data CompletionItemTagOptions = CompletionItemTagOptions { completionItemTagOptionsValueSet :: [CompletionItemTag] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionList.curry
+++ b/src/LSP/Protocol/Types/CompletionList.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionList where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CompletionItem
+import LSP.Protocol.Types.CompletionItemDefaults
+import LSP.Utils.JSON
+
+instance FromJSON CompletionList where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIsIncomplete <- lookupFromJSON "isIncomplete" vs
+           parsedItemDefaults <- lookupMaybeFromJSON "itemDefaults" vs
+           parsedItems <- lookupFromJSON "items" vs
+           return
+            CompletionList { completionListIsIncomplete = parsedIsIncomplete
+                           , completionListItemDefaults = parsedItemDefaults
+                           , completionListItems = parsedItems }
+      _ -> Left ("Unrecognized CompletionList value: " ++ ppJSON j)
+
+data CompletionList = CompletionList { completionListIsIncomplete :: Bool
+                                     , completionListItemDefaults :: Maybe CompletionItemDefaults
+                                     , completionListItems :: [CompletionItem] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionListCapabilities.curry
+++ b/src/LSP/Protocol/Types/CompletionListCapabilities.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionListCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionListCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItemDefaults <- lookupMaybeFromJSON "itemDefaults" vs
+           return
+            CompletionListCapabilities { completionListCapabilitiesItemDefaults = parsedItemDefaults }
+      _ ->
+        Left ("Unrecognized CompletionListCapabilities value: " ++ ppJSON j)
+
+data CompletionListCapabilities = CompletionListCapabilities { completionListCapabilitiesItemDefaults :: Maybe [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionOptions.curry
+++ b/src/LSP/Protocol/Types/CompletionOptions.curry
@@ -1,0 +1,33 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ServerCompletionItemOptions
+import LSP.Utils.JSON
+
+instance FromJSON CompletionOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+                                       vs
+           parsedAllCommitCharacters <- lookupMaybeFromJSON
+                                         "allCommitCharacters"
+                                         vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
+           return
+            CompletionOptions { completionOptionsTriggerCharacters = parsedTriggerCharacters
+                              , completionOptionsAllCommitCharacters = parsedAllCommitCharacters
+                              , completionOptionsResolveProvider = parsedResolveProvider
+                              , completionOptionsCompletionItem = parsedCompletionItem }
+      _ -> Left ("Unrecognized CompletionOptions value: " ++ ppJSON j)
+
+data CompletionOptions = CompletionOptions { completionOptionsTriggerCharacters :: Maybe [String]
+                                           , completionOptionsAllCommitCharacters :: Maybe [String]
+                                           , completionOptionsResolveProvider :: Maybe Bool
+                                           , completionOptionsCompletionItem :: Maybe ServerCompletionItemOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionParams.curry
+++ b/src/LSP/Protocol/Types/CompletionParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CompletionContext
+import LSP.Utils.JSON
+
+instance FromJSON CompletionParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedContext <- lookupMaybeFromJSON "context" vs
+           return CompletionParams { completionParamsContext = parsedContext }
+      _ -> Left ("Unrecognized CompletionParams value: " ++ ppJSON j)
+
+data CompletionParams = CompletionParams { completionParamsContext :: Maybe CompletionContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CompletionRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return CompletionRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized CompletionRegistrationOptions value: " ++ ppJSON j)
+
+data CompletionRegistrationOptions = CompletionRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CompletionTriggerKind.curry
+++ b/src/LSP/Protocol/Types/CompletionTriggerKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CompletionTriggerKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CompletionTriggerKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right CompletionTriggerKindInvoked
+         2 -> Right CompletionTriggerKindTriggerCharacter
+         3 -> Right CompletionTriggerKindTriggerForIncompleteCompletions
+         _ -> Left ("Unrecognized CompletionTriggerKind value: " ++ ppJSON j)
+
+data CompletionTriggerKind = CompletionTriggerKindInvoked
+                           | CompletionTriggerKindTriggerCharacter
+                           | CompletionTriggerKindTriggerForIncompleteCompletions
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/ConfigurationItem.curry
+++ b/src/LSP/Protocol/Types/ConfigurationItem.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ConfigurationItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON ConfigurationItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedScopeUri <- lookupMaybeFromJSON "scopeUri" vs
+           parsedSection <- lookupMaybeFromJSON "section" vs
+           return
+            ConfigurationItem { configurationItemScopeUri = parsedScopeUri
+                              , configurationItemSection = parsedSection }
+      _ -> Left ("Unrecognized ConfigurationItem value: " ++ ppJSON j)
+
+data ConfigurationItem = ConfigurationItem { configurationItemScopeUri :: Maybe Uri
+                                           , configurationItemSection :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ConfigurationParams.curry
+++ b/src/LSP/Protocol/Types/ConfigurationParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ConfigurationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ConfigurationItem
+import LSP.Utils.JSON
+
+instance FromJSON ConfigurationParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItems <- lookupFromJSON "items" vs
+           return
+            ConfigurationParams { configurationParamsItems = parsedItems }
+      _ -> Left ("Unrecognized ConfigurationParams value: " ++ ppJSON j)
+
+data ConfigurationParams = ConfigurationParams { configurationParamsItems :: [ConfigurationItem] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CreateFile.curry
+++ b/src/LSP/Protocol/Types/CreateFile.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CreateFile where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.CreateFileOptions
+import LSP.Utils.JSON
+
+instance FromJSON CreateFile where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedUri <- lookupFromJSON "uri" vs
+           parsedOptions <- lookupMaybeFromJSON "options" vs
+           return
+            CreateFile { createFileKind = parsedKind
+                       , createFileUri = parsedUri
+                       , createFileOptions = parsedOptions }
+      _ -> Left ("Unrecognized CreateFile value: " ++ ppJSON j)
+
+data CreateFile = CreateFile { createFileKind :: String
+                             , createFileUri :: DocumentUri
+                             , createFileOptions :: Maybe CreateFileOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CreateFileOptions.curry
+++ b/src/LSP/Protocol/Types/CreateFileOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CreateFileOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON CreateFileOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedOverwrite <- lookupMaybeFromJSON "overwrite" vs
+           parsedIgnoreIfExists <- lookupMaybeFromJSON "ignoreIfExists" vs
+           return
+            CreateFileOptions { createFileOptionsOverwrite = parsedOverwrite
+                              , createFileOptionsIgnoreIfExists = parsedIgnoreIfExists }
+      _ -> Left ("Unrecognized CreateFileOptions value: " ++ ppJSON j)
+
+data CreateFileOptions = CreateFileOptions { createFileOptionsOverwrite :: Maybe Bool
+                                           , createFileOptionsIgnoreIfExists :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/CreateFilesParams.curry
+++ b/src/LSP/Protocol/Types/CreateFilesParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.CreateFilesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileCreate
+import LSP.Utils.JSON
+
+instance FromJSON CreateFilesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFiles <- lookupFromJSON "files" vs
+           return CreateFilesParams { createFilesParamsFiles = parsedFiles }
+      _ -> Left ("Unrecognized CreateFilesParams value: " ++ ppJSON j)
+
+data CreateFilesParams = CreateFilesParams { createFilesParamsFiles :: [FileCreate] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Declaration.curry
+++ b/src/LSP/Protocol/Types/Declaration.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Declaration where
+
+import LSP.Protocol.Types.Location
+
+type Declaration = Either Location [Location]
+

--- a/src/LSP/Protocol/Types/DeclarationClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DeclarationClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeclarationClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DeclarationClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
+           return
+            DeclarationClientCapabilities { declarationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                          , declarationClientCapabilitiesLinkSupport = parsedLinkSupport }
+      _ ->
+        Left
+         ("Unrecognized DeclarationClientCapabilities value: " ++ ppJSON j)
+
+data DeclarationClientCapabilities = DeclarationClientCapabilities { declarationClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                   , declarationClientCapabilitiesLinkSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeclarationLink.curry
+++ b/src/LSP/Protocol/Types/DeclarationLink.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeclarationLink where
+
+import LSP.Protocol.Types.LocationLink
+
+type DeclarationLink = LocationLink
+

--- a/src/LSP/Protocol/Types/DeclarationOptions.curry
+++ b/src/LSP/Protocol/Types/DeclarationOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeclarationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DeclarationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DeclarationOptions {  }
+      _ -> Left ("Unrecognized DeclarationOptions value: " ++ ppJSON j)
+
+data DeclarationOptions = DeclarationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeclarationParams.curry
+++ b/src/LSP/Protocol/Types/DeclarationParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeclarationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DeclarationParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DeclarationParams {  }
+      _ -> Left ("Unrecognized DeclarationParams value: " ++ ppJSON j)
+
+data DeclarationParams = DeclarationParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeclarationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DeclarationRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeclarationRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DeclarationRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DeclarationRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DeclarationRegistrationOptions value: " ++ ppJSON j)
+
+data DeclarationRegistrationOptions = DeclarationRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Definition.curry
+++ b/src/LSP/Protocol/Types/Definition.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Definition where
+
+import LSP.Protocol.Types.Location
+
+type Definition = Either Location [Location]
+

--- a/src/LSP/Protocol/Types/DefinitionClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DefinitionClientCapabilities.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DefinitionClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DefinitionClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
+           return
+            DefinitionClientCapabilities { definitionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                         , definitionClientCapabilitiesLinkSupport = parsedLinkSupport }
+      _ ->
+        Left ("Unrecognized DefinitionClientCapabilities value: " ++ ppJSON j)
+
+data DefinitionClientCapabilities = DefinitionClientCapabilities { definitionClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                 , definitionClientCapabilitiesLinkSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DefinitionLink.curry
+++ b/src/LSP/Protocol/Types/DefinitionLink.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DefinitionLink where
+
+import LSP.Protocol.Types.LocationLink
+
+type DefinitionLink = LocationLink
+

--- a/src/LSP/Protocol/Types/DefinitionOptions.curry
+++ b/src/LSP/Protocol/Types/DefinitionOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DefinitionOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DefinitionOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DefinitionOptions {  }
+      _ -> Left ("Unrecognized DefinitionOptions value: " ++ ppJSON j)
+
+data DefinitionOptions = DefinitionOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DefinitionParams.curry
+++ b/src/LSP/Protocol/Types/DefinitionParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DefinitionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DefinitionParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DefinitionParams {  }
+      _ -> Left ("Unrecognized DefinitionParams value: " ++ ppJSON j)
+
+data DefinitionParams = DefinitionParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DefinitionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DefinitionRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DefinitionRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DefinitionRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DefinitionRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DefinitionRegistrationOptions value: " ++ ppJSON j)
+
+data DefinitionRegistrationOptions = DefinitionRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeleteFile.curry
+++ b/src/LSP/Protocol/Types/DeleteFile.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeleteFile where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.DeleteFileOptions
+import LSP.Utils.JSON
+
+instance FromJSON DeleteFile where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedUri <- lookupFromJSON "uri" vs
+           parsedOptions <- lookupMaybeFromJSON "options" vs
+           return
+            DeleteFile { deleteFileKind = parsedKind
+                       , deleteFileUri = parsedUri
+                       , deleteFileOptions = parsedOptions }
+      _ -> Left ("Unrecognized DeleteFile value: " ++ ppJSON j)
+
+data DeleteFile = DeleteFile { deleteFileKind :: String
+                             , deleteFileUri :: DocumentUri
+                             , deleteFileOptions :: Maybe DeleteFileOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeleteFileOptions.curry
+++ b/src/LSP/Protocol/Types/DeleteFileOptions.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeleteFileOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DeleteFileOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRecursive <- lookupMaybeFromJSON "recursive" vs
+           parsedIgnoreIfNotExists <- lookupMaybeFromJSON "ignoreIfNotExists"
+                                       vs
+           return
+            DeleteFileOptions { deleteFileOptionsRecursive = parsedRecursive
+                              , deleteFileOptionsIgnoreIfNotExists = parsedIgnoreIfNotExists }
+      _ -> Left ("Unrecognized DeleteFileOptions value: " ++ ppJSON j)
+
+data DeleteFileOptions = DeleteFileOptions { deleteFileOptionsRecursive :: Maybe Bool
+                                           , deleteFileOptionsIgnoreIfNotExists :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DeleteFilesParams.curry
+++ b/src/LSP/Protocol/Types/DeleteFilesParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DeleteFilesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileDelete
+import LSP.Utils.JSON
+
+instance FromJSON DeleteFilesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFiles <- lookupFromJSON "files" vs
+           return DeleteFilesParams { deleteFilesParamsFiles = parsedFiles }
+      _ -> Left ("Unrecognized DeleteFilesParams value: " ++ ppJSON j)
+
+data DeleteFilesParams = DeleteFilesParams { deleteFilesParamsFiles :: [FileDelete] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Diagnostic.curry
+++ b/src/LSP/Protocol/Types/Diagnostic.curry
@@ -1,0 +1,52 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Diagnostic where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.CodeDescription
+import LSP.Protocol.Types.DiagnosticRelatedInformation
+import LSP.Protocol.Types.DiagnosticSeverity
+import LSP.Protocol.Types.DiagnosticTag
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON Diagnostic where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedSeverity <- lookupMaybeFromJSON "severity" vs
+           parsedCode <- lookupMaybeFromJSON "code" vs
+           parsedCodeDescription <- lookupMaybeFromJSON "codeDescription" vs
+           parsedSource <- lookupMaybeFromJSON "source" vs
+           parsedMessage <- lookupFromJSON "message" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedRelatedInformation <- lookupMaybeFromJSON
+                                        "relatedInformation"
+                                        vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            Diagnostic { diagnosticRange = parsedRange
+                       , diagnosticSeverity = parsedSeverity
+                       , diagnosticCode = parsedCode
+                       , diagnosticCodeDescription = parsedCodeDescription
+                       , diagnosticSource = parsedSource
+                       , diagnosticMessage = parsedMessage
+                       , diagnosticTags = parsedTags
+                       , diagnosticRelatedInformation = parsedRelatedInformation
+                       , diagnosticData = parsedData }
+      _ -> Left ("Unrecognized Diagnostic value: " ++ ppJSON j)
+
+data Diagnostic = Diagnostic { diagnosticRange :: Range
+                             , diagnosticSeverity :: Maybe DiagnosticSeverity
+                             , diagnosticCode :: Maybe (Either Int String)
+                             , diagnosticCodeDescription :: Maybe CodeDescription
+                             , diagnosticSource :: Maybe String
+                             , diagnosticMessage :: String
+                             , diagnosticTags :: Maybe [DiagnosticTag]
+                             , diagnosticRelatedInformation :: Maybe [DiagnosticRelatedInformation]
+                             , diagnosticData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DiagnosticClientCapabilities.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedRelatedDocumentSupport <- lookupMaybeFromJSON
+                                            "relatedDocumentSupport"
+                                            vs
+           return
+            DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                         , diagnosticClientCapabilitiesRelatedDocumentSupport = parsedRelatedDocumentSupport }
+      _ ->
+        Left ("Unrecognized DiagnosticClientCapabilities value: " ++ ppJSON j)
+
+data DiagnosticClientCapabilities = DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                 , diagnosticClientCapabilitiesRelatedDocumentSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticOptions.curry
+++ b/src/LSP/Protocol/Types/DiagnosticOptions.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+           parsedInterFileDependencies <- lookupFromJSON
+                                           "interFileDependencies"
+                                           vs
+           parsedWorkspaceDiagnostics <- lookupFromJSON "workspaceDiagnostics"
+                                          vs
+           return
+            DiagnosticOptions { diagnosticOptionsIdentifier = parsedIdentifier
+                              , diagnosticOptionsInterFileDependencies = parsedInterFileDependencies
+                              , diagnosticOptionsWorkspaceDiagnostics = parsedWorkspaceDiagnostics }
+      _ -> Left ("Unrecognized DiagnosticOptions value: " ++ ppJSON j)
+
+data DiagnosticOptions = DiagnosticOptions { diagnosticOptionsIdentifier :: Maybe String
+                                           , diagnosticOptionsInterFileDependencies :: Bool
+                                           , diagnosticOptionsWorkspaceDiagnostics :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DiagnosticRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DiagnosticRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DiagnosticRegistrationOptions value: " ++ ppJSON j)
+
+data DiagnosticRegistrationOptions = DiagnosticRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticRelatedInformation.curry
+++ b/src/LSP/Protocol/Types/DiagnosticRelatedInformation.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticRelatedInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Location
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticRelatedInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLocation <- lookupFromJSON "location" vs
+           parsedMessage <- lookupFromJSON "message" vs
+           return
+            DiagnosticRelatedInformation { diagnosticRelatedInformationLocation = parsedLocation
+                                         , diagnosticRelatedInformationMessage = parsedMessage }
+      _ ->
+        Left ("Unrecognized DiagnosticRelatedInformation value: " ++ ppJSON j)
+
+data DiagnosticRelatedInformation = DiagnosticRelatedInformation { diagnosticRelatedInformationLocation :: Location
+                                                                 , diagnosticRelatedInformationMessage :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticServerCancellationData.curry
+++ b/src/LSP/Protocol/Types/DiagnosticServerCancellationData.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticServerCancellationData where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticServerCancellationData where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRetriggerRequest <- lookupFromJSON "retriggerRequest" vs
+           return
+            DiagnosticServerCancellationData { diagnosticServerCancellationDataRetriggerRequest = parsedRetriggerRequest }
+      _ ->
+        Left
+         ("Unrecognized DiagnosticServerCancellationData value: " ++ ppJSON j)
+
+data DiagnosticServerCancellationData = DiagnosticServerCancellationData { diagnosticServerCancellationDataRetriggerRequest :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticSeverity.curry
+++ b/src/LSP/Protocol/Types/DiagnosticSeverity.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticSeverity where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticSeverity where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right DiagnosticSeverityError
+         2 -> Right DiagnosticSeverityWarning
+         3 -> Right DiagnosticSeverityInformation
+         4 -> Right DiagnosticSeverityHint
+         _ -> Left ("Unrecognized DiagnosticSeverity value: " ++ ppJSON j)
+
+data DiagnosticSeverity = DiagnosticSeverityError
+                        | DiagnosticSeverityWarning
+                        | DiagnosticSeverityInformation
+                        | DiagnosticSeverityHint
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/DiagnosticTag.curry
+++ b/src/LSP/Protocol/Types/DiagnosticTag.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticTag where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticTag where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right DiagnosticTagUnnecessary
+         2 -> Right DiagnosticTagDeprecated
+         _ -> Left ("Unrecognized DiagnosticTag value: " ++ ppJSON j)
+
+data DiagnosticTag = DiagnosticTagUnnecessary | DiagnosticTagDeprecated
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/DiagnosticWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DiagnosticWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            DiagnosticWorkspaceClientCapabilities { diagnosticWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized DiagnosticWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data DiagnosticWorkspaceClientCapabilities = DiagnosticWorkspaceClientCapabilities { diagnosticWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DiagnosticsCapabilities.curry
+++ b/src/LSP/Protocol/Types/DiagnosticsCapabilities.curry
@@ -1,0 +1,34 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DiagnosticsCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientDiagnosticsTagOptions
+import LSP.Utils.JSON
+
+instance FromJSON DiagnosticsCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRelatedInformation <- lookupMaybeFromJSON
+                                        "relatedInformation"
+                                        vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedCodeDescriptionSupport <- lookupMaybeFromJSON
+                                            "codeDescriptionSupport"
+                                            vs
+           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
+           return
+            DiagnosticsCapabilities { diagnosticsCapabilitiesRelatedInformation = parsedRelatedInformation
+                                    , diagnosticsCapabilitiesTagSupport = parsedTagSupport
+                                    , diagnosticsCapabilitiesCodeDescriptionSupport = parsedCodeDescriptionSupport
+                                    , diagnosticsCapabilitiesDataSupport = parsedDataSupport }
+      _ -> Left ("Unrecognized DiagnosticsCapabilities value: " ++ ppJSON j)
+
+data DiagnosticsCapabilities = DiagnosticsCapabilities { diagnosticsCapabilitiesRelatedInformation :: Maybe Bool
+                                                       , diagnosticsCapabilitiesTagSupport :: Maybe ClientDiagnosticsTagOptions
+                                                       , diagnosticsCapabilitiesCodeDescriptionSupport :: Maybe Bool
+                                                       , diagnosticsCapabilitiesDataSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeConfigurationClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DidChangeConfigurationClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeConfigurationClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeConfigurationClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            DidChangeConfigurationClientCapabilities { didChangeConfigurationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized DidChangeConfigurationClientCapabilities value: "
+           ++ ppJSON j)
+
+data DidChangeConfigurationClientCapabilities = DidChangeConfigurationClientCapabilities { didChangeConfigurationClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeConfigurationParams.curry
+++ b/src/LSP/Protocol/Types/DidChangeConfigurationParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeConfigurationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeConfigurationParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSettings <- lookupFromJSON "settings" vs
+           return
+            DidChangeConfigurationParams { didChangeConfigurationParamsSettings = parsedSettings }
+      _ ->
+        Left ("Unrecognized DidChangeConfigurationParams value: " ++ ppJSON j)
+
+data DidChangeConfigurationParams = DidChangeConfigurationParams { didChangeConfigurationParamsSettings :: LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeConfigurationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DidChangeConfigurationRegistrationOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeConfigurationRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeConfigurationRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSection <- lookupMaybeFromJSON "section" vs
+           return
+            DidChangeConfigurationRegistrationOptions { didChangeConfigurationRegistrationOptionsSection = parsedSection }
+      _ ->
+        Left
+         ("Unrecognized DidChangeConfigurationRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DidChangeConfigurationRegistrationOptions = DidChangeConfigurationRegistrationOptions { didChangeConfigurationRegistrationOptionsSection :: Maybe (Either String [String]) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeNotebookDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidChangeNotebookDocumentParams.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeNotebookDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentChangeEvent
+import LSP.Protocol.Types.VersionedNotebookDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeNotebookDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
+           parsedChange <- lookupFromJSON "change" vs
+           return
+            DidChangeNotebookDocumentParams { didChangeNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
+                                            , didChangeNotebookDocumentParamsChange = parsedChange }
+      _ ->
+        Left
+         ("Unrecognized DidChangeNotebookDocumentParams value: " ++ ppJSON j)
+
+data DidChangeNotebookDocumentParams = DidChangeNotebookDocumentParams { didChangeNotebookDocumentParamsNotebookDocument :: VersionedNotebookDocumentIdentifier
+                                                                       , didChangeNotebookDocumentParamsChange :: NotebookDocumentChangeEvent }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeTextDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidChangeTextDocumentParams.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeTextDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentContentChangeEvent
+import LSP.Protocol.Types.VersionedTextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeTextDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedContentChanges <- lookupFromJSON "contentChanges" vs
+           return
+            DidChangeTextDocumentParams { didChangeTextDocumentParamsTextDocument = parsedTextDocument
+                                        , didChangeTextDocumentParamsContentChanges = parsedContentChanges }
+      _ ->
+        Left ("Unrecognized DidChangeTextDocumentParams value: " ++ ppJSON j)
+
+data DidChangeTextDocumentParams = DidChangeTextDocumentParams { didChangeTextDocumentParamsTextDocument :: VersionedTextDocumentIdentifier
+                                                               , didChangeTextDocumentParamsContentChanges :: [TextDocumentContentChangeEvent] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeWatchedFilesClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DidChangeWatchedFilesClientCapabilities.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeWatchedFilesClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeWatchedFilesClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedRelativePatternSupport <- lookupMaybeFromJSON
+                                            "relativePatternSupport"
+                                            vs
+           return
+            DidChangeWatchedFilesClientCapabilities { didChangeWatchedFilesClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                                    , didChangeWatchedFilesClientCapabilitiesRelativePatternSupport = parsedRelativePatternSupport }
+      _ ->
+        Left
+         ("Unrecognized DidChangeWatchedFilesClientCapabilities value: "
+           ++ ppJSON j)
+
+data DidChangeWatchedFilesClientCapabilities = DidChangeWatchedFilesClientCapabilities { didChangeWatchedFilesClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                                       , didChangeWatchedFilesClientCapabilitiesRelativePatternSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeWatchedFilesParams.curry
+++ b/src/LSP/Protocol/Types/DidChangeWatchedFilesParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeWatchedFilesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileEvent
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeWatchedFilesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedChanges <- lookupFromJSON "changes" vs
+           return
+            DidChangeWatchedFilesParams { didChangeWatchedFilesParamsChanges = parsedChanges }
+      _ ->
+        Left ("Unrecognized DidChangeWatchedFilesParams value: " ++ ppJSON j)
+
+data DidChangeWatchedFilesParams = DidChangeWatchedFilesParams { didChangeWatchedFilesParamsChanges :: [FileEvent] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeWatchedFilesRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DidChangeWatchedFilesRegistrationOptions.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeWatchedFilesRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileSystemWatcher
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeWatchedFilesRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWatchers <- lookupFromJSON "watchers" vs
+           return
+            DidChangeWatchedFilesRegistrationOptions { didChangeWatchedFilesRegistrationOptionsWatchers = parsedWatchers }
+      _ ->
+        Left
+         ("Unrecognized DidChangeWatchedFilesRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DidChangeWatchedFilesRegistrationOptions = DidChangeWatchedFilesRegistrationOptions { didChangeWatchedFilesRegistrationOptionsWatchers :: [FileSystemWatcher] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidChangeWorkspaceFoldersParams.curry
+++ b/src/LSP/Protocol/Types/DidChangeWorkspaceFoldersParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidChangeWorkspaceFoldersParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceFoldersChangeEvent
+import LSP.Utils.JSON
+
+instance FromJSON DidChangeWorkspaceFoldersParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedEvent <- lookupFromJSON "event" vs
+           return
+            DidChangeWorkspaceFoldersParams { didChangeWorkspaceFoldersParamsEvent = parsedEvent }
+      _ ->
+        Left
+         ("Unrecognized DidChangeWorkspaceFoldersParams value: " ++ ppJSON j)
+
+data DidChangeWorkspaceFoldersParams = DidChangeWorkspaceFoldersParams { didChangeWorkspaceFoldersParamsEvent :: WorkspaceFoldersChangeEvent }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidCloseNotebookDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidCloseNotebookDocumentParams.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidCloseNotebookDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentIdentifier
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidCloseNotebookDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
+           parsedCellTextDocuments <- lookupFromJSON "cellTextDocuments" vs
+           return
+            DidCloseNotebookDocumentParams { didCloseNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
+                                           , didCloseNotebookDocumentParamsCellTextDocuments = parsedCellTextDocuments }
+      _ ->
+        Left
+         ("Unrecognized DidCloseNotebookDocumentParams value: " ++ ppJSON j)
+
+data DidCloseNotebookDocumentParams = DidCloseNotebookDocumentParams { didCloseNotebookDocumentParamsNotebookDocument :: NotebookDocumentIdentifier
+                                                                     , didCloseNotebookDocumentParamsCellTextDocuments :: [TextDocumentIdentifier] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidCloseTextDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidCloseTextDocumentParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidCloseTextDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidCloseTextDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            DidCloseTextDocumentParams { didCloseTextDocumentParamsTextDocument = parsedTextDocument }
+      _ ->
+        Left ("Unrecognized DidCloseTextDocumentParams value: " ++ ppJSON j)
+
+data DidCloseTextDocumentParams = DidCloseTextDocumentParams { didCloseTextDocumentParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidOpenNotebookDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidOpenNotebookDocumentParams.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidOpenNotebookDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocument
+import LSP.Protocol.Types.TextDocumentItem
+import LSP.Utils.JSON
+
+instance FromJSON DidOpenNotebookDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
+           parsedCellTextDocuments <- lookupFromJSON "cellTextDocuments" vs
+           return
+            DidOpenNotebookDocumentParams { didOpenNotebookDocumentParamsNotebookDocument = parsedNotebookDocument
+                                          , didOpenNotebookDocumentParamsCellTextDocuments = parsedCellTextDocuments }
+      _ ->
+        Left
+         ("Unrecognized DidOpenNotebookDocumentParams value: " ++ ppJSON j)
+
+data DidOpenNotebookDocumentParams = DidOpenNotebookDocumentParams { didOpenNotebookDocumentParamsNotebookDocument :: NotebookDocument
+                                                                   , didOpenNotebookDocumentParamsCellTextDocuments :: [TextDocumentItem] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidOpenTextDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidOpenTextDocumentParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidOpenTextDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentItem
+import LSP.Utils.JSON
+
+instance FromJSON DidOpenTextDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            DidOpenTextDocumentParams { didOpenTextDocumentParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized DidOpenTextDocumentParams value: " ++ ppJSON j)
+
+data DidOpenTextDocumentParams = DidOpenTextDocumentParams { didOpenTextDocumentParamsTextDocument :: TextDocumentItem }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidSaveNotebookDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidSaveNotebookDocumentParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidSaveNotebookDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidSaveNotebookDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookDocument <- lookupFromJSON "notebookDocument" vs
+           return
+            DidSaveNotebookDocumentParams { didSaveNotebookDocumentParamsNotebookDocument = parsedNotebookDocument }
+      _ ->
+        Left
+         ("Unrecognized DidSaveNotebookDocumentParams value: " ++ ppJSON j)
+
+data DidSaveNotebookDocumentParams = DidSaveNotebookDocumentParams { didSaveNotebookDocumentParamsNotebookDocument :: NotebookDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DidSaveTextDocumentParams.curry
+++ b/src/LSP/Protocol/Types/DidSaveTextDocumentParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DidSaveTextDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DidSaveTextDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedText <- lookupMaybeFromJSON "text" vs
+           return
+            DidSaveTextDocumentParams { didSaveTextDocumentParamsTextDocument = parsedTextDocument
+                                      , didSaveTextDocumentParamsText = parsedText }
+      _ -> Left ("Unrecognized DidSaveTextDocumentParams value: " ++ ppJSON j)
+
+data DidSaveTextDocumentParams = DidSaveTextDocumentParams { didSaveTextDocumentParamsTextDocument :: TextDocumentIdentifier
+                                                           , didSaveTextDocumentParamsText :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentColorClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentColorClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentColorClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentColorClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            DocumentColorClientCapabilities { documentColorClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized DocumentColorClientCapabilities value: " ++ ppJSON j)
+
+data DocumentColorClientCapabilities = DocumentColorClientCapabilities { documentColorClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentColorOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentColorOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentColorOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentColorOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentColorOptions {  }
+      _ -> Left ("Unrecognized DocumentColorOptions value: " ++ ppJSON j)
+
+data DocumentColorOptions = DocumentColorOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentColorParams.curry
+++ b/src/LSP/Protocol/Types/DocumentColorParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentColorParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentColorParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            DocumentColorParams { documentColorParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized DocumentColorParams value: " ++ ppJSON j)
+
+data DocumentColorParams = DocumentColorParams { documentColorParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentColorRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentColorRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentColorRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentColorRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentColorRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentColorRegistrationOptions value: " ++ ppJSON j)
+
+data DocumentColorRegistrationOptions = DocumentColorRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentDiagnosticParams.curry
+++ b/src/LSP/Protocol/Types/DocumentDiagnosticParams.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentDiagnosticParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentDiagnosticParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+           parsedPreviousResultId <- lookupMaybeFromJSON "previousResultId" vs
+           return
+            DocumentDiagnosticParams { documentDiagnosticParamsTextDocument = parsedTextDocument
+                                     , documentDiagnosticParamsIdentifier = parsedIdentifier
+                                     , documentDiagnosticParamsPreviousResultId = parsedPreviousResultId }
+      _ -> Left ("Unrecognized DocumentDiagnosticParams value: " ++ ppJSON j)
+
+data DocumentDiagnosticParams = DocumentDiagnosticParams { documentDiagnosticParamsTextDocument :: TextDocumentIdentifier
+                                                         , documentDiagnosticParamsIdentifier :: Maybe String
+                                                         , documentDiagnosticParamsPreviousResultId :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/DocumentDiagnosticReport.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentDiagnosticReport where
+
+import LSP.Protocol.Types.RelatedFullDocumentDiagnosticReport
+import LSP.Protocol.Types.RelatedUnchangedDocumentDiagnosticReport
+
+type DocumentDiagnosticReport = Either RelatedFullDocumentDiagnosticReport RelatedUnchangedDocumentDiagnosticReport
+

--- a/src/LSP/Protocol/Types/DocumentDiagnosticReportKind.curry
+++ b/src/LSP/Protocol/Types/DocumentDiagnosticReportKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentDiagnosticReportKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentDiagnosticReportKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "full" -> Right DocumentDiagnosticReportKindFull
+         "unchanged" -> Right DocumentDiagnosticReportKindUnchanged
+         _ ->
+           Left
+            ("Unrecognized DocumentDiagnosticReportKind value: " ++ ppJSON j)
+
+data DocumentDiagnosticReportKind = DocumentDiagnosticReportKindFull
+                                  | DocumentDiagnosticReportKindUnchanged
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/DocumentDiagnosticReportPartialResult.curry
+++ b/src/LSP/Protocol/Types/DocumentDiagnosticReportPartialResult.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentDiagnosticReportPartialResult where
+
+import Data.Map
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.FullDocumentDiagnosticReport
+import LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
+import LSP.Utils.JSON
+
+instance FromJSON DocumentDiagnosticReportPartialResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRelatedDocuments <- lookupFromJSON "relatedDocuments" vs
+           return
+            DocumentDiagnosticReportPartialResult { documentDiagnosticReportPartialResultRelatedDocuments = parsedRelatedDocuments }
+      _ ->
+        Left
+         ("Unrecognized DocumentDiagnosticReportPartialResult value: "
+           ++ ppJSON j)
+
+data DocumentDiagnosticReportPartialResult = DocumentDiagnosticReportPartialResult { documentDiagnosticReportPartialResultRelatedDocuments :: Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentFilter.curry
+++ b/src/LSP/Protocol/Types/DocumentFilter.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentFilter where
+
+import LSP.Protocol.Types.NotebookCellTextDocumentFilter
+import LSP.Protocol.Types.TextDocumentFilter
+
+type DocumentFilter = Either TextDocumentFilter NotebookCellTextDocumentFilter
+

--- a/src/LSP/Protocol/Types/DocumentFormattingClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentFormattingClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentFormattingClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            DocumentFormattingClientCapabilities { documentFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized DocumentFormattingClientCapabilities value: "
+           ++ ppJSON j)
+
+data DocumentFormattingClientCapabilities = DocumentFormattingClientCapabilities { documentFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentFormattingOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentFormattingOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentFormattingOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentFormattingOptions {  }
+      _ -> Left ("Unrecognized DocumentFormattingOptions value: " ++ ppJSON j)
+
+data DocumentFormattingOptions = DocumentFormattingOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingParams.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentFormattingParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentFormattingParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedOptions <- lookupFromJSON "options" vs
+           return
+            DocumentFormattingParams { documentFormattingParamsTextDocument = parsedTextDocument
+                                     , documentFormattingParamsOptions = parsedOptions }
+      _ -> Left ("Unrecognized DocumentFormattingParams value: " ++ ppJSON j)
+
+data DocumentFormattingParams = DocumentFormattingParams { documentFormattingParamsTextDocument :: TextDocumentIdentifier
+                                                         , documentFormattingParamsOptions :: FormattingOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentFormattingRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentFormattingRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentFormattingRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentFormattingRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DocumentFormattingRegistrationOptions = DocumentFormattingRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentHighlight.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlight.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlight where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.DocumentHighlightKind
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlight where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           return
+            DocumentHighlight { documentHighlightRange = parsedRange
+                              , documentHighlightKind = parsedKind }
+      _ -> Left ("Unrecognized DocumentHighlight value: " ++ ppJSON j)
+
+data DocumentHighlight = DocumentHighlight { documentHighlightRange :: Range
+                                           , documentHighlightKind :: Maybe DocumentHighlightKind }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentHighlightClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlightClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlightClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            DocumentHighlightClientCapabilities { documentHighlightClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized DocumentHighlightClientCapabilities value: "
+           ++ ppJSON j)
+
+data DocumentHighlightClientCapabilities = DocumentHighlightClientCapabilities { documentHighlightClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentHighlightKind.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlightKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlightKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right DocumentHighlightKindText
+         2 -> Right DocumentHighlightKindRead
+         3 -> Right DocumentHighlightKindWrite
+         _ -> Left ("Unrecognized DocumentHighlightKind value: " ++ ppJSON j)
+
+data DocumentHighlightKind = DocumentHighlightKindText
+                           | DocumentHighlightKindRead
+                           | DocumentHighlightKindWrite
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/DocumentHighlightOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlightOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlightOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentHighlightOptions {  }
+      _ -> Left ("Unrecognized DocumentHighlightOptions value: " ++ ppJSON j)
+
+data DocumentHighlightOptions = DocumentHighlightOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentHighlightParams.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlightParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlightParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentHighlightParams {  }
+      _ -> Left ("Unrecognized DocumentHighlightParams value: " ++ ppJSON j)
+
+data DocumentHighlightParams = DocumentHighlightParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentHighlightRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentHighlightRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentHighlightRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentHighlightRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentHighlightRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DocumentHighlightRegistrationOptions = DocumentHighlightRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentLink.curry
+++ b/src/LSP/Protocol/Types/DocumentLink.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentLink where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON DocumentLink where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedTarget <- lookupMaybeFromJSON "target" vs
+           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            DocumentLink { documentLinkRange = parsedRange
+                         , documentLinkTarget = parsedTarget
+                         , documentLinkTooltip = parsedTooltip
+                         , documentLinkData = parsedData }
+      _ -> Left ("Unrecognized DocumentLink value: " ++ ppJSON j)
+
+data DocumentLink = DocumentLink { documentLinkRange :: Range
+                                 , documentLinkTarget :: Maybe Uri
+                                 , documentLinkTooltip :: Maybe String
+                                 , documentLinkData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentLinkClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentLinkClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentLinkClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedTooltipSupport <- lookupMaybeFromJSON "tooltipSupport" vs
+           return
+            DocumentLinkClientCapabilities { documentLinkClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                           , documentLinkClientCapabilitiesTooltipSupport = parsedTooltipSupport }
+      _ ->
+        Left
+         ("Unrecognized DocumentLinkClientCapabilities value: " ++ ppJSON j)
+
+data DocumentLinkClientCapabilities = DocumentLinkClientCapabilities { documentLinkClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                     , documentLinkClientCapabilitiesTooltipSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentLinkOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentLinkOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentLinkOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            DocumentLinkOptions { documentLinkOptionsResolveProvider = parsedResolveProvider }
+      _ -> Left ("Unrecognized DocumentLinkOptions value: " ++ ppJSON j)
+
+data DocumentLinkOptions = DocumentLinkOptions { documentLinkOptionsResolveProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentLinkParams.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentLinkParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentLinkParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            DocumentLinkParams { documentLinkParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized DocumentLinkParams value: " ++ ppJSON j)
+
+data DocumentLinkParams = DocumentLinkParams { documentLinkParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentLinkRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentLinkRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentLinkRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentLinkRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentLinkRegistrationOptions value: " ++ ppJSON j)
+
+data DocumentLinkRegistrationOptions = DocumentLinkRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentOnTypeFormattingClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentOnTypeFormattingClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentOnTypeFormattingClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentOnTypeFormattingClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            DocumentOnTypeFormattingClientCapabilities { documentOnTypeFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized DocumentOnTypeFormattingClientCapabilities value: "
+           ++ ppJSON j)
+
+data DocumentOnTypeFormattingClientCapabilities = DocumentOnTypeFormattingClientCapabilities { documentOnTypeFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentOnTypeFormattingOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentOnTypeFormattingOptions.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentOnTypeFormattingOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentOnTypeFormattingOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFirstTriggerCharacter <- lookupFromJSON
+                                           "firstTriggerCharacter"
+                                           vs
+           parsedMoreTriggerCharacter <- lookupMaybeFromJSON
+                                          "moreTriggerCharacter"
+                                          vs
+           return
+            DocumentOnTypeFormattingOptions { documentOnTypeFormattingOptionsFirstTriggerCharacter = parsedFirstTriggerCharacter
+                                            , documentOnTypeFormattingOptionsMoreTriggerCharacter = parsedMoreTriggerCharacter }
+      _ ->
+        Left
+         ("Unrecognized DocumentOnTypeFormattingOptions value: " ++ ppJSON j)
+
+data DocumentOnTypeFormattingOptions = DocumentOnTypeFormattingOptions { documentOnTypeFormattingOptionsFirstTriggerCharacter :: String
+                                                                       , documentOnTypeFormattingOptionsMoreTriggerCharacter :: Maybe [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentOnTypeFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentOnTypeFormattingParams.curry
@@ -1,0 +1,34 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentOnTypeFormattingParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentOnTypeFormattingParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedCh <- lookupFromJSON "ch" vs
+           parsedOptions <- lookupFromJSON "options" vs
+           return
+            DocumentOnTypeFormattingParams { documentOnTypeFormattingParamsTextDocument = parsedTextDocument
+                                           , documentOnTypeFormattingParamsPosition = parsedPosition
+                                           , documentOnTypeFormattingParamsCh = parsedCh
+                                           , documentOnTypeFormattingParamsOptions = parsedOptions }
+      _ ->
+        Left
+         ("Unrecognized DocumentOnTypeFormattingParams value: " ++ ppJSON j)
+
+data DocumentOnTypeFormattingParams = DocumentOnTypeFormattingParams { documentOnTypeFormattingParamsTextDocument :: TextDocumentIdentifier
+                                                                     , documentOnTypeFormattingParamsPosition :: Position
+                                                                     , documentOnTypeFormattingParamsCh :: String
+                                                                     , documentOnTypeFormattingParamsOptions :: FormattingOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentOnTypeFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentOnTypeFormattingRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentOnTypeFormattingRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentOnTypeFormattingRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentOnTypeFormattingRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentOnTypeFormattingRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DocumentOnTypeFormattingRegistrationOptions = DocumentOnTypeFormattingRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingClientCapabilities.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentRangeFormattingClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentRangeFormattingClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
+           return
+            DocumentRangeFormattingClientCapabilities { documentRangeFormattingClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                                      , documentRangeFormattingClientCapabilitiesRangesSupport = parsedRangesSupport }
+      _ ->
+        Left
+         ("Unrecognized DocumentRangeFormattingClientCapabilities value: "
+           ++ ppJSON j)
+
+data DocumentRangeFormattingClientCapabilities = DocumentRangeFormattingClientCapabilities { documentRangeFormattingClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                                           , documentRangeFormattingClientCapabilitiesRangesSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingOptions.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentRangeFormattingOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentRangeFormattingOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
+           return
+            DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport = parsedRangesSupport }
+      _ ->
+        Left
+         ("Unrecognized DocumentRangeFormattingOptions value: " ++ ppJSON j)
+
+data DocumentRangeFormattingOptions = DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingParams.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentRangeFormattingParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentRangeFormattingParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedOptions <- lookupFromJSON "options" vs
+           return
+            DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument = parsedTextDocument
+                                          , documentRangeFormattingParamsRange = parsedRange
+                                          , documentRangeFormattingParamsOptions = parsedOptions }
+      _ ->
+        Left
+         ("Unrecognized DocumentRangeFormattingParams value: " ++ ppJSON j)
+
+data DocumentRangeFormattingParams = DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument :: TextDocumentIdentifier
+                                                                   , documentRangeFormattingParamsRange :: Range
+                                                                   , documentRangeFormattingParamsOptions :: FormattingOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentRangeFormattingRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentRangeFormattingRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentRangeFormattingRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentRangeFormattingRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DocumentRangeFormattingRegistrationOptions = DocumentRangeFormattingRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentRangesFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentRangesFormattingParams.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentRangesFormattingParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentRangesFormattingParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRanges <- lookupFromJSON "ranges" vs
+           parsedOptions <- lookupFromJSON "options" vs
+           return
+            DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument = parsedTextDocument
+                                           , documentRangesFormattingParamsRanges = parsedRanges
+                                           , documentRangesFormattingParamsOptions = parsedOptions }
+      _ ->
+        Left
+         ("Unrecognized DocumentRangesFormattingParams value: " ++ ppJSON j)
+
+data DocumentRangesFormattingParams = DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument :: TextDocumentIdentifier
+                                                                     , documentRangesFormattingParamsRanges :: [Range]
+                                                                     , documentRangesFormattingParamsOptions :: FormattingOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentSelector.curry
+++ b/src/LSP/Protocol/Types/DocumentSelector.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSelector where
+
+import LSP.Protocol.Types.DocumentFilter
+
+type DocumentSelector = [DocumentFilter]
+

--- a/src/LSP/Protocol/Types/DocumentSymbol.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbol.curry
@@ -1,0 +1,44 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSymbol where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
+import LSP.Utils.JSON
+
+instance FromJSON DocumentSymbol where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedDetail <- lookupMaybeFromJSON "detail" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
+           parsedChildren <- lookupMaybeFromJSON "children" vs
+           return
+            DocumentSymbol { documentSymbolName = parsedName
+                           , documentSymbolDetail = parsedDetail
+                           , documentSymbolKind = parsedKind
+                           , documentSymbolTags = parsedTags
+                           , documentSymbolDeprecated = parsedDeprecated
+                           , documentSymbolRange = parsedRange
+                           , documentSymbolSelectionRange = parsedSelectionRange
+                           , documentSymbolChildren = parsedChildren }
+      _ -> Left ("Unrecognized DocumentSymbol value: " ++ ppJSON j)
+
+data DocumentSymbol = DocumentSymbol { documentSymbolName :: String
+                                     , documentSymbolDetail :: Maybe String
+                                     , documentSymbolKind :: SymbolKind
+                                     , documentSymbolTags :: Maybe [SymbolTag]
+                                     , documentSymbolDeprecated :: Maybe Bool
+                                     , documentSymbolRange :: Range
+                                     , documentSymbolSelectionRange :: Range
+                                     , documentSymbolChildren :: Maybe [DocumentSymbol] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentSymbolClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolClientCapabilities.curry
@@ -1,0 +1,40 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSymbolClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSymbolKindOptions
+import LSP.Protocol.Types.ClientSymbolTagOptions
+import LSP.Utils.JSON
+
+instance FromJSON DocumentSymbolClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedSymbolKind <- lookupMaybeFromJSON "symbolKind" vs
+           parsedHierarchicalDocumentSymbolSupport <- lookupMaybeFromJSON
+                                                       "hierarchicalDocumentSymbolSupport"
+                                                       vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedLabelSupport <- lookupMaybeFromJSON "labelSupport" vs
+           return
+            DocumentSymbolClientCapabilities { documentSymbolClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                             , documentSymbolClientCapabilitiesSymbolKind = parsedSymbolKind
+                                             , documentSymbolClientCapabilitiesHierarchicalDocumentSymbolSupport = parsedHierarchicalDocumentSymbolSupport
+                                             , documentSymbolClientCapabilitiesTagSupport = parsedTagSupport
+                                             , documentSymbolClientCapabilitiesLabelSupport = parsedLabelSupport }
+      _ ->
+        Left
+         ("Unrecognized DocumentSymbolClientCapabilities value: " ++ ppJSON j)
+
+data DocumentSymbolClientCapabilities = DocumentSymbolClientCapabilities { documentSymbolClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                         , documentSymbolClientCapabilitiesSymbolKind :: Maybe ClientSymbolKindOptions
+                                                                         , documentSymbolClientCapabilitiesHierarchicalDocumentSymbolSupport :: Maybe Bool
+                                                                         , documentSymbolClientCapabilitiesTagSupport :: Maybe ClientSymbolTagOptions
+                                                                         , documentSymbolClientCapabilitiesLabelSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentSymbolOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSymbolOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentSymbolOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupMaybeFromJSON "label" vs
+           return
+            DocumentSymbolOptions { documentSymbolOptionsLabel = parsedLabel }
+      _ -> Left ("Unrecognized DocumentSymbolOptions value: " ++ ppJSON j)
+
+data DocumentSymbolOptions = DocumentSymbolOptions { documentSymbolOptionsLabel :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentSymbolParams.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSymbolParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON DocumentSymbolParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            DocumentSymbolParams { documentSymbolParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized DocumentSymbolParams value: " ++ ppJSON j)
+
+data DocumentSymbolParams = DocumentSymbolParams { documentSymbolParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/DocumentSymbolRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.DocumentSymbolRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON DocumentSymbolRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return DocumentSymbolRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized DocumentSymbolRegistrationOptions value: "
+           ++ ppJSON j)
+
+data DocumentSymbolRegistrationOptions = DocumentSymbolRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/EditRangeWithInsertReplace.curry
+++ b/src/LSP/Protocol/Types/EditRangeWithInsertReplace.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.EditRangeWithInsertReplace where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON EditRangeWithInsertReplace where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedInsert <- lookupFromJSON "insert" vs
+           parsedReplace <- lookupFromJSON "replace" vs
+           return
+            EditRangeWithInsertReplace { editRangeWithInsertReplaceInsert = parsedInsert
+                                       , editRangeWithInsertReplaceReplace = parsedReplace }
+      _ ->
+        Left ("Unrecognized EditRangeWithInsertReplace value: " ++ ppJSON j)
+
+data EditRangeWithInsertReplace = EditRangeWithInsertReplace { editRangeWithInsertReplaceInsert :: Range
+                                                             , editRangeWithInsertReplaceReplace :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ErrorCodes.curry
+++ b/src/LSP/Protocol/Types/ErrorCodes.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ErrorCodes where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ErrorCodes where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         -32700 -> Right ErrorCodesParseError
+         -32600 -> Right ErrorCodesInvalidRequest
+         -32601 -> Right ErrorCodesMethodNotFound
+         -32602 -> Right ErrorCodesInvalidParams
+         -32603 -> Right ErrorCodesInternalError
+         -32002 -> Right ErrorCodesServerNotInitialized
+         -32001 -> Right ErrorCodesUnknownErrorCode
+         _ -> Left ("Unrecognized ErrorCodes value: " ++ ppJSON j)
+
+data ErrorCodes = ErrorCodesParseError
+                | ErrorCodesInvalidRequest
+                | ErrorCodesMethodNotFound
+                | ErrorCodesInvalidParams
+                | ErrorCodesInternalError
+                | ErrorCodesServerNotInitialized
+                | ErrorCodesUnknownErrorCode
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/ExecuteCommandClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ExecuteCommandClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ExecuteCommandClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            ExecuteCommandClientCapabilities { executeCommandClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized ExecuteCommandClientCapabilities value: " ++ ppJSON j)
+
+data ExecuteCommandClientCapabilities = ExecuteCommandClientCapabilities { executeCommandClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ExecuteCommandOptions.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ExecuteCommandOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ExecuteCommandOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCommands <- lookupFromJSON "commands" vs
+           return
+            ExecuteCommandOptions { executeCommandOptionsCommands = parsedCommands }
+      _ -> Left ("Unrecognized ExecuteCommandOptions value: " ++ ppJSON j)
+
+data ExecuteCommandOptions = ExecuteCommandOptions { executeCommandOptionsCommands :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ExecuteCommandParams.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ExecuteCommandParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON ExecuteCommandParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCommand <- lookupFromJSON "command" vs
+           parsedArguments <- lookupMaybeFromJSON "arguments" vs
+           return
+            ExecuteCommandParams { executeCommandParamsCommand = parsedCommand
+                                 , executeCommandParamsArguments = parsedArguments }
+      _ -> Left ("Unrecognized ExecuteCommandParams value: " ++ ppJSON j)
+
+data ExecuteCommandParams = ExecuteCommandParams { executeCommandParamsCommand :: String
+                                                 , executeCommandParamsArguments :: Maybe [LSPAny] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ExecuteCommandRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ExecuteCommandRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ExecuteCommandRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ExecuteCommandRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized ExecuteCommandRegistrationOptions value: "
+           ++ ppJSON j)
+
+data ExecuteCommandRegistrationOptions = ExecuteCommandRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ExecutionSummary.curry
+++ b/src/LSP/Protocol/Types/ExecutionSummary.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ExecutionSummary where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ExecutionSummary where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedExecutionOrder <- lookupFromJSON "executionOrder" vs
+           parsedSuccess <- lookupMaybeFromJSON "success" vs
+           return
+            ExecutionSummary { executionSummaryExecutionOrder = parsedExecutionOrder
+                             , executionSummarySuccess = parsedSuccess }
+      _ -> Left ("Unrecognized ExecutionSummary value: " ++ ppJSON j)
+
+data ExecutionSummary = ExecutionSummary { executionSummaryExecutionOrder :: Int
+                                         , executionSummarySuccess :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FailureHandlingKind.curry
+++ b/src/LSP/Protocol/Types/FailureHandlingKind.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FailureHandlingKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FailureHandlingKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "abort" -> Right FailureHandlingKindAbort
+         "transactional" -> Right FailureHandlingKindTransactional
+         "textOnlyTransactional" ->
+           Right FailureHandlingKindTextOnlyTransactional
+         "undo" -> Right FailureHandlingKindUndo
+         _ -> Left ("Unrecognized FailureHandlingKind value: " ++ ppJSON j)
+
+data FailureHandlingKind = FailureHandlingKindAbort
+                         | FailureHandlingKindTransactional
+                         | FailureHandlingKindTextOnlyTransactional
+                         | FailureHandlingKindUndo
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/FileChangeType.curry
+++ b/src/LSP/Protocol/Types/FileChangeType.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileChangeType where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileChangeType where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right FileChangeTypeCreated
+         2 -> Right FileChangeTypeChanged
+         3 -> Right FileChangeTypeDeleted
+         _ -> Left ("Unrecognized FileChangeType value: " ++ ppJSON j)
+
+data FileChangeType = FileChangeTypeCreated
+                    | FileChangeTypeChanged
+                    | FileChangeTypeDeleted
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/FileCreate.curry
+++ b/src/LSP/Protocol/Types/FileCreate.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileCreate where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileCreate where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           return FileCreate { fileCreateUri = parsedUri }
+      _ -> Left ("Unrecognized FileCreate value: " ++ ppJSON j)
+
+data FileCreate = FileCreate { fileCreateUri :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileDelete.curry
+++ b/src/LSP/Protocol/Types/FileDelete.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileDelete where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileDelete where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           return FileDelete { fileDeleteUri = parsedUri }
+      _ -> Left ("Unrecognized FileDelete value: " ++ ppJSON j)
+
+data FileDelete = FileDelete { fileDeleteUri :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileEvent.curry
+++ b/src/LSP/Protocol/Types/FileEvent.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileEvent where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.FileChangeType
+import LSP.Utils.JSON
+
+instance FromJSON FileEvent where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedType <- lookupFromJSON "type" vs
+           return
+            FileEvent { fileEventUri = parsedUri, fileEventType = parsedType }
+      _ -> Left ("Unrecognized FileEvent value: " ++ ppJSON j)
+
+data FileEvent = FileEvent { fileEventUri :: DocumentUri
+                           , fileEventType :: FileChangeType }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/FileOperationClientCapabilities.curry
@@ -1,0 +1,42 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedDidCreate <- lookupMaybeFromJSON "didCreate" vs
+           parsedWillCreate <- lookupMaybeFromJSON "willCreate" vs
+           parsedDidRename <- lookupMaybeFromJSON "didRename" vs
+           parsedWillRename <- lookupMaybeFromJSON "willRename" vs
+           parsedDidDelete <- lookupMaybeFromJSON "didDelete" vs
+           parsedWillDelete <- lookupMaybeFromJSON "willDelete" vs
+           return
+            FileOperationClientCapabilities { fileOperationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                            , fileOperationClientCapabilitiesDidCreate = parsedDidCreate
+                                            , fileOperationClientCapabilitiesWillCreate = parsedWillCreate
+                                            , fileOperationClientCapabilitiesDidRename = parsedDidRename
+                                            , fileOperationClientCapabilitiesWillRename = parsedWillRename
+                                            , fileOperationClientCapabilitiesDidDelete = parsedDidDelete
+                                            , fileOperationClientCapabilitiesWillDelete = parsedWillDelete }
+      _ ->
+        Left
+         ("Unrecognized FileOperationClientCapabilities value: " ++ ppJSON j)
+
+data FileOperationClientCapabilities = FileOperationClientCapabilities { fileOperationClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesDidCreate :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesWillCreate :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesDidRename :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesWillRename :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesDidDelete :: Maybe Bool
+                                                                       , fileOperationClientCapabilitiesWillDelete :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationFilter.curry
+++ b/src/LSP/Protocol/Types/FileOperationFilter.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationFilter where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileOperationPattern
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationFilter where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedScheme <- lookupMaybeFromJSON "scheme" vs
+           parsedPattern <- lookupFromJSON "pattern" vs
+           return
+            FileOperationFilter { fileOperationFilterScheme = parsedScheme
+                                , fileOperationFilterPattern = parsedPattern }
+      _ -> Left ("Unrecognized FileOperationFilter value: " ++ ppJSON j)
+
+data FileOperationFilter = FileOperationFilter { fileOperationFilterScheme :: Maybe String
+                                               , fileOperationFilterPattern :: FileOperationPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationOptions.curry
+++ b/src/LSP/Protocol/Types/FileOperationOptions.curry
@@ -1,0 +1,36 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileOperationRegistrationOptions
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDidCreate <- lookupMaybeFromJSON "didCreate" vs
+           parsedWillCreate <- lookupMaybeFromJSON "willCreate" vs
+           parsedDidRename <- lookupMaybeFromJSON "didRename" vs
+           parsedWillRename <- lookupMaybeFromJSON "willRename" vs
+           parsedDidDelete <- lookupMaybeFromJSON "didDelete" vs
+           parsedWillDelete <- lookupMaybeFromJSON "willDelete" vs
+           return
+            FileOperationOptions { fileOperationOptionsDidCreate = parsedDidCreate
+                                 , fileOperationOptionsWillCreate = parsedWillCreate
+                                 , fileOperationOptionsDidRename = parsedDidRename
+                                 , fileOperationOptionsWillRename = parsedWillRename
+                                 , fileOperationOptionsDidDelete = parsedDidDelete
+                                 , fileOperationOptionsWillDelete = parsedWillDelete }
+      _ -> Left ("Unrecognized FileOperationOptions value: " ++ ppJSON j)
+
+data FileOperationOptions = FileOperationOptions { fileOperationOptionsDidCreate :: Maybe FileOperationRegistrationOptions
+                                                 , fileOperationOptionsWillCreate :: Maybe FileOperationRegistrationOptions
+                                                 , fileOperationOptionsDidRename :: Maybe FileOperationRegistrationOptions
+                                                 , fileOperationOptionsWillRename :: Maybe FileOperationRegistrationOptions
+                                                 , fileOperationOptionsDidDelete :: Maybe FileOperationRegistrationOptions
+                                                 , fileOperationOptionsWillDelete :: Maybe FileOperationRegistrationOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationPattern.curry
+++ b/src/LSP/Protocol/Types/FileOperationPattern.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationPattern where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileOperationPatternKind
+import LSP.Protocol.Types.FileOperationPatternOptions
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationPattern where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedGlob <- lookupFromJSON "glob" vs
+           parsedMatches <- lookupMaybeFromJSON "matches" vs
+           parsedOptions <- lookupMaybeFromJSON "options" vs
+           return
+            FileOperationPattern { fileOperationPatternGlob = parsedGlob
+                                 , fileOperationPatternMatches = parsedMatches
+                                 , fileOperationPatternOptions = parsedOptions }
+      _ -> Left ("Unrecognized FileOperationPattern value: " ++ ppJSON j)
+
+data FileOperationPattern = FileOperationPattern { fileOperationPatternGlob :: String
+                                                 , fileOperationPatternMatches :: Maybe FileOperationPatternKind
+                                                 , fileOperationPatternOptions :: Maybe FileOperationPatternOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationPatternKind.curry
+++ b/src/LSP/Protocol/Types/FileOperationPatternKind.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationPatternKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationPatternKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "file" -> Right FileOperationPatternKindFile
+         "folder" -> Right FileOperationPatternKindFolder
+         _ ->
+           Left ("Unrecognized FileOperationPatternKind value: " ++ ppJSON j)
+
+data FileOperationPatternKind = FileOperationPatternKindFile
+                              | FileOperationPatternKindFolder
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/FileOperationPatternOptions.curry
+++ b/src/LSP/Protocol/Types/FileOperationPatternOptions.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationPatternOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationPatternOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIgnoreCase <- lookupMaybeFromJSON "ignoreCase" vs
+           return
+            FileOperationPatternOptions { fileOperationPatternOptionsIgnoreCase = parsedIgnoreCase }
+      _ ->
+        Left ("Unrecognized FileOperationPatternOptions value: " ++ ppJSON j)
+
+data FileOperationPatternOptions = FileOperationPatternOptions { fileOperationPatternOptionsIgnoreCase :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileOperationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/FileOperationRegistrationOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileOperationRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileOperationFilter
+import LSP.Utils.JSON
+
+instance FromJSON FileOperationRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFilters <- lookupFromJSON "filters" vs
+           return
+            FileOperationRegistrationOptions { fileOperationRegistrationOptionsFilters = parsedFilters }
+      _ ->
+        Left
+         ("Unrecognized FileOperationRegistrationOptions value: " ++ ppJSON j)
+
+data FileOperationRegistrationOptions = FileOperationRegistrationOptions { fileOperationRegistrationOptionsFilters :: [FileOperationFilter] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileRename.curry
+++ b/src/LSP/Protocol/Types/FileRename.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileRename where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FileRename where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedOldUri <- lookupFromJSON "oldUri" vs
+           parsedNewUri <- lookupFromJSON "newUri" vs
+           return
+            FileRename { fileRenameOldUri = parsedOldUri
+                       , fileRenameNewUri = parsedNewUri }
+      _ -> Left ("Unrecognized FileRename value: " ++ ppJSON j)
+
+data FileRename = FileRename { fileRenameOldUri :: String
+                             , fileRenameNewUri :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FileSystemWatcher.curry
+++ b/src/LSP/Protocol/Types/FileSystemWatcher.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FileSystemWatcher where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Protocol.Types.WatchKind
+import LSP.Utils.JSON
+
+instance FromJSON FileSystemWatcher where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedGlobPattern <- lookupFromJSON "globPattern" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           return
+            FileSystemWatcher { fileSystemWatcherGlobPattern = parsedGlobPattern
+                              , fileSystemWatcherKind = parsedKind }
+      _ -> Left ("Unrecognized FileSystemWatcher value: " ++ ppJSON j)
+
+data FileSystemWatcher = FileSystemWatcher { fileSystemWatcherGlobPattern :: GlobPattern
+                                           , fileSystemWatcherKind :: Maybe WatchKind }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRange.curry
+++ b/src/LSP/Protocol/Types/FoldingRange.curry
@@ -1,0 +1,36 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRange where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FoldingRangeKind
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRange where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStartLine <- lookupFromJSON "startLine" vs
+           parsedStartCharacter <- lookupMaybeFromJSON "startCharacter" vs
+           parsedEndLine <- lookupFromJSON "endLine" vs
+           parsedEndCharacter <- lookupMaybeFromJSON "endCharacter" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           parsedCollapsedText <- lookupMaybeFromJSON "collapsedText" vs
+           return
+            FoldingRange { foldingRangeStartLine = parsedStartLine
+                         , foldingRangeStartCharacter = parsedStartCharacter
+                         , foldingRangeEndLine = parsedEndLine
+                         , foldingRangeEndCharacter = parsedEndCharacter
+                         , foldingRangeKind = parsedKind
+                         , foldingRangeCollapsedText = parsedCollapsedText }
+      _ -> Left ("Unrecognized FoldingRange value: " ++ ppJSON j)
+
+data FoldingRange = FoldingRange { foldingRangeStartLine :: Int
+                                 , foldingRangeStartCharacter :: Maybe Int
+                                 , foldingRangeEndLine :: Int
+                                 , foldingRangeEndCharacter :: Maybe Int
+                                 , foldingRangeKind :: Maybe FoldingRangeKind
+                                 , foldingRangeCollapsedText :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRangeClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeClientCapabilities.curry
@@ -1,0 +1,38 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientFoldingRangeKindOptions
+import LSP.Protocol.Types.ClientFoldingRangeOptions
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedRangeLimit <- lookupMaybeFromJSON "rangeLimit" vs
+           parsedLineFoldingOnly <- lookupMaybeFromJSON "lineFoldingOnly" vs
+           parsedFoldingRangeKind <- lookupMaybeFromJSON "foldingRangeKind" vs
+           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
+           return
+            FoldingRangeClientCapabilities { foldingRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                           , foldingRangeClientCapabilitiesRangeLimit = parsedRangeLimit
+                                           , foldingRangeClientCapabilitiesLineFoldingOnly = parsedLineFoldingOnly
+                                           , foldingRangeClientCapabilitiesFoldingRangeKind = parsedFoldingRangeKind
+                                           , foldingRangeClientCapabilitiesFoldingRange = parsedFoldingRange }
+      _ ->
+        Left
+         ("Unrecognized FoldingRangeClientCapabilities value: " ++ ppJSON j)
+
+data FoldingRangeClientCapabilities = FoldingRangeClientCapabilities { foldingRangeClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                     , foldingRangeClientCapabilitiesRangeLimit :: Maybe Int
+                                                                     , foldingRangeClientCapabilitiesLineFoldingOnly :: Maybe Bool
+                                                                     , foldingRangeClientCapabilitiesFoldingRangeKind :: Maybe ClientFoldingRangeKindOptions
+                                                                     , foldingRangeClientCapabilitiesFoldingRange :: Maybe ClientFoldingRangeOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRangeKind.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "comment" -> Right FoldingRangeKindComment
+         "imports" -> Right FoldingRangeKindImports
+         "region" -> Right FoldingRangeKindRegion
+         _ -> Left ("Unrecognized FoldingRangeKind value: " ++ ppJSON j)
+
+data FoldingRangeKind = FoldingRangeKindComment
+                      | FoldingRangeKindImports
+                      | FoldingRangeKindRegion
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/FoldingRangeOptions.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return FoldingRangeOptions {  }
+      _ -> Left ("Unrecognized FoldingRangeOptions value: " ++ ppJSON j)
+
+data FoldingRangeOptions = FoldingRangeOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRangeParams.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            FoldingRangeParams { foldingRangeParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized FoldingRangeParams value: " ++ ppJSON j)
+
+data FoldingRangeParams = FoldingRangeParams { foldingRangeParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return FoldingRangeRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized FoldingRangeRegistrationOptions value: " ++ ppJSON j)
+
+data FoldingRangeRegistrationOptions = FoldingRangeRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FoldingRangeWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FoldingRangeWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FoldingRangeWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            FoldingRangeWorkspaceClientCapabilities { foldingRangeWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized FoldingRangeWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data FoldingRangeWorkspaceClientCapabilities = FoldingRangeWorkspaceClientCapabilities { foldingRangeWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FormattingOptions.curry
+++ b/src/LSP/Protocol/Types/FormattingOptions.curry
@@ -1,0 +1,37 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FormattingOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON FormattingOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTabSize <- lookupFromJSON "tabSize" vs
+           parsedInsertSpaces <- lookupFromJSON "insertSpaces" vs
+           parsedTrimTrailingWhitespace <- lookupMaybeFromJSON
+                                            "trimTrailingWhitespace"
+                                            vs
+           parsedInsertFinalNewline <- lookupMaybeFromJSON
+                                        "insertFinalNewline"
+                                        vs
+           parsedTrimFinalNewlines <- lookupMaybeFromJSON "trimFinalNewlines"
+                                       vs
+           return
+            FormattingOptions { formattingOptionsTabSize = parsedTabSize
+                              , formattingOptionsInsertSpaces = parsedInsertSpaces
+                              , formattingOptionsTrimTrailingWhitespace = parsedTrimTrailingWhitespace
+                              , formattingOptionsInsertFinalNewline = parsedInsertFinalNewline
+                              , formattingOptionsTrimFinalNewlines = parsedTrimFinalNewlines }
+      _ -> Left ("Unrecognized FormattingOptions value: " ++ ppJSON j)
+
+data FormattingOptions = FormattingOptions { formattingOptionsTabSize :: Int
+                                           , formattingOptionsInsertSpaces :: Bool
+                                           , formattingOptionsTrimTrailingWhitespace :: Maybe Bool
+                                           , formattingOptionsInsertFinalNewline :: Maybe Bool
+                                           , formattingOptionsTrimFinalNewlines :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/FullDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/FullDocumentDiagnosticReport.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.FullDocumentDiagnosticReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Diagnostic
+import LSP.Utils.JSON
+
+instance FromJSON FullDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupMaybeFromJSON "resultId" vs
+           parsedItems <- lookupFromJSON "items" vs
+           return
+            FullDocumentDiagnosticReport { fullDocumentDiagnosticReportKind = parsedKind
+                                         , fullDocumentDiagnosticReportResultId = parsedResultId
+                                         , fullDocumentDiagnosticReportItems = parsedItems }
+      _ ->
+        Left ("Unrecognized FullDocumentDiagnosticReport value: " ++ ppJSON j)
+
+data FullDocumentDiagnosticReport = FullDocumentDiagnosticReport { fullDocumentDiagnosticReportKind :: String
+                                                                 , fullDocumentDiagnosticReportResultId :: Maybe String
+                                                                 , fullDocumentDiagnosticReportItems :: [Diagnostic] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/GeneralClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/GeneralClientCapabilities.curry
@@ -1,0 +1,38 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.GeneralClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkdownClientCapabilities
+import LSP.Protocol.Types.PositionEncodingKind
+import LSP.Protocol.Types.RegularExpressionsClientCapabilities
+import LSP.Protocol.Types.StaleRequestSupportOptions
+import LSP.Utils.JSON
+
+instance FromJSON GeneralClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStaleRequestSupport <- lookupMaybeFromJSON
+                                         "staleRequestSupport"
+                                         vs
+           parsedRegularExpressions <- lookupMaybeFromJSON
+                                        "regularExpressions"
+                                        vs
+           parsedMarkdown <- lookupMaybeFromJSON "markdown" vs
+           parsedPositionEncodings <- lookupMaybeFromJSON "positionEncodings"
+                                       vs
+           return
+            GeneralClientCapabilities { generalClientCapabilitiesStaleRequestSupport = parsedStaleRequestSupport
+                                      , generalClientCapabilitiesRegularExpressions = parsedRegularExpressions
+                                      , generalClientCapabilitiesMarkdown = parsedMarkdown
+                                      , generalClientCapabilitiesPositionEncodings = parsedPositionEncodings }
+      _ -> Left ("Unrecognized GeneralClientCapabilities value: " ++ ppJSON j)
+
+data GeneralClientCapabilities = GeneralClientCapabilities { generalClientCapabilitiesStaleRequestSupport :: Maybe StaleRequestSupportOptions
+                                                           , generalClientCapabilitiesRegularExpressions :: Maybe RegularExpressionsClientCapabilities
+                                                           , generalClientCapabilitiesMarkdown :: Maybe MarkdownClientCapabilities
+                                                           , generalClientCapabilitiesPositionEncodings :: Maybe [PositionEncodingKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/GlobPattern.curry
+++ b/src/LSP/Protocol/Types/GlobPattern.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.GlobPattern where
+
+import LSP.Protocol.Types.Pattern
+import LSP.Protocol.Types.RelativePattern
+
+type GlobPattern = Either Pattern RelativePattern
+

--- a/src/LSP/Protocol/Types/Hover.curry
+++ b/src/LSP/Protocol/Types/Hover.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Hover where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkedString
+import LSP.Protocol.Types.MarkupContent
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON Hover where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedContents <- lookupFromJSON "contents" vs
+           parsedRange <- lookupMaybeFromJSON "range" vs
+           return
+            Hover { hoverContents = parsedContents, hoverRange = parsedRange }
+      _ -> Left ("Unrecognized Hover value: " ++ ppJSON j)
+
+data Hover = Hover { hoverContents :: Either (Either MarkupContent MarkedString) [MarkedString]
+                   , hoverRange :: Maybe Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/HoverClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/HoverClientCapabilities.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.HoverClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkupKind
+import LSP.Utils.JSON
+
+instance FromJSON HoverClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedContentFormat <- lookupMaybeFromJSON "contentFormat" vs
+           return
+            HoverClientCapabilities { hoverClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                    , hoverClientCapabilitiesContentFormat = parsedContentFormat }
+      _ -> Left ("Unrecognized HoverClientCapabilities value: " ++ ppJSON j)
+
+data HoverClientCapabilities = HoverClientCapabilities { hoverClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                       , hoverClientCapabilitiesContentFormat :: Maybe [MarkupKind] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/HoverOptions.curry
+++ b/src/LSP/Protocol/Types/HoverOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.HoverOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON HoverOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return HoverOptions {  }
+      _ -> Left ("Unrecognized HoverOptions value: " ++ ppJSON j)
+
+data HoverOptions = HoverOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/HoverParams.curry
+++ b/src/LSP/Protocol/Types/HoverParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.HoverParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON HoverParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return HoverParams {  }
+      _ -> Left ("Unrecognized HoverParams value: " ++ ppJSON j)
+
+data HoverParams = HoverParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/HoverRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/HoverRegistrationOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.HoverRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON HoverRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return HoverRegistrationOptions {  }
+      _ -> Left ("Unrecognized HoverRegistrationOptions value: " ++ ppJSON j)
+
+data HoverRegistrationOptions = HoverRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ImplementationClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ImplementationClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ImplementationClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ImplementationClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
+           return
+            ImplementationClientCapabilities { implementationClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                             , implementationClientCapabilitiesLinkSupport = parsedLinkSupport }
+      _ ->
+        Left
+         ("Unrecognized ImplementationClientCapabilities value: " ++ ppJSON j)
+
+data ImplementationClientCapabilities = ImplementationClientCapabilities { implementationClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                         , implementationClientCapabilitiesLinkSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ImplementationOptions.curry
+++ b/src/LSP/Protocol/Types/ImplementationOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ImplementationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ImplementationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ImplementationOptions {  }
+      _ -> Left ("Unrecognized ImplementationOptions value: " ++ ppJSON j)
+
+data ImplementationOptions = ImplementationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ImplementationParams.curry
+++ b/src/LSP/Protocol/Types/ImplementationParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ImplementationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ImplementationParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ImplementationParams {  }
+      _ -> Left ("Unrecognized ImplementationParams value: " ++ ppJSON j)
+
+data ImplementationParams = ImplementationParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ImplementationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ImplementationRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ImplementationRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ImplementationRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ImplementationRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized ImplementationRegistrationOptions value: "
+           ++ ppJSON j)
+
+data ImplementationRegistrationOptions = ImplementationRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InitializeError.curry
+++ b/src/LSP/Protocol/Types/InitializeError.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InitializeError where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InitializeError where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRetry <- lookupFromJSON "retry" vs
+           return InitializeError { initializeErrorRetry = parsedRetry }
+      _ -> Left ("Unrecognized InitializeError value: " ++ ppJSON j)
+
+data InitializeError = InitializeError { initializeErrorRetry :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InitializeParams.curry
+++ b/src/LSP/Protocol/Types/InitializeParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InitializeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InitializeParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InitializeParams {  }
+      _ -> Left ("Unrecognized InitializeParams value: " ++ ppJSON j)
+
+data InitializeParams = InitializeParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InitializeResult.curry
+++ b/src/LSP/Protocol/Types/InitializeResult.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InitializeResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ServerCapabilities
+import LSP.Protocol.Types.ServerInfo
+import LSP.Utils.JSON
+
+instance FromJSON InitializeResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCapabilities <- lookupFromJSON "capabilities" vs
+           parsedServerInfo <- lookupMaybeFromJSON "serverInfo" vs
+           return
+            InitializeResult { initializeResultCapabilities = parsedCapabilities
+                             , initializeResultServerInfo = parsedServerInfo }
+      _ -> Left ("Unrecognized InitializeResult value: " ++ ppJSON j)
+
+data InitializeResult = InitializeResult { initializeResultCapabilities :: ServerCapabilities
+                                         , initializeResultServerInfo :: Maybe ServerInfo }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InitializedParams.curry
+++ b/src/LSP/Protocol/Types/InitializedParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InitializedParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InitializedParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InitializedParams {  }
+      _ -> Left ("Unrecognized InitializedParams value: " ++ ppJSON j)
+
+data InitializedParams = InitializedParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHint.curry
+++ b/src/LSP/Protocol/Types/InlayHint.curry
@@ -1,0 +1,47 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHint where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.InlayHintKind
+import LSP.Protocol.Types.InlayHintLabelPart
+import LSP.Protocol.Types.MarkupContent
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.TextEdit
+import LSP.Utils.JSON
+
+instance FromJSON InlayHint where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedPosition <- lookupFromJSON "position" vs
+           parsedLabel <- lookupFromJSON "label" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           parsedTextEdits <- lookupMaybeFromJSON "textEdits" vs
+           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
+           parsedPaddingLeft <- lookupMaybeFromJSON "paddingLeft" vs
+           parsedPaddingRight <- lookupMaybeFromJSON "paddingRight" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            InlayHint { inlayHintPosition = parsedPosition
+                      , inlayHintLabel = parsedLabel
+                      , inlayHintKind = parsedKind
+                      , inlayHintTextEdits = parsedTextEdits
+                      , inlayHintTooltip = parsedTooltip
+                      , inlayHintPaddingLeft = parsedPaddingLeft
+                      , inlayHintPaddingRight = parsedPaddingRight
+                      , inlayHintData = parsedData }
+      _ -> Left ("Unrecognized InlayHint value: " ++ ppJSON j)
+
+data InlayHint = InlayHint { inlayHintPosition :: Position
+                           , inlayHintLabel :: Either String [InlayHintLabelPart]
+                           , inlayHintKind :: Maybe InlayHintKind
+                           , inlayHintTextEdits :: Maybe [TextEdit]
+                           , inlayHintTooltip :: Maybe (Either String MarkupContent)
+                           , inlayHintPaddingLeft :: Maybe Bool
+                           , inlayHintPaddingRight :: Maybe Bool
+                           , inlayHintData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/InlayHintClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientInlayHintResolveOptions
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
+           return
+            InlayHintClientCapabilities { inlayHintClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                        , inlayHintClientCapabilitiesResolveSupport = parsedResolveSupport }
+      _ ->
+        Left ("Unrecognized InlayHintClientCapabilities value: " ++ ppJSON j)
+
+data InlayHintClientCapabilities = InlayHintClientCapabilities { inlayHintClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                               , inlayHintClientCapabilitiesResolveSupport :: Maybe ClientInlayHintResolveOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintKind.curry
+++ b/src/LSP/Protocol/Types/InlayHintKind.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right InlayHintKindType
+         2 -> Right InlayHintKindParameter
+         _ -> Left ("Unrecognized InlayHintKind value: " ++ ppJSON j)
+
+data InlayHintKind = InlayHintKindType | InlayHintKindParameter
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/InlayHintLabelPart.curry
+++ b/src/LSP/Protocol/Types/InlayHintLabelPart.curry
@@ -1,0 +1,32 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintLabelPart where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.Location
+import LSP.Protocol.Types.MarkupContent
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintLabelPart where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValue <- lookupFromJSON "value" vs
+           parsedTooltip <- lookupMaybeFromJSON "tooltip" vs
+           parsedLocation <- lookupMaybeFromJSON "location" vs
+           parsedCommand <- lookupMaybeFromJSON "command" vs
+           return
+            InlayHintLabelPart { inlayHintLabelPartValue = parsedValue
+                               , inlayHintLabelPartTooltip = parsedTooltip
+                               , inlayHintLabelPartLocation = parsedLocation
+                               , inlayHintLabelPartCommand = parsedCommand }
+      _ -> Left ("Unrecognized InlayHintLabelPart value: " ++ ppJSON j)
+
+data InlayHintLabelPart = InlayHintLabelPart { inlayHintLabelPartValue :: String
+                                             , inlayHintLabelPartTooltip :: Maybe (Either String MarkupContent)
+                                             , inlayHintLabelPartLocation :: Maybe Location
+                                             , inlayHintLabelPartCommand :: Maybe Command }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintOptions.curry
+++ b/src/LSP/Protocol/Types/InlayHintOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            InlayHintOptions { inlayHintOptionsResolveProvider = parsedResolveProvider }
+      _ -> Left ("Unrecognized InlayHintOptions value: " ++ ppJSON j)
+
+data InlayHintOptions = InlayHintOptions { inlayHintOptionsResolveProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintParams.curry
+++ b/src/LSP/Protocol/Types/InlayHintParams.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRange <- lookupFromJSON "range" vs
+           return
+            InlayHintParams { inlayHintParamsTextDocument = parsedTextDocument
+                            , inlayHintParamsRange = parsedRange }
+      _ -> Left ("Unrecognized InlayHintParams value: " ++ ppJSON j)
+
+data InlayHintParams = InlayHintParams { inlayHintParamsTextDocument :: TextDocumentIdentifier
+                                       , inlayHintParamsRange :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlayHintRegistrationOptions.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InlayHintRegistrationOptions {  }
+      _ ->
+        Left ("Unrecognized InlayHintRegistrationOptions value: " ++ ppJSON j)
+
+data InlayHintRegistrationOptions = InlayHintRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlayHintWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/InlayHintWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlayHintWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlayHintWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            InlayHintWorkspaceClientCapabilities { inlayHintWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized InlayHintWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data InlayHintWorkspaceClientCapabilities = InlayHintWorkspaceClientCapabilities { inlayHintWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            InlineCompletionClientCapabilities { inlineCompletionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized InlineCompletionClientCapabilities value: "
+           ++ ppJSON j)
+
+data InlineCompletionClientCapabilities = InlineCompletionClientCapabilities { inlineCompletionClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionContext.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionContext.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.InlineCompletionTriggerKind
+import LSP.Protocol.Types.SelectedCompletionInfo
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
+           parsedSelectedCompletionInfo <- lookupMaybeFromJSON
+                                            "selectedCompletionInfo"
+                                            vs
+           return
+            InlineCompletionContext { inlineCompletionContextTriggerKind = parsedTriggerKind
+                                    , inlineCompletionContextSelectedCompletionInfo = parsedSelectedCompletionInfo }
+      _ -> Left ("Unrecognized InlineCompletionContext value: " ++ ppJSON j)
+
+data InlineCompletionContext = InlineCompletionContext { inlineCompletionContextTriggerKind :: InlineCompletionTriggerKind
+                                                       , inlineCompletionContextSelectedCompletionInfo :: Maybe SelectedCompletionInfo }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionItem.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionItem.curry
@@ -1,0 +1,32 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Command
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.StringValue
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedInsertText <- lookupFromJSON "insertText" vs
+           parsedFilterText <- lookupMaybeFromJSON "filterText" vs
+           parsedRange <- lookupMaybeFromJSON "range" vs
+           parsedCommand <- lookupMaybeFromJSON "command" vs
+           return
+            InlineCompletionItem { inlineCompletionItemInsertText = parsedInsertText
+                                 , inlineCompletionItemFilterText = parsedFilterText
+                                 , inlineCompletionItemRange = parsedRange
+                                 , inlineCompletionItemCommand = parsedCommand }
+      _ -> Left ("Unrecognized InlineCompletionItem value: " ++ ppJSON j)
+
+data InlineCompletionItem = InlineCompletionItem { inlineCompletionItemInsertText :: Either String StringValue
+                                                 , inlineCompletionItemFilterText :: Maybe String
+                                                 , inlineCompletionItemRange :: Maybe Range
+                                                 , inlineCompletionItemCommand :: Maybe Command }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionList.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionList.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionList where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.InlineCompletionItem
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionList where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItems <- lookupFromJSON "items" vs
+           return
+            InlineCompletionList { inlineCompletionListItems = parsedItems }
+      _ -> Left ("Unrecognized InlineCompletionList value: " ++ ppJSON j)
+
+data InlineCompletionList = InlineCompletionList { inlineCompletionListItems :: [InlineCompletionItem] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionOptions.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InlineCompletionOptions {  }
+      _ -> Left ("Unrecognized InlineCompletionOptions value: " ++ ppJSON j)
+
+data InlineCompletionOptions = InlineCompletionOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionParams.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.InlineCompletionContext
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedContext <- lookupFromJSON "context" vs
+           return
+            InlineCompletionParams { inlineCompletionParamsContext = parsedContext }
+      _ -> Left ("Unrecognized InlineCompletionParams value: " ++ ppJSON j)
+
+data InlineCompletionParams = InlineCompletionParams { inlineCompletionParamsContext :: InlineCompletionContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InlineCompletionRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized InlineCompletionRegistrationOptions value: "
+           ++ ppJSON j)
+
+data InlineCompletionRegistrationOptions = InlineCompletionRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineCompletionTriggerKind.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionTriggerKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineCompletionTriggerKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineCompletionTriggerKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right InlineCompletionTriggerKindInvoked
+         2 -> Right InlineCompletionTriggerKindAutomatic
+         _ ->
+           Left
+            ("Unrecognized InlineCompletionTriggerKind value: " ++ ppJSON j)
+
+data InlineCompletionTriggerKind = InlineCompletionTriggerKindInvoked
+                                 | InlineCompletionTriggerKindAutomatic
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/InlineValue.curry
+++ b/src/LSP/Protocol/Types/InlineValue.curry
@@ -1,0 +1,10 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValue where
+
+import LSP.Protocol.Types.InlineValueEvaluatableExpression
+import LSP.Protocol.Types.InlineValueText
+import LSP.Protocol.Types.InlineValueVariableLookup
+
+type InlineValue = Either (Either InlineValueText InlineValueVariableLookup) InlineValueEvaluatableExpression
+

--- a/src/LSP/Protocol/Types/InlineValueClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/InlineValueClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            InlineValueClientCapabilities { inlineValueClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized InlineValueClientCapabilities value: " ++ ppJSON j)
+
+data InlineValueClientCapabilities = InlineValueClientCapabilities { inlineValueClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueContext.curry
+++ b/src/LSP/Protocol/Types/InlineValueContext.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFrameId <- lookupFromJSON "frameId" vs
+           parsedStoppedLocation <- lookupFromJSON "stoppedLocation" vs
+           return
+            InlineValueContext { inlineValueContextFrameId = parsedFrameId
+                               , inlineValueContextStoppedLocation = parsedStoppedLocation }
+      _ -> Left ("Unrecognized InlineValueContext value: " ++ ppJSON j)
+
+data InlineValueContext = InlineValueContext { inlineValueContextFrameId :: Int
+                                             , inlineValueContextStoppedLocation :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueEvaluatableExpression.curry
+++ b/src/LSP/Protocol/Types/InlineValueEvaluatableExpression.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueEvaluatableExpression where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueEvaluatableExpression where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedExpression <- lookupMaybeFromJSON "expression" vs
+           return
+            InlineValueEvaluatableExpression { inlineValueEvaluatableExpressionRange = parsedRange
+                                             , inlineValueEvaluatableExpressionExpression = parsedExpression }
+      _ ->
+        Left
+         ("Unrecognized InlineValueEvaluatableExpression value: " ++ ppJSON j)
+
+data InlineValueEvaluatableExpression = InlineValueEvaluatableExpression { inlineValueEvaluatableExpressionRange :: Range
+                                                                         , inlineValueEvaluatableExpressionExpression :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueOptions.curry
+++ b/src/LSP/Protocol/Types/InlineValueOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InlineValueOptions {  }
+      _ -> Left ("Unrecognized InlineValueOptions value: " ++ ppJSON j)
+
+data InlineValueOptions = InlineValueOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueParams.curry
+++ b/src/LSP/Protocol/Types/InlineValueParams.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.InlineValueContext
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedContext <- lookupFromJSON "context" vs
+           return
+            InlineValueParams { inlineValueParamsTextDocument = parsedTextDocument
+                              , inlineValueParamsRange = parsedRange
+                              , inlineValueParamsContext = parsedContext }
+      _ -> Left ("Unrecognized InlineValueParams value: " ++ ppJSON j)
+
+data InlineValueParams = InlineValueParams { inlineValueParamsTextDocument :: TextDocumentIdentifier
+                                           , inlineValueParamsRange :: Range
+                                           , inlineValueParamsContext :: InlineValueContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlineValueRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return InlineValueRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized InlineValueRegistrationOptions value: " ++ ppJSON j)
+
+data InlineValueRegistrationOptions = InlineValueRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueText.curry
+++ b/src/LSP/Protocol/Types/InlineValueText.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueText where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueText where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedText <- lookupFromJSON "text" vs
+           return
+            InlineValueText { inlineValueTextRange = parsedRange
+                            , inlineValueTextText = parsedText }
+      _ -> Left ("Unrecognized InlineValueText value: " ++ ppJSON j)
+
+data InlineValueText = InlineValueText { inlineValueTextRange :: Range
+                                       , inlineValueTextText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueVariableLookup.curry
+++ b/src/LSP/Protocol/Types/InlineValueVariableLookup.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueVariableLookup where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueVariableLookup where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedVariableName <- lookupMaybeFromJSON "variableName" vs
+           parsedCaseSensitiveLookup <- lookupFromJSON "caseSensitiveLookup"
+                                         vs
+           return
+            InlineValueVariableLookup { inlineValueVariableLookupRange = parsedRange
+                                      , inlineValueVariableLookupVariableName = parsedVariableName
+                                      , inlineValueVariableLookupCaseSensitiveLookup = parsedCaseSensitiveLookup }
+      _ -> Left ("Unrecognized InlineValueVariableLookup value: " ++ ppJSON j)
+
+data InlineValueVariableLookup = InlineValueVariableLookup { inlineValueVariableLookupRange :: Range
+                                                           , inlineValueVariableLookupVariableName :: Maybe String
+                                                           , inlineValueVariableLookupCaseSensitiveLookup :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InlineValueWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/InlineValueWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InlineValueWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InlineValueWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            InlineValueWorkspaceClientCapabilities { inlineValueWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized InlineValueWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data InlineValueWorkspaceClientCapabilities = InlineValueWorkspaceClientCapabilities { inlineValueWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InsertReplaceEdit.curry
+++ b/src/LSP/Protocol/Types/InsertReplaceEdit.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InsertReplaceEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON InsertReplaceEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNewText <- lookupFromJSON "newText" vs
+           parsedInsert <- lookupFromJSON "insert" vs
+           parsedReplace <- lookupFromJSON "replace" vs
+           return
+            InsertReplaceEdit { insertReplaceEditNewText = parsedNewText
+                              , insertReplaceEditInsert = parsedInsert
+                              , insertReplaceEditReplace = parsedReplace }
+      _ -> Left ("Unrecognized InsertReplaceEdit value: " ++ ppJSON j)
+
+data InsertReplaceEdit = InsertReplaceEdit { insertReplaceEditNewText :: String
+                                           , insertReplaceEditInsert :: Range
+                                           , insertReplaceEditReplace :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/InsertTextFormat.curry
+++ b/src/LSP/Protocol/Types/InsertTextFormat.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InsertTextFormat where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InsertTextFormat where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right InsertTextFormatPlainText
+         2 -> Right InsertTextFormatSnippet
+         _ -> Left ("Unrecognized InsertTextFormat value: " ++ ppJSON j)
+
+data InsertTextFormat = InsertTextFormatPlainText | InsertTextFormatSnippet
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/InsertTextMode.curry
+++ b/src/LSP/Protocol/Types/InsertTextMode.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.InsertTextMode where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON InsertTextMode where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right InsertTextModeAsIs
+         2 -> Right InsertTextModeAdjustIndentation
+         _ -> Left ("Unrecognized InsertTextMode value: " ++ ppJSON j)
+
+data InsertTextMode = InsertTextModeAsIs | InsertTextModeAdjustIndentation
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/LSPArray.curry
+++ b/src/LSP/Protocol/Types/LSPArray.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LSPArray where
+
+import LSP.Protocol.Support
+
+type LSPArray = [LSPAny]
+

--- a/src/LSP/Protocol/Types/LSPErrorCodes.curry
+++ b/src/LSP/Protocol/Types/LSPErrorCodes.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LSPErrorCodes where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LSPErrorCodes where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         -32803 -> Right LSPErrorCodesRequestFailed
+         -32802 -> Right LSPErrorCodesServerCancelled
+         -32801 -> Right LSPErrorCodesContentModified
+         -32800 -> Right LSPErrorCodesRequestCancelled
+         _ -> Left ("Unrecognized LSPErrorCodes value: " ++ ppJSON j)
+
+data LSPErrorCodes = LSPErrorCodesRequestFailed
+                   | LSPErrorCodesServerCancelled
+                   | LSPErrorCodesContentModified
+                   | LSPErrorCodesRequestCancelled
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/LSPObject.curry
+++ b/src/LSP/Protocol/Types/LSPObject.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LSPObject where
+
+import Data.Map
+import LSP.Protocol.Support
+
+type LSPObject = Map String LSPAny
+

--- a/src/LSP/Protocol/Types/LanguageKind.curry
+++ b/src/LSP/Protocol/Types/LanguageKind.curry
@@ -1,0 +1,138 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LanguageKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LanguageKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "abap" -> Right LanguageKindABAP
+         "bat" -> Right LanguageKindWindowsBat
+         "bibtex" -> Right LanguageKindBibTeX
+         "clojure" -> Right LanguageKindClojure
+         "coffeescript" -> Right LanguageKindCoffeescript
+         "c" -> Right LanguageKindC
+         "cpp" -> Right LanguageKindCPP
+         "csharp" -> Right LanguageKindCSharp
+         "css" -> Right LanguageKindCSS
+         "d" -> Right LanguageKindD
+         "pascal" -> Right LanguageKindDelphi
+         "diff" -> Right LanguageKindDiff
+         "dart" -> Right LanguageKindDart
+         "dockerfile" -> Right LanguageKindDockerfile
+         "elixir" -> Right LanguageKindElixir
+         "erlang" -> Right LanguageKindErlang
+         "fsharp" -> Right LanguageKindFSharp
+         "git-commit" -> Right LanguageKindGitCommit
+         "rebase" -> Right LanguageKindGitRebase
+         "go" -> Right LanguageKindGo
+         "groovy" -> Right LanguageKindGroovy
+         "handlebars" -> Right LanguageKindHandlebars
+         "haskell" -> Right LanguageKindHaskell
+         "html" -> Right LanguageKindHTML
+         "ini" -> Right LanguageKindIni
+         "java" -> Right LanguageKindJava
+         "javascript" -> Right LanguageKindJavaScript
+         "javascriptreact" -> Right LanguageKindJavaScriptReact
+         "json" -> Right LanguageKindJSON
+         "latex" -> Right LanguageKindLaTeX
+         "less" -> Right LanguageKindLess
+         "lua" -> Right LanguageKindLua
+         "makefile" -> Right LanguageKindMakefile
+         "markdown" -> Right LanguageKindMarkdown
+         "objective-c" -> Right LanguageKindObjectiveC
+         "objective-cpp" -> Right LanguageKindObjectiveCPP
+         "pascal" -> Right LanguageKindPascal
+         "perl" -> Right LanguageKindPerl
+         "perl6" -> Right LanguageKindPerl6
+         "php" -> Right LanguageKindPHP
+         "powershell" -> Right LanguageKindPowershell
+         "jade" -> Right LanguageKindPug
+         "python" -> Right LanguageKindPython
+         "r" -> Right LanguageKindR
+         "razor" -> Right LanguageKindRazor
+         "ruby" -> Right LanguageKindRuby
+         "rust" -> Right LanguageKindRust
+         "scss" -> Right LanguageKindSCSS
+         "sass" -> Right LanguageKindSASS
+         "scala" -> Right LanguageKindScala
+         "shaderlab" -> Right LanguageKindShaderLab
+         "shellscript" -> Right LanguageKindShellScript
+         "sql" -> Right LanguageKindSQL
+         "swift" -> Right LanguageKindSwift
+         "typescript" -> Right LanguageKindTypeScript
+         "typescriptreact" -> Right LanguageKindTypeScriptReact
+         "tex" -> Right LanguageKindTeX
+         "vb" -> Right LanguageKindVisualBasic
+         "xml" -> Right LanguageKindXML
+         "xsl" -> Right LanguageKindXSL
+         "yaml" -> Right LanguageKindYAML
+         _ -> Left ("Unrecognized LanguageKind value: " ++ ppJSON j)
+
+data LanguageKind = LanguageKindABAP
+                  | LanguageKindWindowsBat
+                  | LanguageKindBibTeX
+                  | LanguageKindClojure
+                  | LanguageKindCoffeescript
+                  | LanguageKindC
+                  | LanguageKindCPP
+                  | LanguageKindCSharp
+                  | LanguageKindCSS
+                  | LanguageKindD
+                  | LanguageKindDelphi
+                  | LanguageKindDiff
+                  | LanguageKindDart
+                  | LanguageKindDockerfile
+                  | LanguageKindElixir
+                  | LanguageKindErlang
+                  | LanguageKindFSharp
+                  | LanguageKindGitCommit
+                  | LanguageKindGitRebase
+                  | LanguageKindGo
+                  | LanguageKindGroovy
+                  | LanguageKindHandlebars
+                  | LanguageKindHaskell
+                  | LanguageKindHTML
+                  | LanguageKindIni
+                  | LanguageKindJava
+                  | LanguageKindJavaScript
+                  | LanguageKindJavaScriptReact
+                  | LanguageKindJSON
+                  | LanguageKindLaTeX
+                  | LanguageKindLess
+                  | LanguageKindLua
+                  | LanguageKindMakefile
+                  | LanguageKindMarkdown
+                  | LanguageKindObjectiveC
+                  | LanguageKindObjectiveCPP
+                  | LanguageKindPascal
+                  | LanguageKindPerl
+                  | LanguageKindPerl6
+                  | LanguageKindPHP
+                  | LanguageKindPowershell
+                  | LanguageKindPug
+                  | LanguageKindPython
+                  | LanguageKindR
+                  | LanguageKindRazor
+                  | LanguageKindRuby
+                  | LanguageKindRust
+                  | LanguageKindSCSS
+                  | LanguageKindSASS
+                  | LanguageKindScala
+                  | LanguageKindShaderLab
+                  | LanguageKindShellScript
+                  | LanguageKindSQL
+                  | LanguageKindSwift
+                  | LanguageKindTypeScript
+                  | LanguageKindTypeScriptReact
+                  | LanguageKindTeX
+                  | LanguageKindVisualBasic
+                  | LanguageKindXML
+                  | LanguageKindXSL
+                  | LanguageKindYAML
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/LinkedEditingRangeClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LinkedEditingRangeClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LinkedEditingRangeClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            LinkedEditingRangeClientCapabilities { linkedEditingRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized LinkedEditingRangeClientCapabilities value: "
+           ++ ppJSON j)
+
+data LinkedEditingRangeClientCapabilities = LinkedEditingRangeClientCapabilities { linkedEditingRangeClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LinkedEditingRangeOptions.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LinkedEditingRangeOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LinkedEditingRangeOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return LinkedEditingRangeOptions {  }
+      _ -> Left ("Unrecognized LinkedEditingRangeOptions value: " ++ ppJSON j)
+
+data LinkedEditingRangeOptions = LinkedEditingRangeOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LinkedEditingRangeParams.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LinkedEditingRangeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LinkedEditingRangeParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return LinkedEditingRangeParams {  }
+      _ -> Left ("Unrecognized LinkedEditingRangeParams value: " ++ ppJSON j)
+
+data LinkedEditingRangeParams = LinkedEditingRangeParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LinkedEditingRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LinkedEditingRangeRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LinkedEditingRangeRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return LinkedEditingRangeRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized LinkedEditingRangeRegistrationOptions value: "
+           ++ ppJSON j)
+
+data LinkedEditingRangeRegistrationOptions = LinkedEditingRangeRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LinkedEditingRanges.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRanges.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LinkedEditingRanges where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON LinkedEditingRanges where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRanges <- lookupFromJSON "ranges" vs
+           parsedWordPattern <- lookupMaybeFromJSON "wordPattern" vs
+           return
+            LinkedEditingRanges { linkedEditingRangesRanges = parsedRanges
+                                , linkedEditingRangesWordPattern = parsedWordPattern }
+      _ -> Left ("Unrecognized LinkedEditingRanges value: " ++ ppJSON j)
+
+data LinkedEditingRanges = LinkedEditingRanges { linkedEditingRangesRanges :: [Range]
+                                               , linkedEditingRangesWordPattern :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Location.curry
+++ b/src/LSP/Protocol/Types/Location.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Location where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON Location where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedRange <- lookupFromJSON "range" vs
+           return
+            Location { locationUri = parsedUri, locationRange = parsedRange }
+      _ -> Left ("Unrecognized Location value: " ++ ppJSON j)
+
+data Location = Location { locationUri :: DocumentUri
+                         , locationRange :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LocationLink.curry
+++ b/src/LSP/Protocol/Types/LocationLink.curry
@@ -1,0 +1,34 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LocationLink where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON LocationLink where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedOriginSelectionRange <- lookupMaybeFromJSON
+                                          "originSelectionRange"
+                                          vs
+           parsedTargetUri <- lookupFromJSON "targetUri" vs
+           parsedTargetRange <- lookupFromJSON "targetRange" vs
+           parsedTargetSelectionRange <- lookupFromJSON "targetSelectionRange"
+                                          vs
+           return
+            LocationLink { locationLinkOriginSelectionRange = parsedOriginSelectionRange
+                         , locationLinkTargetUri = parsedTargetUri
+                         , locationLinkTargetRange = parsedTargetRange
+                         , locationLinkTargetSelectionRange = parsedTargetSelectionRange }
+      _ -> Left ("Unrecognized LocationLink value: " ++ ppJSON j)
+
+data LocationLink = LocationLink { locationLinkOriginSelectionRange :: Maybe Range
+                                 , locationLinkTargetUri :: DocumentUri
+                                 , locationLinkTargetRange :: Range
+                                 , locationLinkTargetSelectionRange :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LocationUriOnly.curry
+++ b/src/LSP/Protocol/Types/LocationUriOnly.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LocationUriOnly where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON LocationUriOnly where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           return LocationUriOnly { locationUriOnlyUri = parsedUri }
+      _ -> Left ("Unrecognized LocationUriOnly value: " ++ ppJSON j)
+
+data LocationUriOnly = LocationUriOnly { locationUriOnlyUri :: DocumentUri }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LogMessageParams.curry
+++ b/src/LSP/Protocol/Types/LogMessageParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LogMessageParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MessageType
+import LSP.Utils.JSON
+
+instance FromJSON LogMessageParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedType <- lookupFromJSON "type" vs
+           parsedMessage <- lookupFromJSON "message" vs
+           return
+            LogMessageParams { logMessageParamsType = parsedType
+                             , logMessageParamsMessage = parsedMessage }
+      _ -> Left ("Unrecognized LogMessageParams value: " ++ ppJSON j)
+
+data LogMessageParams = LogMessageParams { logMessageParamsType :: MessageType
+                                         , logMessageParamsMessage :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/LogTraceParams.curry
+++ b/src/LSP/Protocol/Types/LogTraceParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.LogTraceParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON LogTraceParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedMessage <- lookupFromJSON "message" vs
+           parsedVerbose <- lookupMaybeFromJSON "verbose" vs
+           return
+            LogTraceParams { logTraceParamsMessage = parsedMessage
+                           , logTraceParamsVerbose = parsedVerbose }
+      _ -> Left ("Unrecognized LogTraceParams value: " ++ ppJSON j)
+
+data LogTraceParams = LogTraceParams { logTraceParamsMessage :: String
+                                     , logTraceParamsVerbose :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MarkdownClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/MarkdownClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MarkdownClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MarkdownClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedParser <- lookupFromJSON "parser" vs
+           parsedVersion <- lookupMaybeFromJSON "version" vs
+           parsedAllowedTags <- lookupMaybeFromJSON "allowedTags" vs
+           return
+            MarkdownClientCapabilities { markdownClientCapabilitiesParser = parsedParser
+                                       , markdownClientCapabilitiesVersion = parsedVersion
+                                       , markdownClientCapabilitiesAllowedTags = parsedAllowedTags }
+      _ ->
+        Left ("Unrecognized MarkdownClientCapabilities value: " ++ ppJSON j)
+
+data MarkdownClientCapabilities = MarkdownClientCapabilities { markdownClientCapabilitiesParser :: String
+                                                             , markdownClientCapabilitiesVersion :: Maybe String
+                                                             , markdownClientCapabilitiesAllowedTags :: Maybe [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MarkedString.curry
+++ b/src/LSP/Protocol/Types/MarkedString.curry
@@ -1,0 +1,8 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MarkedString where
+
+import LSP.Protocol.Types.MarkedStringWithLanguage
+
+type MarkedString = Either String MarkedStringWithLanguage
+

--- a/src/LSP/Protocol/Types/MarkedStringWithLanguage.curry
+++ b/src/LSP/Protocol/Types/MarkedStringWithLanguage.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MarkedStringWithLanguage where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MarkedStringWithLanguage where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLanguage <- lookupFromJSON "language" vs
+           parsedValue <- lookupFromJSON "value" vs
+           return
+            MarkedStringWithLanguage { markedStringWithLanguageLanguage = parsedLanguage
+                                     , markedStringWithLanguageValue = parsedValue }
+      _ -> Left ("Unrecognized MarkedStringWithLanguage value: " ++ ppJSON j)
+
+data MarkedStringWithLanguage = MarkedStringWithLanguage { markedStringWithLanguageLanguage :: String
+                                                         , markedStringWithLanguageValue :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MarkupContent.curry
+++ b/src/LSP/Protocol/Types/MarkupContent.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MarkupContent where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkupKind
+import LSP.Utils.JSON
+
+instance FromJSON MarkupContent where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedValue <- lookupFromJSON "value" vs
+           return
+            MarkupContent { markupContentKind = parsedKind
+                          , markupContentValue = parsedValue }
+      _ -> Left ("Unrecognized MarkupContent value: " ++ ppJSON j)
+
+data MarkupContent = MarkupContent { markupContentKind :: MarkupKind
+                                   , markupContentValue :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MarkupKind.curry
+++ b/src/LSP/Protocol/Types/MarkupKind.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MarkupKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MarkupKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "plaintext" -> Right MarkupKindPlainText
+         "markdown" -> Right MarkupKindMarkdown
+         _ -> Left ("Unrecognized MarkupKind value: " ++ ppJSON j)
+
+data MarkupKind = MarkupKindPlainText | MarkupKindMarkdown
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/MessageActionItem.curry
+++ b/src/LSP/Protocol/Types/MessageActionItem.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MessageActionItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MessageActionItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTitle <- lookupFromJSON "title" vs
+           return MessageActionItem { messageActionItemTitle = parsedTitle }
+      _ -> Left ("Unrecognized MessageActionItem value: " ++ ppJSON j)
+
+data MessageActionItem = MessageActionItem { messageActionItemTitle :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MessageType.curry
+++ b/src/LSP/Protocol/Types/MessageType.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MessageType where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MessageType where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right MessageTypeError
+         2 -> Right MessageTypeWarning
+         3 -> Right MessageTypeInfo
+         4 -> Right MessageTypeLog
+         5 -> Right MessageTypeDebug
+         _ -> Left ("Unrecognized MessageType value: " ++ ppJSON j)
+
+data MessageType = MessageTypeError
+                 | MessageTypeWarning
+                 | MessageTypeInfo
+                 | MessageTypeLog
+                 | MessageTypeDebug
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/Moniker.curry
+++ b/src/LSP/Protocol/Types/Moniker.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Moniker where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MonikerKind
+import LSP.Protocol.Types.UniquenessLevel
+import LSP.Utils.JSON
+
+instance FromJSON Moniker where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedScheme <- lookupFromJSON "scheme" vs
+           parsedIdentifier <- lookupFromJSON "identifier" vs
+           parsedUnique <- lookupFromJSON "unique" vs
+           parsedKind <- lookupMaybeFromJSON "kind" vs
+           return
+            Moniker { monikerScheme = parsedScheme
+                    , monikerIdentifier = parsedIdentifier
+                    , monikerUnique = parsedUnique
+                    , monikerKind = parsedKind }
+      _ -> Left ("Unrecognized Moniker value: " ++ ppJSON j)
+
+data Moniker = Moniker { monikerScheme :: String
+                       , monikerIdentifier :: String
+                       , monikerUnique :: UniquenessLevel
+                       , monikerKind :: Maybe MonikerKind }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MonikerClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/MonikerClientCapabilities.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MonikerClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MonikerClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            MonikerClientCapabilities { monikerClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ -> Left ("Unrecognized MonikerClientCapabilities value: " ++ ppJSON j)
+
+data MonikerClientCapabilities = MonikerClientCapabilities { monikerClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MonikerKind.curry
+++ b/src/LSP/Protocol/Types/MonikerKind.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MonikerKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MonikerKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "import" -> Right MonikerKindImport
+         "export" -> Right MonikerKindExport
+         "local" -> Right MonikerKindLocal
+         _ -> Left ("Unrecognized MonikerKind value: " ++ ppJSON j)
+
+data MonikerKind = MonikerKindImport | MonikerKindExport | MonikerKindLocal
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/MonikerOptions.curry
+++ b/src/LSP/Protocol/Types/MonikerOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MonikerOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MonikerOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return MonikerOptions {  }
+      _ -> Left ("Unrecognized MonikerOptions value: " ++ ppJSON j)
+
+data MonikerOptions = MonikerOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MonikerParams.curry
+++ b/src/LSP/Protocol/Types/MonikerParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MonikerParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MonikerParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return MonikerParams {  }
+      _ -> Left ("Unrecognized MonikerParams value: " ++ ppJSON j)
+
+data MonikerParams = MonikerParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/MonikerRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/MonikerRegistrationOptions.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.MonikerRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON MonikerRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return MonikerRegistrationOptions {  }
+      _ ->
+        Left ("Unrecognized MonikerRegistrationOptions value: " ++ ppJSON j)
+
+data MonikerRegistrationOptions = MonikerRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookCell.curry
+++ b/src/LSP/Protocol/Types/NotebookCell.curry
@@ -1,0 +1,33 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookCell where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.ExecutionSummary
+import LSP.Protocol.Types.LSPObject
+import LSP.Protocol.Types.NotebookCellKind
+import LSP.Utils.JSON
+
+instance FromJSON NotebookCell where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedDocument <- lookupFromJSON "document" vs
+           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
+           parsedExecutionSummary <- lookupMaybeFromJSON "executionSummary" vs
+           return
+            NotebookCell { notebookCellKind = parsedKind
+                         , notebookCellDocument = parsedDocument
+                         , notebookCellMetadata = parsedMetadata
+                         , notebookCellExecutionSummary = parsedExecutionSummary }
+      _ -> Left ("Unrecognized NotebookCell value: " ++ ppJSON j)
+
+data NotebookCell = NotebookCell { notebookCellKind :: NotebookCellKind
+                                 , notebookCellDocument :: DocumentUri
+                                 , notebookCellMetadata :: Maybe LSPObject
+                                 , notebookCellExecutionSummary :: Maybe ExecutionSummary }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookCellArrayChange.curry
+++ b/src/LSP/Protocol/Types/NotebookCellArrayChange.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookCellArrayChange where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookCell
+import LSP.Utils.JSON
+
+instance FromJSON NotebookCellArrayChange where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStart <- lookupFromJSON "start" vs
+           parsedDeleteCount <- lookupFromJSON "deleteCount" vs
+           parsedCells <- lookupMaybeFromJSON "cells" vs
+           return
+            NotebookCellArrayChange { notebookCellArrayChangeStart = parsedStart
+                                    , notebookCellArrayChangeDeleteCount = parsedDeleteCount
+                                    , notebookCellArrayChangeCells = parsedCells }
+      _ -> Left ("Unrecognized NotebookCellArrayChange value: " ++ ppJSON j)
+
+data NotebookCellArrayChange = NotebookCellArrayChange { notebookCellArrayChangeStart :: Int
+                                                       , notebookCellArrayChangeDeleteCount :: Int
+                                                       , notebookCellArrayChangeCells :: Maybe [NotebookCell] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookCellKind.curry
+++ b/src/LSP/Protocol/Types/NotebookCellKind.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookCellKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON NotebookCellKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right NotebookCellKindMarkup
+         2 -> Right NotebookCellKindCode
+         _ -> Left ("Unrecognized NotebookCellKind value: " ++ ppJSON j)
+
+data NotebookCellKind = NotebookCellKindMarkup | NotebookCellKindCode
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/NotebookCellLanguage.curry
+++ b/src/LSP/Protocol/Types/NotebookCellLanguage.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookCellLanguage where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON NotebookCellLanguage where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLanguage <- lookupFromJSON "language" vs
+           return
+            NotebookCellLanguage { notebookCellLanguageLanguage = parsedLanguage }
+      _ -> Left ("Unrecognized NotebookCellLanguage value: " ++ ppJSON j)
+
+data NotebookCellLanguage = NotebookCellLanguage { notebookCellLanguageLanguage :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookCellTextDocumentFilter.curry
+++ b/src/LSP/Protocol/Types/NotebookCellTextDocumentFilter.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookCellTextDocumentFilter where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentFilter
+import LSP.Utils.JSON
+
+instance FromJSON NotebookCellTextDocumentFilter where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebook <- lookupFromJSON "notebook" vs
+           parsedLanguage <- lookupMaybeFromJSON "language" vs
+           return
+            NotebookCellTextDocumentFilter { notebookCellTextDocumentFilterNotebook = parsedNotebook
+                                           , notebookCellTextDocumentFilterLanguage = parsedLanguage }
+      _ ->
+        Left
+         ("Unrecognized NotebookCellTextDocumentFilter value: " ++ ppJSON j)
+
+data NotebookCellTextDocumentFilter = NotebookCellTextDocumentFilter { notebookCellTextDocumentFilterNotebook :: Either String NotebookDocumentFilter
+                                                                     , notebookCellTextDocumentFilterLanguage :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocument.curry
+++ b/src/LSP/Protocol/Types/NotebookDocument.curry
@@ -1,0 +1,35 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocument where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.LSPObject
+import LSP.Protocol.Types.NotebookCell
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocument where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedNotebookType <- lookupFromJSON "notebookType" vs
+           parsedVersion <- lookupFromJSON "version" vs
+           parsedMetadata <- lookupMaybeFromJSON "metadata" vs
+           parsedCells <- lookupFromJSON "cells" vs
+           return
+            NotebookDocument { notebookDocumentUri = parsedUri
+                             , notebookDocumentNotebookType = parsedNotebookType
+                             , notebookDocumentVersion = parsedVersion
+                             , notebookDocumentMetadata = parsedMetadata
+                             , notebookDocumentCells = parsedCells }
+      _ -> Left ("Unrecognized NotebookDocument value: " ++ ppJSON j)
+
+data NotebookDocument = NotebookDocument { notebookDocumentUri :: Uri
+                                         , notebookDocumentNotebookType :: String
+                                         , notebookDocumentVersion :: Int
+                                         , notebookDocumentMetadata :: Maybe LSPObject
+                                         , notebookDocumentCells :: [NotebookCell] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentCellChangeStructure.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentCellChangeStructure.curry
@@ -1,0 +1,32 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentCellChangeStructure where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookCellArrayChange
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Protocol.Types.TextDocumentItem
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentCellChangeStructure where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedArray <- lookupFromJSON "array" vs
+           parsedDidOpen <- lookupMaybeFromJSON "didOpen" vs
+           parsedDidClose <- lookupMaybeFromJSON "didClose" vs
+           return
+            NotebookDocumentCellChangeStructure { notebookDocumentCellChangeStructureArray = parsedArray
+                                                , notebookDocumentCellChangeStructureDidOpen = parsedDidOpen
+                                                , notebookDocumentCellChangeStructureDidClose = parsedDidClose }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentCellChangeStructure value: "
+           ++ ppJSON j)
+
+data NotebookDocumentCellChangeStructure = NotebookDocumentCellChangeStructure { notebookDocumentCellChangeStructureArray :: NotebookCellArrayChange
+                                                                               , notebookDocumentCellChangeStructureDidOpen :: Maybe [TextDocumentItem]
+                                                                               , notebookDocumentCellChangeStructureDidClose :: Maybe [TextDocumentIdentifier] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentCellChanges.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentCellChanges.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentCellChanges where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookCell
+import LSP.Protocol.Types.NotebookDocumentCellChangeStructure
+import LSP.Protocol.Types.NotebookDocumentCellContentChanges
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentCellChanges where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStructure <- lookupMaybeFromJSON "structure" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           parsedTextContent <- lookupMaybeFromJSON "textContent" vs
+           return
+            NotebookDocumentCellChanges { notebookDocumentCellChangesStructure = parsedStructure
+                                        , notebookDocumentCellChangesData = parsedData
+                                        , notebookDocumentCellChangesTextContent = parsedTextContent }
+      _ ->
+        Left ("Unrecognized NotebookDocumentCellChanges value: " ++ ppJSON j)
+
+data NotebookDocumentCellChanges = NotebookDocumentCellChanges { notebookDocumentCellChangesStructure :: Maybe NotebookDocumentCellChangeStructure
+                                                               , notebookDocumentCellChangesData :: Maybe [NotebookCell]
+                                                               , notebookDocumentCellChangesTextContent :: Maybe [NotebookDocumentCellContentChanges] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentCellContentChanges.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentCellContentChanges.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentCellContentChanges where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentContentChangeEvent
+import LSP.Protocol.Types.VersionedTextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentCellContentChanges where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDocument <- lookupFromJSON "document" vs
+           parsedChanges <- lookupFromJSON "changes" vs
+           return
+            NotebookDocumentCellContentChanges { notebookDocumentCellContentChangesDocument = parsedDocument
+                                               , notebookDocumentCellContentChangesChanges = parsedChanges }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentCellContentChanges value: "
+           ++ ppJSON j)
+
+data NotebookDocumentCellContentChanges = NotebookDocumentCellContentChanges { notebookDocumentCellContentChangesDocument :: VersionedTextDocumentIdentifier
+                                                                             , notebookDocumentCellContentChangesChanges :: [TextDocumentContentChangeEvent] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentChangeEvent.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentChangeEvent.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentChangeEvent where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.LSPObject
+import LSP.Protocol.Types.NotebookDocumentCellChanges
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentChangeEvent where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedMetadata <- lookupMaybeFromJSON "metadata" vs
+           parsedCells <- lookupMaybeFromJSON "cells" vs
+           return
+            NotebookDocumentChangeEvent { notebookDocumentChangeEventMetadata = parsedMetadata
+                                        , notebookDocumentChangeEventCells = parsedCells }
+      _ ->
+        Left ("Unrecognized NotebookDocumentChangeEvent value: " ++ ppJSON j)
+
+data NotebookDocumentChangeEvent = NotebookDocumentChangeEvent { notebookDocumentChangeEventMetadata :: Maybe LSPObject
+                                                               , notebookDocumentChangeEventCells :: Maybe NotebookDocumentCellChanges }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentSyncClientCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSynchronization <- lookupFromJSON "synchronization" vs
+           return
+            NotebookDocumentClientCapabilities { notebookDocumentClientCapabilitiesSynchronization = parsedSynchronization }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentClientCapabilities value: "
+           ++ ppJSON j)
+
+data NotebookDocumentClientCapabilities = NotebookDocumentClientCapabilities { notebookDocumentClientCapabilitiesSynchronization :: NotebookDocumentSyncClientCapabilities }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilter.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilter.curry
@@ -1,0 +1,10 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilter where
+
+import LSP.Protocol.Types.NotebookDocumentFilterNotebookType
+import LSP.Protocol.Types.NotebookDocumentFilterPattern
+import LSP.Protocol.Types.NotebookDocumentFilterScheme
+
+type NotebookDocumentFilter = Either (Either NotebookDocumentFilterNotebookType NotebookDocumentFilterScheme) NotebookDocumentFilterPattern
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilterNotebookType.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilterNotebookType.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilterNotebookType where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentFilterNotebookType where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookType <- lookupFromJSON "notebookType" vs
+           parsedScheme <- lookupMaybeFromJSON "scheme" vs
+           parsedPattern <- lookupMaybeFromJSON "pattern" vs
+           return
+            NotebookDocumentFilterNotebookType { notebookDocumentFilterNotebookTypeNotebookType = parsedNotebookType
+                                               , notebookDocumentFilterNotebookTypeScheme = parsedScheme
+                                               , notebookDocumentFilterNotebookTypePattern = parsedPattern }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentFilterNotebookType value: "
+           ++ ppJSON j)
+
+data NotebookDocumentFilterNotebookType = NotebookDocumentFilterNotebookType { notebookDocumentFilterNotebookTypeNotebookType :: String
+                                                                             , notebookDocumentFilterNotebookTypeScheme :: Maybe String
+                                                                             , notebookDocumentFilterNotebookTypePattern :: Maybe GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilterPattern.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilterPattern.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilterPattern where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentFilterPattern where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookType <- lookupMaybeFromJSON "notebookType" vs
+           parsedScheme <- lookupMaybeFromJSON "scheme" vs
+           parsedPattern <- lookupFromJSON "pattern" vs
+           return
+            NotebookDocumentFilterPattern { notebookDocumentFilterPatternNotebookType = parsedNotebookType
+                                          , notebookDocumentFilterPatternScheme = parsedScheme
+                                          , notebookDocumentFilterPatternPattern = parsedPattern }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentFilterPattern value: " ++ ppJSON j)
+
+data NotebookDocumentFilterPattern = NotebookDocumentFilterPattern { notebookDocumentFilterPatternNotebookType :: Maybe String
+                                                                   , notebookDocumentFilterPatternScheme :: Maybe String
+                                                                   , notebookDocumentFilterPatternPattern :: GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilterScheme.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilterScheme.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilterScheme where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentFilterScheme where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookType <- lookupMaybeFromJSON "notebookType" vs
+           parsedScheme <- lookupFromJSON "scheme" vs
+           parsedPattern <- lookupMaybeFromJSON "pattern" vs
+           return
+            NotebookDocumentFilterScheme { notebookDocumentFilterSchemeNotebookType = parsedNotebookType
+                                         , notebookDocumentFilterSchemeScheme = parsedScheme
+                                         , notebookDocumentFilterSchemePattern = parsedPattern }
+      _ ->
+        Left ("Unrecognized NotebookDocumentFilterScheme value: " ++ ppJSON j)
+
+data NotebookDocumentFilterScheme = NotebookDocumentFilterScheme { notebookDocumentFilterSchemeNotebookType :: Maybe String
+                                                                 , notebookDocumentFilterSchemeScheme :: String
+                                                                 , notebookDocumentFilterSchemePattern :: Maybe GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilterWithCells.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilterWithCells.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilterWithCells where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookCellLanguage
+import LSP.Protocol.Types.NotebookDocumentFilter
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentFilterWithCells where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebook <- lookupMaybeFromJSON "notebook" vs
+           parsedCells <- lookupFromJSON "cells" vs
+           return
+            NotebookDocumentFilterWithCells { notebookDocumentFilterWithCellsNotebook = parsedNotebook
+                                            , notebookDocumentFilterWithCellsCells = parsedCells }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentFilterWithCells value: " ++ ppJSON j)
+
+data NotebookDocumentFilterWithCells = NotebookDocumentFilterWithCells { notebookDocumentFilterWithCellsNotebook :: Maybe (Either String NotebookDocumentFilter)
+                                                                       , notebookDocumentFilterWithCellsCells :: [NotebookCellLanguage] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentFilterWithNotebook.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentFilterWithNotebook.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentFilterWithNotebook where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookCellLanguage
+import LSP.Protocol.Types.NotebookDocumentFilter
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentFilterWithNotebook where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebook <- lookupFromJSON "notebook" vs
+           parsedCells <- lookupMaybeFromJSON "cells" vs
+           return
+            NotebookDocumentFilterWithNotebook { notebookDocumentFilterWithNotebookNotebook = parsedNotebook
+                                               , notebookDocumentFilterWithNotebookCells = parsedCells }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentFilterWithNotebook value: "
+           ++ ppJSON j)
+
+data NotebookDocumentFilterWithNotebook = NotebookDocumentFilterWithNotebook { notebookDocumentFilterWithNotebookNotebook :: Either String NotebookDocumentFilter
+                                                                             , notebookDocumentFilterWithNotebookCells :: Maybe [NotebookCellLanguage] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentIdentifier.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentIdentifier where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentIdentifier where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           return
+            NotebookDocumentIdentifier { notebookDocumentIdentifierUri = parsedUri }
+      _ ->
+        Left ("Unrecognized NotebookDocumentIdentifier value: " ++ ppJSON j)
+
+data NotebookDocumentIdentifier = NotebookDocumentIdentifier { notebookDocumentIdentifierUri :: Uri }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentSyncClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentSyncClientCapabilities.curry
@@ -1,0 +1,30 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentSyncClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentSyncClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedExecutionSummarySupport <- lookupMaybeFromJSON
+                                             "executionSummarySupport"
+                                             vs
+           return
+            NotebookDocumentSyncClientCapabilities { notebookDocumentSyncClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                                   , notebookDocumentSyncClientCapabilitiesExecutionSummarySupport = parsedExecutionSummarySupport }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentSyncClientCapabilities value: "
+           ++ ppJSON j)
+
+data NotebookDocumentSyncClientCapabilities = NotebookDocumentSyncClientCapabilities { notebookDocumentSyncClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                                     , notebookDocumentSyncClientCapabilitiesExecutionSummarySupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentSyncOptions.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentSyncOptions.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentSyncOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentFilterWithCells
+import LSP.Protocol.Types.NotebookDocumentFilterWithNotebook
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentSyncOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedNotebookSelector <- lookupFromJSON "notebookSelector" vs
+           parsedSave <- lookupMaybeFromJSON "save" vs
+           return
+            NotebookDocumentSyncOptions { notebookDocumentSyncOptionsNotebookSelector = parsedNotebookSelector
+                                        , notebookDocumentSyncOptionsSave = parsedSave }
+      _ ->
+        Left ("Unrecognized NotebookDocumentSyncOptions value: " ++ ppJSON j)
+
+data NotebookDocumentSyncOptions = NotebookDocumentSyncOptions { notebookDocumentSyncOptionsNotebookSelector :: [Either NotebookDocumentFilterWithNotebook NotebookDocumentFilterWithCells]
+                                                               , notebookDocumentSyncOptionsSave :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/NotebookDocumentSyncRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentSyncRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.NotebookDocumentSyncRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON NotebookDocumentSyncRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return NotebookDocumentSyncRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized NotebookDocumentSyncRegistrationOptions value: "
+           ++ ppJSON j)
+
+data NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/OptionalVersionedTextDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/OptionalVersionedTextDocumentIdentifier.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.OptionalVersionedTextDocumentIdentifier where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON OptionalVersionedTextDocumentIdentifier where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedVersion <- lookupFromJSON "version" vs
+           return
+            OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion = parsedVersion }
+      _ ->
+        Left
+         ("Unrecognized OptionalVersionedTextDocumentIdentifier value: "
+           ++ ppJSON j)
+
+data OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion :: Either Int () }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ParameterInformation.curry
+++ b/src/LSP/Protocol/Types/ParameterInformation.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ParameterInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkupContent
+import LSP.Utils.JSON
+
+instance FromJSON ParameterInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupFromJSON "label" vs
+           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
+           return
+            ParameterInformation { parameterInformationLabel = parsedLabel
+                                 , parameterInformationDocumentation = parsedDocumentation }
+      _ -> Left ("Unrecognized ParameterInformation value: " ++ ppJSON j)
+
+data ParameterInformation = ParameterInformation { parameterInformationLabel :: Either String (Int
+                                                                                              ,Int)
+                                                 , parameterInformationDocumentation :: Maybe (Either String MarkupContent) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PartialResultParams.curry
+++ b/src/LSP/Protocol/Types/PartialResultParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PartialResultParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
+import LSP.Utils.JSON
+
+instance FromJSON PartialResultParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            PartialResultParams { partialResultParamsPartialResultToken = parsedPartialResultToken }
+      _ -> Left ("Unrecognized PartialResultParams value: " ++ ppJSON j)
+
+data PartialResultParams = PartialResultParams { partialResultParamsPartialResultToken :: Maybe ProgressToken }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Pattern.curry
+++ b/src/LSP/Protocol/Types/Pattern.curry
@@ -1,0 +1,6 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Pattern where
+
+type Pattern = String
+

--- a/src/LSP/Protocol/Types/Position.curry
+++ b/src/LSP/Protocol/Types/Position.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Position where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON Position where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLine <- lookupFromJSON "line" vs
+           parsedCharacter <- lookupFromJSON "character" vs
+           return
+            Position { positionLine = parsedLine
+                     , positionCharacter = parsedCharacter }
+      _ -> Left ("Unrecognized Position value: " ++ ppJSON j)
+
+data Position = Position { positionLine :: Int, positionCharacter :: Int }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PositionEncodingKind.curry
+++ b/src/LSP/Protocol/Types/PositionEncodingKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PositionEncodingKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON PositionEncodingKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "utf-8" -> Right PositionEncodingKindUTF8
+         "utf-16" -> Right PositionEncodingKindUTF16
+         "utf-32" -> Right PositionEncodingKindUTF32
+         _ -> Left ("Unrecognized PositionEncodingKind value: " ++ ppJSON j)
+
+data PositionEncodingKind = PositionEncodingKindUTF8
+                          | PositionEncodingKindUTF16
+                          | PositionEncodingKindUTF32
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/PrepareRenameDefaultBehavior.curry
+++ b/src/LSP/Protocol/Types/PrepareRenameDefaultBehavior.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PrepareRenameDefaultBehavior where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON PrepareRenameDefaultBehavior where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDefaultBehavior <- lookupFromJSON "defaultBehavior" vs
+           return
+            PrepareRenameDefaultBehavior { prepareRenameDefaultBehaviorDefaultBehavior = parsedDefaultBehavior }
+      _ ->
+        Left ("Unrecognized PrepareRenameDefaultBehavior value: " ++ ppJSON j)
+
+data PrepareRenameDefaultBehavior = PrepareRenameDefaultBehavior { prepareRenameDefaultBehaviorDefaultBehavior :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PrepareRenameParams.curry
+++ b/src/LSP/Protocol/Types/PrepareRenameParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PrepareRenameParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON PrepareRenameParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return PrepareRenameParams {  }
+      _ -> Left ("Unrecognized PrepareRenameParams value: " ++ ppJSON j)
+
+data PrepareRenameParams = PrepareRenameParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PrepareRenamePlaceholder.curry
+++ b/src/LSP/Protocol/Types/PrepareRenamePlaceholder.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PrepareRenamePlaceholder where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON PrepareRenamePlaceholder where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedPlaceholder <- lookupFromJSON "placeholder" vs
+           return
+            PrepareRenamePlaceholder { prepareRenamePlaceholderRange = parsedRange
+                                     , prepareRenamePlaceholderPlaceholder = parsedPlaceholder }
+      _ -> Left ("Unrecognized PrepareRenamePlaceholder value: " ++ ppJSON j)
+
+data PrepareRenamePlaceholder = PrepareRenamePlaceholder { prepareRenamePlaceholderRange :: Range
+                                                         , prepareRenamePlaceholderPlaceholder :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PrepareRenameResult.curry
+++ b/src/LSP/Protocol/Types/PrepareRenameResult.curry
@@ -1,0 +1,10 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PrepareRenameResult where
+
+import LSP.Protocol.Types.PrepareRenameDefaultBehavior
+import LSP.Protocol.Types.PrepareRenamePlaceholder
+import LSP.Protocol.Types.Range
+
+type PrepareRenameResult = Either (Either Range PrepareRenamePlaceholder) PrepareRenameDefaultBehavior
+

--- a/src/LSP/Protocol/Types/PrepareSupportDefaultBehavior.curry
+++ b/src/LSP/Protocol/Types/PrepareSupportDefaultBehavior.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PrepareSupportDefaultBehavior where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON PrepareSupportDefaultBehavior where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right PrepareSupportDefaultBehaviorIdentifier
+         _ ->
+           Left
+            ("Unrecognized PrepareSupportDefaultBehavior value: " ++ ppJSON j)
+
+data PrepareSupportDefaultBehavior = PrepareSupportDefaultBehaviorIdentifier
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/PreviousResultId.curry
+++ b/src/LSP/Protocol/Types/PreviousResultId.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PreviousResultId where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON PreviousResultId where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedValue <- lookupFromJSON "value" vs
+           return
+            PreviousResultId { previousResultIdUri = parsedUri
+                             , previousResultIdValue = parsedValue }
+      _ -> Left ("Unrecognized PreviousResultId value: " ++ ppJSON j)
+
+data PreviousResultId = PreviousResultId { previousResultIdUri :: DocumentUri
+                                         , previousResultIdValue :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ProgressParams.curry
+++ b/src/LSP/Protocol/Types/ProgressParams.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ProgressParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.ProgressToken
+import LSP.Utils.JSON
+
+instance FromJSON ProgressParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedToken <- lookupFromJSON "token" vs
+           parsedValue <- lookupFromJSON "value" vs
+           return
+            ProgressParams { progressParamsToken = parsedToken
+                           , progressParamsValue = parsedValue }
+      _ -> Left ("Unrecognized ProgressParams value: " ++ ppJSON j)
+
+data ProgressParams = ProgressParams { progressParamsToken :: ProgressToken
+                                     , progressParamsValue :: LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ProgressToken.curry
+++ b/src/LSP/Protocol/Types/ProgressToken.curry
@@ -1,0 +1,6 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ProgressToken where
+
+type ProgressToken = Either Int String
+

--- a/src/LSP/Protocol/Types/PublishDiagnosticsClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/PublishDiagnosticsClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PublishDiagnosticsClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON PublishDiagnosticsClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedVersionSupport <- lookupMaybeFromJSON "versionSupport" vs
+           return
+            PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport = parsedVersionSupport }
+      _ ->
+        Left
+         ("Unrecognized PublishDiagnosticsClientCapabilities value: "
+           ++ ppJSON j)
+
+data PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/PublishDiagnosticsParams.curry
+++ b/src/LSP/Protocol/Types/PublishDiagnosticsParams.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.PublishDiagnosticsParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Diagnostic
+import LSP.Utils.JSON
+
+instance FromJSON PublishDiagnosticsParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedVersion <- lookupMaybeFromJSON "version" vs
+           parsedDiagnostics <- lookupFromJSON "diagnostics" vs
+           return
+            PublishDiagnosticsParams { publishDiagnosticsParamsUri = parsedUri
+                                     , publishDiagnosticsParamsVersion = parsedVersion
+                                     , publishDiagnosticsParamsDiagnostics = parsedDiagnostics }
+      _ -> Left ("Unrecognized PublishDiagnosticsParams value: " ++ ppJSON j)
+
+data PublishDiagnosticsParams = PublishDiagnosticsParams { publishDiagnosticsParamsUri :: DocumentUri
+                                                         , publishDiagnosticsParamsVersion :: Maybe Int
+                                                         , publishDiagnosticsParamsDiagnostics :: [Diagnostic] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Range.curry
+++ b/src/LSP/Protocol/Types/Range.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Range where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Utils.JSON
+
+instance FromJSON Range where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStart <- lookupFromJSON "start" vs
+           parsedEnd <- lookupFromJSON "end" vs
+           return Range { rangeStart = parsedStart, rangeEnd = parsedEnd }
+      _ -> Left ("Unrecognized Range value: " ++ ppJSON j)
+
+data Range = Range { rangeStart :: Position, rangeEnd :: Position }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ReferenceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ReferenceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ReferenceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ReferenceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            ReferenceClientCapabilities { referenceClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left ("Unrecognized ReferenceClientCapabilities value: " ++ ppJSON j)
+
+data ReferenceClientCapabilities = ReferenceClientCapabilities { referenceClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ReferenceContext.curry
+++ b/src/LSP/Protocol/Types/ReferenceContext.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ReferenceContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ReferenceContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIncludeDeclaration <- lookupFromJSON "includeDeclaration" vs
+           return
+            ReferenceContext { referenceContextIncludeDeclaration = parsedIncludeDeclaration }
+      _ -> Left ("Unrecognized ReferenceContext value: " ++ ppJSON j)
+
+data ReferenceContext = ReferenceContext { referenceContextIncludeDeclaration :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ReferenceOptions.curry
+++ b/src/LSP/Protocol/Types/ReferenceOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ReferenceOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ReferenceOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ReferenceOptions {  }
+      _ -> Left ("Unrecognized ReferenceOptions value: " ++ ppJSON j)
+
+data ReferenceOptions = ReferenceOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ReferenceParams.curry
+++ b/src/LSP/Protocol/Types/ReferenceParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ReferenceParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ReferenceContext
+import LSP.Utils.JSON
+
+instance FromJSON ReferenceParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedContext <- lookupFromJSON "context" vs
+           return ReferenceParams { referenceParamsContext = parsedContext }
+      _ -> Left ("Unrecognized ReferenceParams value: " ++ ppJSON j)
+
+data ReferenceParams = ReferenceParams { referenceParamsContext :: ReferenceContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ReferenceRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ReferenceRegistrationOptions.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ReferenceRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ReferenceRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return ReferenceRegistrationOptions {  }
+      _ ->
+        Left ("Unrecognized ReferenceRegistrationOptions value: " ++ ppJSON j)
+
+data ReferenceRegistrationOptions = ReferenceRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/Registration.curry
+++ b/src/LSP/Protocol/Types/Registration.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Registration where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON Registration where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedId <- lookupFromJSON "id" vs
+           parsedMethod <- lookupFromJSON "method" vs
+           parsedRegisterOptions <- lookupMaybeFromJSON "registerOptions" vs
+           return
+            Registration { registrationId = parsedId
+                         , registrationMethod = parsedMethod
+                         , registrationRegisterOptions = parsedRegisterOptions }
+      _ -> Left ("Unrecognized Registration value: " ++ ppJSON j)
+
+data Registration = Registration { registrationId :: String
+                                 , registrationMethod :: String
+                                 , registrationRegisterOptions :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RegistrationParams.curry
+++ b/src/LSP/Protocol/Types/RegistrationParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RegistrationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Registration
+import LSP.Utils.JSON
+
+instance FromJSON RegistrationParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRegistrations <- lookupFromJSON "registrations" vs
+           return
+            RegistrationParams { registrationParamsRegistrations = parsedRegistrations }
+      _ -> Left ("Unrecognized RegistrationParams value: " ++ ppJSON j)
+
+data RegistrationParams = RegistrationParams { registrationParamsRegistrations :: [Registration] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RegularExpressionEngineKind.curry
+++ b/src/LSP/Protocol/Types/RegularExpressionEngineKind.curry
@@ -1,0 +1,6 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RegularExpressionEngineKind where
+
+type RegularExpressionEngineKind = String
+

--- a/src/LSP/Protocol/Types/RegularExpressionsClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/RegularExpressionsClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RegularExpressionsClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.RegularExpressionEngineKind
+import LSP.Utils.JSON
+
+instance FromJSON RegularExpressionsClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedEngine <- lookupFromJSON "engine" vs
+           parsedVersion <- lookupMaybeFromJSON "version" vs
+           return
+            RegularExpressionsClientCapabilities { regularExpressionsClientCapabilitiesEngine = parsedEngine
+                                                 , regularExpressionsClientCapabilitiesVersion = parsedVersion }
+      _ ->
+        Left
+         ("Unrecognized RegularExpressionsClientCapabilities value: "
+           ++ ppJSON j)
+
+data RegularExpressionsClientCapabilities = RegularExpressionsClientCapabilities { regularExpressionsClientCapabilitiesEngine :: RegularExpressionEngineKind
+                                                                                 , regularExpressionsClientCapabilitiesVersion :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RelatedFullDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/RelatedFullDocumentDiagnosticReport.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RelatedFullDocumentDiagnosticReport where
+
+import Data.Map
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.FullDocumentDiagnosticReport
+import LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
+import LSP.Utils.JSON
+
+instance FromJSON RelatedFullDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
+           return
+            RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
+      _ ->
+        Left
+         ("Unrecognized RelatedFullDocumentDiagnosticReport value: "
+           ++ ppJSON j)
+
+data RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RelatedUnchangedDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/RelatedUnchangedDocumentDiagnosticReport.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RelatedUnchangedDocumentDiagnosticReport where
+
+import Data.Map
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.FullDocumentDiagnosticReport
+import LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
+import LSP.Utils.JSON
+
+instance FromJSON RelatedUnchangedDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
+           return
+            RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
+      _ ->
+        Left
+         ("Unrecognized RelatedUnchangedDocumentDiagnosticReport value: "
+           ++ ppJSON j)
+
+data RelatedUnchangedDocumentDiagnosticReport = RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RelativePattern.curry
+++ b/src/LSP/Protocol/Types/RelativePattern.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RelativePattern where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Pattern
+import LSP.Protocol.Types.WorkspaceFolder
+import LSP.Utils.JSON
+
+instance FromJSON RelativePattern where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedBaseUri <- lookupFromJSON "baseUri" vs
+           parsedPattern <- lookupFromJSON "pattern" vs
+           return
+            RelativePattern { relativePatternBaseUri = parsedBaseUri
+                            , relativePatternPattern = parsedPattern }
+      _ -> Left ("Unrecognized RelativePattern value: " ++ ppJSON j)
+
+data RelativePattern = RelativePattern { relativePatternBaseUri :: Either WorkspaceFolder Uri
+                                       , relativePatternPattern :: Pattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/RenameClientCapabilities.curry
@@ -1,0 +1,36 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.PrepareSupportDefaultBehavior
+import LSP.Utils.JSON
+
+instance FromJSON RenameClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedPrepareSupport <- lookupMaybeFromJSON "prepareSupport" vs
+           parsedPrepareSupportDefaultBehavior <- lookupMaybeFromJSON
+                                                   "prepareSupportDefaultBehavior"
+                                                   vs
+           parsedHonorsChangeAnnotations <- lookupMaybeFromJSON
+                                             "honorsChangeAnnotations"
+                                             vs
+           return
+            RenameClientCapabilities { renameClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                     , renameClientCapabilitiesPrepareSupport = parsedPrepareSupport
+                                     , renameClientCapabilitiesPrepareSupportDefaultBehavior = parsedPrepareSupportDefaultBehavior
+                                     , renameClientCapabilitiesHonorsChangeAnnotations = parsedHonorsChangeAnnotations }
+      _ -> Left ("Unrecognized RenameClientCapabilities value: " ++ ppJSON j)
+
+data RenameClientCapabilities = RenameClientCapabilities { renameClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                         , renameClientCapabilitiesPrepareSupport :: Maybe Bool
+                                                         , renameClientCapabilitiesPrepareSupportDefaultBehavior :: Maybe PrepareSupportDefaultBehavior
+                                                         , renameClientCapabilitiesHonorsChangeAnnotations :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameFile.curry
+++ b/src/LSP/Protocol/Types/RenameFile.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameFile where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.RenameFileOptions
+import LSP.Utils.JSON
+
+instance FromJSON RenameFile where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedOldUri <- lookupFromJSON "oldUri" vs
+           parsedNewUri <- lookupFromJSON "newUri" vs
+           parsedOptions <- lookupMaybeFromJSON "options" vs
+           return
+            RenameFile { renameFileKind = parsedKind
+                       , renameFileOldUri = parsedOldUri
+                       , renameFileNewUri = parsedNewUri
+                       , renameFileOptions = parsedOptions }
+      _ -> Left ("Unrecognized RenameFile value: " ++ ppJSON j)
+
+data RenameFile = RenameFile { renameFileKind :: String
+                             , renameFileOldUri :: DocumentUri
+                             , renameFileNewUri :: DocumentUri
+                             , renameFileOptions :: Maybe RenameFileOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameFileOptions.curry
+++ b/src/LSP/Protocol/Types/RenameFileOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameFileOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON RenameFileOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedOverwrite <- lookupMaybeFromJSON "overwrite" vs
+           parsedIgnoreIfExists <- lookupMaybeFromJSON "ignoreIfExists" vs
+           return
+            RenameFileOptions { renameFileOptionsOverwrite = parsedOverwrite
+                              , renameFileOptionsIgnoreIfExists = parsedIgnoreIfExists }
+      _ -> Left ("Unrecognized RenameFileOptions value: " ++ ppJSON j)
+
+data RenameFileOptions = RenameFileOptions { renameFileOptionsOverwrite :: Maybe Bool
+                                           , renameFileOptionsIgnoreIfExists :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameFilesParams.curry
+++ b/src/LSP/Protocol/Types/RenameFilesParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameFilesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileRename
+import LSP.Utils.JSON
+
+instance FromJSON RenameFilesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedFiles <- lookupFromJSON "files" vs
+           return RenameFilesParams { renameFilesParamsFiles = parsedFiles }
+      _ -> Left ("Unrecognized RenameFilesParams value: " ++ ppJSON j)
+
+data RenameFilesParams = RenameFilesParams { renameFilesParamsFiles :: [FileRename] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameOptions.curry
+++ b/src/LSP/Protocol/Types/RenameOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON RenameOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedPrepareProvider <- lookupMaybeFromJSON "prepareProvider" vs
+           return
+            RenameOptions { renameOptionsPrepareProvider = parsedPrepareProvider }
+      _ -> Left ("Unrecognized RenameOptions value: " ++ ppJSON j)
+
+data RenameOptions = RenameOptions { renameOptionsPrepareProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameParams.curry
+++ b/src/LSP/Protocol/Types/RenameParams.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON RenameParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedNewName <- lookupFromJSON "newName" vs
+           return
+            RenameParams { renameParamsTextDocument = parsedTextDocument
+                         , renameParamsPosition = parsedPosition
+                         , renameParamsNewName = parsedNewName }
+      _ -> Left ("Unrecognized RenameParams value: " ++ ppJSON j)
+
+data RenameParams = RenameParams { renameParamsTextDocument :: TextDocumentIdentifier
+                                 , renameParamsPosition :: Position
+                                 , renameParamsNewName :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/RenameRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/RenameRegistrationOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.RenameRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON RenameRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return RenameRegistrationOptions {  }
+      _ -> Left ("Unrecognized RenameRegistrationOptions value: " ++ ppJSON j)
+
+data RenameRegistrationOptions = RenameRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ResourceOperation.curry
+++ b/src/LSP/Protocol/Types/ResourceOperation.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ResourceOperation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON ResourceOperation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
+           return
+            ResourceOperation { resourceOperationKind = parsedKind
+                              , resourceOperationAnnotationId = parsedAnnotationId }
+      _ -> Left ("Unrecognized ResourceOperation value: " ++ ppJSON j)
+
+data ResourceOperation = ResourceOperation { resourceOperationKind :: String
+                                           , resourceOperationAnnotationId :: Maybe ChangeAnnotationIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ResourceOperationKind.curry
+++ b/src/LSP/Protocol/Types/ResourceOperationKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ResourceOperationKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ResourceOperationKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "create" -> Right ResourceOperationKindCreate
+         "rename" -> Right ResourceOperationKindRename
+         "delete" -> Right ResourceOperationKindDelete
+         _ -> Left ("Unrecognized ResourceOperationKind value: " ++ ppJSON j)
+
+data ResourceOperationKind = ResourceOperationKindCreate
+                           | ResourceOperationKindRename
+                           | ResourceOperationKindDelete
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/SaveOptions.curry
+++ b/src/LSP/Protocol/Types/SaveOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SaveOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SaveOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIncludeText <- lookupMaybeFromJSON "includeText" vs
+           return SaveOptions { saveOptionsIncludeText = parsedIncludeText }
+      _ -> Left ("Unrecognized SaveOptions value: " ++ ppJSON j)
+
+data SaveOptions = SaveOptions { saveOptionsIncludeText :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectedCompletionInfo.curry
+++ b/src/LSP/Protocol/Types/SelectedCompletionInfo.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectedCompletionInfo where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON SelectedCompletionInfo where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedText <- lookupFromJSON "text" vs
+           return
+            SelectedCompletionInfo { selectedCompletionInfoRange = parsedRange
+                                   , selectedCompletionInfoText = parsedText }
+      _ -> Left ("Unrecognized SelectedCompletionInfo value: " ++ ppJSON j)
+
+data SelectedCompletionInfo = SelectedCompletionInfo { selectedCompletionInfoRange :: Range
+                                                     , selectedCompletionInfoText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectionRange.curry
+++ b/src/LSP/Protocol/Types/SelectionRange.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectionRange where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON SelectionRange where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedParent <- lookupMaybeFromJSON "parent" vs
+           return
+            SelectionRange { selectionRangeRange = parsedRange
+                           , selectionRangeParent = parsedParent }
+      _ -> Left ("Unrecognized SelectionRange value: " ++ ppJSON j)
+
+data SelectionRange = SelectionRange { selectionRangeRange :: Range
+                                     , selectionRangeParent :: Maybe SelectionRange }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectionRangeClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectionRangeClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SelectionRangeClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            SelectionRangeClientCapabilities { selectionRangeClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized SelectionRangeClientCapabilities value: " ++ ppJSON j)
+
+data SelectionRangeClientCapabilities = SelectionRangeClientCapabilities { selectionRangeClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectionRangeOptions.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectionRangeOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SelectionRangeOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return SelectionRangeOptions {  }
+      _ -> Left ("Unrecognized SelectionRangeOptions value: " ++ ppJSON j)
+
+data SelectionRangeOptions = SelectionRangeOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectionRangeParams.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeParams.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectionRangeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON SelectionRangeParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPositions <- lookupFromJSON "positions" vs
+           return
+            SelectionRangeParams { selectionRangeParamsTextDocument = parsedTextDocument
+                                 , selectionRangeParamsPositions = parsedPositions }
+      _ -> Left ("Unrecognized SelectionRangeParams value: " ++ ppJSON j)
+
+data SelectionRangeParams = SelectionRangeParams { selectionRangeParamsTextDocument :: TextDocumentIdentifier
+                                                 , selectionRangeParamsPositions :: [Position] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SelectionRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SelectionRangeRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SelectionRangeRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return SelectionRangeRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized SelectionRangeRegistrationOptions value: "
+           ++ ppJSON j)
+
+data SelectionRangeRegistrationOptions = SelectionRangeRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokenModifiers.curry
+++ b/src/LSP/Protocol/Types/SemanticTokenModifiers.curry
@@ -1,0 +1,36 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokenModifiers where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokenModifiers where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "declaration" -> Right SemanticTokenModifiersDeclaration
+         "definition" -> Right SemanticTokenModifiersDefinition
+         "readonly" -> Right SemanticTokenModifiersReadonly
+         "static" -> Right SemanticTokenModifiersStatic
+         "deprecated" -> Right SemanticTokenModifiersDeprecated
+         "abstract" -> Right SemanticTokenModifiersAbstract
+         "async" -> Right SemanticTokenModifiersAsync
+         "modification" -> Right SemanticTokenModifiersModification
+         "documentation" -> Right SemanticTokenModifiersDocumentation
+         "defaultLibrary" -> Right SemanticTokenModifiersDefaultLibrary
+         _ -> Left ("Unrecognized SemanticTokenModifiers value: " ++ ppJSON j)
+
+data SemanticTokenModifiers = SemanticTokenModifiersDeclaration
+                            | SemanticTokenModifiersDefinition
+                            | SemanticTokenModifiersReadonly
+                            | SemanticTokenModifiersStatic
+                            | SemanticTokenModifiersDeprecated
+                            | SemanticTokenModifiersAbstract
+                            | SemanticTokenModifiersAsync
+                            | SemanticTokenModifiersModification
+                            | SemanticTokenModifiersDocumentation
+                            | SemanticTokenModifiersDefaultLibrary
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/SemanticTokenTypes.curry
+++ b/src/LSP/Protocol/Types/SemanticTokenTypes.curry
@@ -1,0 +1,64 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokenTypes where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokenTypes where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "namespace" -> Right SemanticTokenTypesNamespace
+         "type" -> Right SemanticTokenTypesType
+         "class" -> Right SemanticTokenTypesClass
+         "enum" -> Right SemanticTokenTypesEnum
+         "interface" -> Right SemanticTokenTypesInterface
+         "struct" -> Right SemanticTokenTypesStruct
+         "typeParameter" -> Right SemanticTokenTypesTypeParameter
+         "parameter" -> Right SemanticTokenTypesParameter
+         "variable" -> Right SemanticTokenTypesVariable
+         "property" -> Right SemanticTokenTypesProperty
+         "enumMember" -> Right SemanticTokenTypesEnumMember
+         "event" -> Right SemanticTokenTypesEvent
+         "function" -> Right SemanticTokenTypesFunction
+         "method" -> Right SemanticTokenTypesMethod
+         "macro" -> Right SemanticTokenTypesMacro
+         "keyword" -> Right SemanticTokenTypesKeyword
+         "modifier" -> Right SemanticTokenTypesModifier
+         "comment" -> Right SemanticTokenTypesComment
+         "string" -> Right SemanticTokenTypesString
+         "number" -> Right SemanticTokenTypesNumber
+         "regexp" -> Right SemanticTokenTypesRegexp
+         "operator" -> Right SemanticTokenTypesOperator
+         "decorator" -> Right SemanticTokenTypesDecorator
+         "label" -> Right SemanticTokenTypesLabel
+         _ -> Left ("Unrecognized SemanticTokenTypes value: " ++ ppJSON j)
+
+data SemanticTokenTypes = SemanticTokenTypesNamespace
+                        | SemanticTokenTypesType
+                        | SemanticTokenTypesClass
+                        | SemanticTokenTypesEnum
+                        | SemanticTokenTypesInterface
+                        | SemanticTokenTypesStruct
+                        | SemanticTokenTypesTypeParameter
+                        | SemanticTokenTypesParameter
+                        | SemanticTokenTypesVariable
+                        | SemanticTokenTypesProperty
+                        | SemanticTokenTypesEnumMember
+                        | SemanticTokenTypesEvent
+                        | SemanticTokenTypesFunction
+                        | SemanticTokenTypesMethod
+                        | SemanticTokenTypesMacro
+                        | SemanticTokenTypesKeyword
+                        | SemanticTokenTypesModifier
+                        | SemanticTokenTypesComment
+                        | SemanticTokenTypesString
+                        | SemanticTokenTypesNumber
+                        | SemanticTokenTypesRegexp
+                        | SemanticTokenTypesOperator
+                        | SemanticTokenTypesDecorator
+                        | SemanticTokenTypesLabel
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/SemanticTokens.curry
+++ b/src/LSP/Protocol/Types/SemanticTokens.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokens where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokens where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResultId <- lookupMaybeFromJSON "resultId" vs
+           parsedData <- lookupFromJSON "data" vs
+           return
+            SemanticTokens { semanticTokensResultId = parsedResultId
+                           , semanticTokensData = parsedData }
+      _ -> Left ("Unrecognized SemanticTokens value: " ++ ppJSON j)
+
+data SemanticTokens = SemanticTokens { semanticTokensResultId :: Maybe String
+                                     , semanticTokensData :: [Int] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensClientCapabilities.curry
@@ -1,0 +1,58 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSemanticTokensRequestOptions
+import LSP.Protocol.Types.TokenFormat
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedRequests <- lookupFromJSON "requests" vs
+           parsedTokenTypes <- lookupFromJSON "tokenTypes" vs
+           parsedTokenModifiers <- lookupFromJSON "tokenModifiers" vs
+           parsedFormats <- lookupFromJSON "formats" vs
+           parsedOverlappingTokenSupport <- lookupMaybeFromJSON
+                                             "overlappingTokenSupport"
+                                             vs
+           parsedMultilineTokenSupport <- lookupMaybeFromJSON
+                                           "multilineTokenSupport"
+                                           vs
+           parsedServerCancelSupport <- lookupMaybeFromJSON
+                                         "serverCancelSupport"
+                                         vs
+           parsedAugmentsSyntaxTokens <- lookupMaybeFromJSON
+                                          "augmentsSyntaxTokens"
+                                          vs
+           return
+            SemanticTokensClientCapabilities { semanticTokensClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                             , semanticTokensClientCapabilitiesRequests = parsedRequests
+                                             , semanticTokensClientCapabilitiesTokenTypes = parsedTokenTypes
+                                             , semanticTokensClientCapabilitiesTokenModifiers = parsedTokenModifiers
+                                             , semanticTokensClientCapabilitiesFormats = parsedFormats
+                                             , semanticTokensClientCapabilitiesOverlappingTokenSupport = parsedOverlappingTokenSupport
+                                             , semanticTokensClientCapabilitiesMultilineTokenSupport = parsedMultilineTokenSupport
+                                             , semanticTokensClientCapabilitiesServerCancelSupport = parsedServerCancelSupport
+                                             , semanticTokensClientCapabilitiesAugmentsSyntaxTokens = parsedAugmentsSyntaxTokens }
+      _ ->
+        Left
+         ("Unrecognized SemanticTokensClientCapabilities value: " ++ ppJSON j)
+
+data SemanticTokensClientCapabilities = SemanticTokensClientCapabilities { semanticTokensClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                         , semanticTokensClientCapabilitiesRequests :: ClientSemanticTokensRequestOptions
+                                                                         , semanticTokensClientCapabilitiesTokenTypes :: [String]
+                                                                         , semanticTokensClientCapabilitiesTokenModifiers :: [String]
+                                                                         , semanticTokensClientCapabilitiesFormats :: [TokenFormat]
+                                                                         , semanticTokensClientCapabilitiesOverlappingTokenSupport :: Maybe Bool
+                                                                         , semanticTokensClientCapabilitiesMultilineTokenSupport :: Maybe Bool
+                                                                         , semanticTokensClientCapabilitiesServerCancelSupport :: Maybe Bool
+                                                                         , semanticTokensClientCapabilitiesAugmentsSyntaxTokens :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensDelta.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensDelta.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensDelta where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SemanticTokensEdit
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensDelta where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResultId <- lookupMaybeFromJSON "resultId" vs
+           parsedEdits <- lookupFromJSON "edits" vs
+           return
+            SemanticTokensDelta { semanticTokensDeltaResultId = parsedResultId
+                                , semanticTokensDeltaEdits = parsedEdits }
+      _ -> Left ("Unrecognized SemanticTokensDelta value: " ++ ppJSON j)
+
+data SemanticTokensDelta = SemanticTokensDelta { semanticTokensDeltaResultId :: Maybe String
+                                               , semanticTokensDeltaEdits :: [SemanticTokensEdit] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensDeltaParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensDeltaParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensDeltaParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensDeltaParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPreviousResultId <- lookupFromJSON "previousResultId" vs
+           return
+            SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument = parsedTextDocument
+                                      , semanticTokensDeltaParamsPreviousResultId = parsedPreviousResultId }
+      _ -> Left ("Unrecognized SemanticTokensDeltaParams value: " ++ ppJSON j)
+
+data SemanticTokensDeltaParams = SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument :: TextDocumentIdentifier
+                                                           , semanticTokensDeltaParamsPreviousResultId :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensDeltaPartialResult.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensDeltaPartialResult.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensDeltaPartialResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SemanticTokensEdit
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensDeltaPartialResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedEdits <- lookupFromJSON "edits" vs
+           return
+            SemanticTokensDeltaPartialResult { semanticTokensDeltaPartialResultEdits = parsedEdits }
+      _ ->
+        Left
+         ("Unrecognized SemanticTokensDeltaPartialResult value: " ++ ppJSON j)
+
+data SemanticTokensDeltaPartialResult = SemanticTokensDeltaPartialResult { semanticTokensDeltaPartialResultEdits :: [SemanticTokensEdit] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensEdit.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensEdit.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedStart <- lookupFromJSON "start" vs
+           parsedDeleteCount <- lookupFromJSON "deleteCount" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            SemanticTokensEdit { semanticTokensEditStart = parsedStart
+                               , semanticTokensEditDeleteCount = parsedDeleteCount
+                               , semanticTokensEditData = parsedData }
+      _ -> Left ("Unrecognized SemanticTokensEdit value: " ++ ppJSON j)
+
+data SemanticTokensEdit = SemanticTokensEdit { semanticTokensEditStart :: Int
+                                             , semanticTokensEditDeleteCount :: Int
+                                             , semanticTokensEditData :: Maybe [Int] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensFullDelta.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensFullDelta.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensFullDelta where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensFullDelta where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDelta <- lookupMaybeFromJSON "delta" vs
+           return
+            SemanticTokensFullDelta { semanticTokensFullDeltaDelta = parsedDelta }
+      _ -> Left ("Unrecognized SemanticTokensFullDelta value: " ++ ppJSON j)
+
+data SemanticTokensFullDelta = SemanticTokensFullDelta { semanticTokensFullDeltaDelta :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensLegend.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensLegend.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensLegend where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensLegend where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTokenTypes <- lookupFromJSON "tokenTypes" vs
+           parsedTokenModifiers <- lookupFromJSON "tokenModifiers" vs
+           return
+            SemanticTokensLegend { semanticTokensLegendTokenTypes = parsedTokenTypes
+                                 , semanticTokensLegendTokenModifiers = parsedTokenModifiers }
+      _ -> Left ("Unrecognized SemanticTokensLegend value: " ++ ppJSON j)
+
+data SemanticTokensLegend = SemanticTokensLegend { semanticTokensLegendTokenTypes :: [String]
+                                                 , semanticTokensLegendTokenModifiers :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensOptions.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensOptions.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SemanticTokensFullDelta
+import LSP.Protocol.Types.SemanticTokensLegend
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLegend <- lookupFromJSON "legend" vs
+           parsedRange <- lookupMaybeFromJSON "range" vs
+           parsedFull <- lookupMaybeFromJSON "full" vs
+           return
+            SemanticTokensOptions { semanticTokensOptionsLegend = parsedLegend
+                                  , semanticTokensOptionsRange = parsedRange
+                                  , semanticTokensOptionsFull = parsedFull }
+      _ -> Left ("Unrecognized SemanticTokensOptions value: " ++ ppJSON j)
+
+data SemanticTokensOptions = SemanticTokensOptions { semanticTokensOptionsLegend :: SemanticTokensLegend
+                                                   , semanticTokensOptionsRange :: Maybe (Either Bool ())
+                                                   , semanticTokensOptionsFull :: Maybe (Either Bool SemanticTokensFullDelta) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           return
+            SemanticTokensParams { semanticTokensParamsTextDocument = parsedTextDocument }
+      _ -> Left ("Unrecognized SemanticTokensParams value: " ++ ppJSON j)
+
+data SemanticTokensParams = SemanticTokensParams { semanticTokensParamsTextDocument :: TextDocumentIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensPartialResult.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensPartialResult.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensPartialResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensPartialResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedData <- lookupFromJSON "data" vs
+           return
+            SemanticTokensPartialResult { semanticTokensPartialResultData = parsedData }
+      _ ->
+        Left ("Unrecognized SemanticTokensPartialResult value: " ++ ppJSON j)
+
+data SemanticTokensPartialResult = SemanticTokensPartialResult { semanticTokensPartialResultData :: [Int] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensRangeParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensRangeParams.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensRangeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensRangeParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedRange <- lookupFromJSON "range" vs
+           return
+            SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument = parsedTextDocument
+                                      , semanticTokensRangeParamsRange = parsedRange }
+      _ -> Left ("Unrecognized SemanticTokensRangeParams value: " ++ ppJSON j)
+
+data SemanticTokensRangeParams = SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument :: TextDocumentIdentifier
+                                                           , semanticTokensRangeParamsRange :: Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return SemanticTokensRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized SemanticTokensRegistrationOptions value: "
+           ++ ppJSON j)
+
+data SemanticTokensRegistrationOptions = SemanticTokensRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SemanticTokensWorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensWorkspaceClientCapabilities.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SemanticTokensWorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SemanticTokensWorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRefreshSupport <- lookupMaybeFromJSON "refreshSupport" vs
+           return
+            SemanticTokensWorkspaceClientCapabilities { semanticTokensWorkspaceClientCapabilitiesRefreshSupport = parsedRefreshSupport }
+      _ ->
+        Left
+         ("Unrecognized SemanticTokensWorkspaceClientCapabilities value: "
+           ++ ppJSON j)
+
+data SemanticTokensWorkspaceClientCapabilities = SemanticTokensWorkspaceClientCapabilities { semanticTokensWorkspaceClientCapabilitiesRefreshSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ServerCapabilities.curry
+++ b/src/LSP/Protocol/Types/ServerCapabilities.curry
@@ -1,0 +1,230 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ServerCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.CallHierarchyOptions
+import LSP.Protocol.Types.CallHierarchyRegistrationOptions
+import LSP.Protocol.Types.CodeActionOptions
+import LSP.Protocol.Types.CodeLensOptions
+import LSP.Protocol.Types.CompletionOptions
+import LSP.Protocol.Types.DeclarationOptions
+import LSP.Protocol.Types.DeclarationRegistrationOptions
+import LSP.Protocol.Types.DefinitionOptions
+import LSP.Protocol.Types.DiagnosticOptions
+import LSP.Protocol.Types.DiagnosticRegistrationOptions
+import LSP.Protocol.Types.DocumentColorOptions
+import LSP.Protocol.Types.DocumentColorRegistrationOptions
+import LSP.Protocol.Types.DocumentFormattingOptions
+import LSP.Protocol.Types.DocumentHighlightOptions
+import LSP.Protocol.Types.DocumentLinkOptions
+import LSP.Protocol.Types.DocumentOnTypeFormattingOptions
+import LSP.Protocol.Types.DocumentRangeFormattingOptions
+import LSP.Protocol.Types.DocumentSymbolOptions
+import LSP.Protocol.Types.ExecuteCommandOptions
+import LSP.Protocol.Types.FoldingRangeOptions
+import LSP.Protocol.Types.FoldingRangeRegistrationOptions
+import LSP.Protocol.Types.HoverOptions
+import LSP.Protocol.Types.ImplementationOptions
+import LSP.Protocol.Types.ImplementationRegistrationOptions
+import LSP.Protocol.Types.InlayHintOptions
+import LSP.Protocol.Types.InlayHintRegistrationOptions
+import LSP.Protocol.Types.InlineCompletionOptions
+import LSP.Protocol.Types.InlineValueOptions
+import LSP.Protocol.Types.InlineValueRegistrationOptions
+import LSP.Protocol.Types.LinkedEditingRangeOptions
+import LSP.Protocol.Types.LinkedEditingRangeRegistrationOptions
+import LSP.Protocol.Types.MonikerOptions
+import LSP.Protocol.Types.MonikerRegistrationOptions
+import LSP.Protocol.Types.NotebookDocumentSyncOptions
+import LSP.Protocol.Types.NotebookDocumentSyncRegistrationOptions
+import LSP.Protocol.Types.PositionEncodingKind
+import LSP.Protocol.Types.ReferenceOptions
+import LSP.Protocol.Types.RenameOptions
+import LSP.Protocol.Types.SelectionRangeOptions
+import LSP.Protocol.Types.SelectionRangeRegistrationOptions
+import LSP.Protocol.Types.SemanticTokensOptions
+import LSP.Protocol.Types.SemanticTokensRegistrationOptions
+import LSP.Protocol.Types.SignatureHelpOptions
+import LSP.Protocol.Types.TextDocumentSyncKind
+import LSP.Protocol.Types.TextDocumentSyncOptions
+import LSP.Protocol.Types.TypeDefinitionOptions
+import LSP.Protocol.Types.TypeDefinitionRegistrationOptions
+import LSP.Protocol.Types.TypeHierarchyOptions
+import LSP.Protocol.Types.TypeHierarchyRegistrationOptions
+import LSP.Protocol.Types.WorkspaceOptions
+import LSP.Protocol.Types.WorkspaceSymbolOptions
+import LSP.Utils.JSON
+
+instance FromJSON ServerCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedPositionEncoding <- lookupMaybeFromJSON "positionEncoding" vs
+           parsedTextDocumentSync <- lookupMaybeFromJSON "textDocumentSync" vs
+           parsedNotebookDocumentSync <- lookupMaybeFromJSON
+                                          "notebookDocumentSync"
+                                          vs
+           parsedCompletionProvider <- lookupMaybeFromJSON
+                                        "completionProvider"
+                                        vs
+           parsedHoverProvider <- lookupMaybeFromJSON "hoverProvider" vs
+           parsedSignatureHelpProvider <- lookupMaybeFromJSON
+                                           "signatureHelpProvider"
+                                           vs
+           parsedDeclarationProvider <- lookupMaybeFromJSON
+                                         "declarationProvider"
+                                         vs
+           parsedDefinitionProvider <- lookupMaybeFromJSON
+                                        "definitionProvider"
+                                        vs
+           parsedTypeDefinitionProvider <- lookupMaybeFromJSON
+                                            "typeDefinitionProvider"
+                                            vs
+           parsedImplementationProvider <- lookupMaybeFromJSON
+                                            "implementationProvider"
+                                            vs
+           parsedReferencesProvider <- lookupMaybeFromJSON
+                                        "referencesProvider"
+                                        vs
+           parsedDocumentHighlightProvider <- lookupMaybeFromJSON
+                                               "documentHighlightProvider"
+                                               vs
+           parsedDocumentSymbolProvider <- lookupMaybeFromJSON
+                                            "documentSymbolProvider"
+                                            vs
+           parsedCodeActionProvider <- lookupMaybeFromJSON
+                                        "codeActionProvider"
+                                        vs
+           parsedCodeLensProvider <- lookupMaybeFromJSON "codeLensProvider" vs
+           parsedDocumentLinkProvider <- lookupMaybeFromJSON
+                                          "documentLinkProvider"
+                                          vs
+           parsedColorProvider <- lookupMaybeFromJSON "colorProvider" vs
+           parsedWorkspaceSymbolProvider <- lookupMaybeFromJSON
+                                             "workspaceSymbolProvider"
+                                             vs
+           parsedDocumentFormattingProvider <- lookupMaybeFromJSON
+                                                "documentFormattingProvider"
+                                                vs
+           parsedDocumentRangeFormattingProvider <- lookupMaybeFromJSON
+                                                     "documentRangeFormattingProvider"
+                                                     vs
+           parsedDocumentOnTypeFormattingProvider <- lookupMaybeFromJSON
+                                                      "documentOnTypeFormattingProvider"
+                                                      vs
+           parsedRenameProvider <- lookupMaybeFromJSON "renameProvider" vs
+           parsedFoldingRangeProvider <- lookupMaybeFromJSON
+                                          "foldingRangeProvider"
+                                          vs
+           parsedSelectionRangeProvider <- lookupMaybeFromJSON
+                                            "selectionRangeProvider"
+                                            vs
+           parsedExecuteCommandProvider <- lookupMaybeFromJSON
+                                            "executeCommandProvider"
+                                            vs
+           parsedCallHierarchyProvider <- lookupMaybeFromJSON
+                                           "callHierarchyProvider"
+                                           vs
+           parsedLinkedEditingRangeProvider <- lookupMaybeFromJSON
+                                                "linkedEditingRangeProvider"
+                                                vs
+           parsedSemanticTokensProvider <- lookupMaybeFromJSON
+                                            "semanticTokensProvider"
+                                            vs
+           parsedMonikerProvider <- lookupMaybeFromJSON "monikerProvider" vs
+           parsedTypeHierarchyProvider <- lookupMaybeFromJSON
+                                           "typeHierarchyProvider"
+                                           vs
+           parsedInlineValueProvider <- lookupMaybeFromJSON
+                                         "inlineValueProvider"
+                                         vs
+           parsedInlayHintProvider <- lookupMaybeFromJSON "inlayHintProvider"
+                                       vs
+           parsedDiagnosticProvider <- lookupMaybeFromJSON
+                                        "diagnosticProvider"
+                                        vs
+           parsedInlineCompletionProvider <- lookupMaybeFromJSON
+                                              "inlineCompletionProvider"
+                                              vs
+           parsedWorkspace <- lookupMaybeFromJSON "workspace" vs
+           parsedExperimental <- lookupMaybeFromJSON "experimental" vs
+           return
+            ServerCapabilities { serverCapabilitiesPositionEncoding = parsedPositionEncoding
+                               , serverCapabilitiesTextDocumentSync = parsedTextDocumentSync
+                               , serverCapabilitiesNotebookDocumentSync = parsedNotebookDocumentSync
+                               , serverCapabilitiesCompletionProvider = parsedCompletionProvider
+                               , serverCapabilitiesHoverProvider = parsedHoverProvider
+                               , serverCapabilitiesSignatureHelpProvider = parsedSignatureHelpProvider
+                               , serverCapabilitiesDeclarationProvider = parsedDeclarationProvider
+                               , serverCapabilitiesDefinitionProvider = parsedDefinitionProvider
+                               , serverCapabilitiesTypeDefinitionProvider = parsedTypeDefinitionProvider
+                               , serverCapabilitiesImplementationProvider = parsedImplementationProvider
+                               , serverCapabilitiesReferencesProvider = parsedReferencesProvider
+                               , serverCapabilitiesDocumentHighlightProvider = parsedDocumentHighlightProvider
+                               , serverCapabilitiesDocumentSymbolProvider = parsedDocumentSymbolProvider
+                               , serverCapabilitiesCodeActionProvider = parsedCodeActionProvider
+                               , serverCapabilitiesCodeLensProvider = parsedCodeLensProvider
+                               , serverCapabilitiesDocumentLinkProvider = parsedDocumentLinkProvider
+                               , serverCapabilitiesColorProvider = parsedColorProvider
+                               , serverCapabilitiesWorkspaceSymbolProvider = parsedWorkspaceSymbolProvider
+                               , serverCapabilitiesDocumentFormattingProvider = parsedDocumentFormattingProvider
+                               , serverCapabilitiesDocumentRangeFormattingProvider = parsedDocumentRangeFormattingProvider
+                               , serverCapabilitiesDocumentOnTypeFormattingProvider = parsedDocumentOnTypeFormattingProvider
+                               , serverCapabilitiesRenameProvider = parsedRenameProvider
+                               , serverCapabilitiesFoldingRangeProvider = parsedFoldingRangeProvider
+                               , serverCapabilitiesSelectionRangeProvider = parsedSelectionRangeProvider
+                               , serverCapabilitiesExecuteCommandProvider = parsedExecuteCommandProvider
+                               , serverCapabilitiesCallHierarchyProvider = parsedCallHierarchyProvider
+                               , serverCapabilitiesLinkedEditingRangeProvider = parsedLinkedEditingRangeProvider
+                               , serverCapabilitiesSemanticTokensProvider = parsedSemanticTokensProvider
+                               , serverCapabilitiesMonikerProvider = parsedMonikerProvider
+                               , serverCapabilitiesTypeHierarchyProvider = parsedTypeHierarchyProvider
+                               , serverCapabilitiesInlineValueProvider = parsedInlineValueProvider
+                               , serverCapabilitiesInlayHintProvider = parsedInlayHintProvider
+                               , serverCapabilitiesDiagnosticProvider = parsedDiagnosticProvider
+                               , serverCapabilitiesInlineCompletionProvider = parsedInlineCompletionProvider
+                               , serverCapabilitiesWorkspace = parsedWorkspace
+                               , serverCapabilitiesExperimental = parsedExperimental }
+      _ -> Left ("Unrecognized ServerCapabilities value: " ++ ppJSON j)
+
+data ServerCapabilities = ServerCapabilities { serverCapabilitiesPositionEncoding :: Maybe PositionEncodingKind
+                                             , serverCapabilitiesTextDocumentSync :: Maybe (Either TextDocumentSyncOptions TextDocumentSyncKind)
+                                             , serverCapabilitiesNotebookDocumentSync :: Maybe (Either NotebookDocumentSyncOptions NotebookDocumentSyncRegistrationOptions)
+                                             , serverCapabilitiesCompletionProvider :: Maybe CompletionOptions
+                                             , serverCapabilitiesHoverProvider :: Maybe (Either Bool HoverOptions)
+                                             , serverCapabilitiesSignatureHelpProvider :: Maybe SignatureHelpOptions
+                                             , serverCapabilitiesDeclarationProvider :: Maybe (Either (Either Bool DeclarationOptions) DeclarationRegistrationOptions)
+                                             , serverCapabilitiesDefinitionProvider :: Maybe (Either Bool DefinitionOptions)
+                                             , serverCapabilitiesTypeDefinitionProvider :: Maybe (Either (Either Bool TypeDefinitionOptions) TypeDefinitionRegistrationOptions)
+                                             , serverCapabilitiesImplementationProvider :: Maybe (Either (Either Bool ImplementationOptions) ImplementationRegistrationOptions)
+                                             , serverCapabilitiesReferencesProvider :: Maybe (Either Bool ReferenceOptions)
+                                             , serverCapabilitiesDocumentHighlightProvider :: Maybe (Either Bool DocumentHighlightOptions)
+                                             , serverCapabilitiesDocumentSymbolProvider :: Maybe (Either Bool DocumentSymbolOptions)
+                                             , serverCapabilitiesCodeActionProvider :: Maybe (Either Bool CodeActionOptions)
+                                             , serverCapabilitiesCodeLensProvider :: Maybe CodeLensOptions
+                                             , serverCapabilitiesDocumentLinkProvider :: Maybe DocumentLinkOptions
+                                             , serverCapabilitiesColorProvider :: Maybe (Either (Either Bool DocumentColorOptions) DocumentColorRegistrationOptions)
+                                             , serverCapabilitiesWorkspaceSymbolProvider :: Maybe (Either Bool WorkspaceSymbolOptions)
+                                             , serverCapabilitiesDocumentFormattingProvider :: Maybe (Either Bool DocumentFormattingOptions)
+                                             , serverCapabilitiesDocumentRangeFormattingProvider :: Maybe (Either Bool DocumentRangeFormattingOptions)
+                                             , serverCapabilitiesDocumentOnTypeFormattingProvider :: Maybe DocumentOnTypeFormattingOptions
+                                             , serverCapabilitiesRenameProvider :: Maybe (Either Bool RenameOptions)
+                                             , serverCapabilitiesFoldingRangeProvider :: Maybe (Either (Either Bool FoldingRangeOptions) FoldingRangeRegistrationOptions)
+                                             , serverCapabilitiesSelectionRangeProvider :: Maybe (Either (Either Bool SelectionRangeOptions) SelectionRangeRegistrationOptions)
+                                             , serverCapabilitiesExecuteCommandProvider :: Maybe ExecuteCommandOptions
+                                             , serverCapabilitiesCallHierarchyProvider :: Maybe (Either (Either Bool CallHierarchyOptions) CallHierarchyRegistrationOptions)
+                                             , serverCapabilitiesLinkedEditingRangeProvider :: Maybe (Either (Either Bool LinkedEditingRangeOptions) LinkedEditingRangeRegistrationOptions)
+                                             , serverCapabilitiesSemanticTokensProvider :: Maybe (Either SemanticTokensOptions SemanticTokensRegistrationOptions)
+                                             , serverCapabilitiesMonikerProvider :: Maybe (Either (Either Bool MonikerOptions) MonikerRegistrationOptions)
+                                             , serverCapabilitiesTypeHierarchyProvider :: Maybe (Either (Either Bool TypeHierarchyOptions) TypeHierarchyRegistrationOptions)
+                                             , serverCapabilitiesInlineValueProvider :: Maybe (Either (Either Bool InlineValueOptions) InlineValueRegistrationOptions)
+                                             , serverCapabilitiesInlayHintProvider :: Maybe (Either (Either Bool InlayHintOptions) InlayHintRegistrationOptions)
+                                             , serverCapabilitiesDiagnosticProvider :: Maybe (Either DiagnosticOptions DiagnosticRegistrationOptions)
+                                             , serverCapabilitiesInlineCompletionProvider :: Maybe (Either Bool InlineCompletionOptions)
+                                             , serverCapabilitiesWorkspace :: Maybe WorkspaceOptions
+                                             , serverCapabilitiesExperimental :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ServerCompletionItemOptions.curry
+++ b/src/LSP/Protocol/Types/ServerCompletionItemOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ServerCompletionItemOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ServerCompletionItemOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabelDetailsSupport <- lookupMaybeFromJSON
+                                         "labelDetailsSupport"
+                                         vs
+           return
+            ServerCompletionItemOptions { serverCompletionItemOptionsLabelDetailsSupport = parsedLabelDetailsSupport }
+      _ ->
+        Left ("Unrecognized ServerCompletionItemOptions value: " ++ ppJSON j)
+
+data ServerCompletionItemOptions = ServerCompletionItemOptions { serverCompletionItemOptionsLabelDetailsSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ServerInfo.curry
+++ b/src/LSP/Protocol/Types/ServerInfo.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ServerInfo where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ServerInfo where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedVersion <- lookupMaybeFromJSON "version" vs
+           return
+            ServerInfo { serverInfoName = parsedName
+                       , serverInfoVersion = parsedVersion }
+      _ -> Left ("Unrecognized ServerInfo value: " ++ ppJSON j)
+
+data ServerInfo = ServerInfo { serverInfoName :: String
+                             , serverInfoVersion :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SetTraceParams.curry
+++ b/src/LSP/Protocol/Types/SetTraceParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SetTraceParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TraceValue
+import LSP.Utils.JSON
+
+instance FromJSON SetTraceParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedValue <- lookupFromJSON "value" vs
+           return SetTraceParams { setTraceParamsValue = parsedValue }
+      _ -> Left ("Unrecognized SetTraceParams value: " ++ ppJSON j)
+
+data SetTraceParams = SetTraceParams { setTraceParamsValue :: TraceValue }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowDocumentClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ShowDocumentClientCapabilities.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowDocumentClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ShowDocumentClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSupport <- lookupFromJSON "support" vs
+           return
+            ShowDocumentClientCapabilities { showDocumentClientCapabilitiesSupport = parsedSupport }
+      _ ->
+        Left
+         ("Unrecognized ShowDocumentClientCapabilities value: " ++ ppJSON j)
+
+data ShowDocumentClientCapabilities = ShowDocumentClientCapabilities { showDocumentClientCapabilitiesSupport :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowDocumentParams.curry
+++ b/src/LSP/Protocol/Types/ShowDocumentParams.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON ShowDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedExternal <- lookupMaybeFromJSON "external" vs
+           parsedTakeFocus <- lookupMaybeFromJSON "takeFocus" vs
+           parsedSelection <- lookupMaybeFromJSON "selection" vs
+           return
+            ShowDocumentParams { showDocumentParamsUri = parsedUri
+                               , showDocumentParamsExternal = parsedExternal
+                               , showDocumentParamsTakeFocus = parsedTakeFocus
+                               , showDocumentParamsSelection = parsedSelection }
+      _ -> Left ("Unrecognized ShowDocumentParams value: " ++ ppJSON j)
+
+data ShowDocumentParams = ShowDocumentParams { showDocumentParamsUri :: Uri
+                                             , showDocumentParamsExternal :: Maybe Bool
+                                             , showDocumentParamsTakeFocus :: Maybe Bool
+                                             , showDocumentParamsSelection :: Maybe Range }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowDocumentResult.curry
+++ b/src/LSP/Protocol/Types/ShowDocumentResult.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowDocumentResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON ShowDocumentResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSuccess <- lookupFromJSON "success" vs
+           return
+            ShowDocumentResult { showDocumentResultSuccess = parsedSuccess }
+      _ -> Left ("Unrecognized ShowDocumentResult value: " ++ ppJSON j)
+
+data ShowDocumentResult = ShowDocumentResult { showDocumentResultSuccess :: Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowMessageParams.curry
+++ b/src/LSP/Protocol/Types/ShowMessageParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowMessageParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MessageType
+import LSP.Utils.JSON
+
+instance FromJSON ShowMessageParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedType <- lookupFromJSON "type" vs
+           parsedMessage <- lookupFromJSON "message" vs
+           return
+            ShowMessageParams { showMessageParamsType = parsedType
+                              , showMessageParamsMessage = parsedMessage }
+      _ -> Left ("Unrecognized ShowMessageParams value: " ++ ppJSON j)
+
+data ShowMessageParams = ShowMessageParams { showMessageParamsType :: MessageType
+                                           , showMessageParamsMessage :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowMessageRequestClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/ShowMessageRequestClientCapabilities.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowMessageRequestClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientShowMessageActionItemOptions
+import LSP.Utils.JSON
+
+instance FromJSON ShowMessageRequestClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedMessageActionItem <- lookupMaybeFromJSON "messageActionItem"
+                                       vs
+           return
+            ShowMessageRequestClientCapabilities { showMessageRequestClientCapabilitiesMessageActionItem = parsedMessageActionItem }
+      _ ->
+        Left
+         ("Unrecognized ShowMessageRequestClientCapabilities value: "
+           ++ ppJSON j)
+
+data ShowMessageRequestClientCapabilities = ShowMessageRequestClientCapabilities { showMessageRequestClientCapabilitiesMessageActionItem :: Maybe ClientShowMessageActionItemOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/ShowMessageRequestParams.curry
+++ b/src/LSP/Protocol/Types/ShowMessageRequestParams.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.ShowMessageRequestParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MessageActionItem
+import LSP.Protocol.Types.MessageType
+import LSP.Utils.JSON
+
+instance FromJSON ShowMessageRequestParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedType <- lookupFromJSON "type" vs
+           parsedMessage <- lookupFromJSON "message" vs
+           parsedActions <- lookupMaybeFromJSON "actions" vs
+           return
+            ShowMessageRequestParams { showMessageRequestParamsType = parsedType
+                                     , showMessageRequestParamsMessage = parsedMessage
+                                     , showMessageRequestParamsActions = parsedActions }
+      _ -> Left ("Unrecognized ShowMessageRequestParams value: " ++ ppJSON j)
+
+data ShowMessageRequestParams = ShowMessageRequestParams { showMessageRequestParamsType :: MessageType
+                                                         , showMessageRequestParamsMessage :: String
+                                                         , showMessageRequestParamsActions :: Maybe [MessageActionItem] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelp.curry
+++ b/src/LSP/Protocol/Types/SignatureHelp.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelp where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SignatureInformation
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelp where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSignatures <- lookupFromJSON "signatures" vs
+           parsedActiveSignature <- lookupMaybeFromJSON "activeSignature" vs
+           parsedActiveParameter <- lookupMaybeFromJSON "activeParameter" vs
+           return
+            SignatureHelp { signatureHelpSignatures = parsedSignatures
+                          , signatureHelpActiveSignature = parsedActiveSignature
+                          , signatureHelpActiveParameter = parsedActiveParameter }
+      _ -> Left ("Unrecognized SignatureHelp value: " ++ ppJSON j)
+
+data SignatureHelp = SignatureHelp { signatureHelpSignatures :: [SignatureInformation]
+                                   , signatureHelpActiveSignature :: Maybe Int
+                                   , signatureHelpActiveParameter :: Maybe (Either Int ()) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpClientCapabilities.curry
@@ -1,0 +1,33 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSignatureInformationOptions
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedSignatureInformation <- lookupMaybeFromJSON
+                                          "signatureInformation"
+                                          vs
+           parsedContextSupport <- lookupMaybeFromJSON "contextSupport" vs
+           return
+            SignatureHelpClientCapabilities { signatureHelpClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                            , signatureHelpClientCapabilitiesSignatureInformation = parsedSignatureInformation
+                                            , signatureHelpClientCapabilitiesContextSupport = parsedContextSupport }
+      _ ->
+        Left
+         ("Unrecognized SignatureHelpClientCapabilities value: " ++ ppJSON j)
+
+data SignatureHelpClientCapabilities = SignatureHelpClientCapabilities { signatureHelpClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                       , signatureHelpClientCapabilitiesSignatureInformation :: Maybe ClientSignatureInformationOptions
+                                                                       , signatureHelpClientCapabilitiesContextSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpContext.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpContext.curry
@@ -1,0 +1,33 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpContext where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SignatureHelp
+import LSP.Protocol.Types.SignatureHelpTriggerKind
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpContext where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTriggerKind <- lookupFromJSON "triggerKind" vs
+           parsedTriggerCharacter <- lookupMaybeFromJSON "triggerCharacter" vs
+           parsedIsRetrigger <- lookupFromJSON "isRetrigger" vs
+           parsedActiveSignatureHelp <- lookupMaybeFromJSON
+                                         "activeSignatureHelp"
+                                         vs
+           return
+            SignatureHelpContext { signatureHelpContextTriggerKind = parsedTriggerKind
+                                 , signatureHelpContextTriggerCharacter = parsedTriggerCharacter
+                                 , signatureHelpContextIsRetrigger = parsedIsRetrigger
+                                 , signatureHelpContextActiveSignatureHelp = parsedActiveSignatureHelp }
+      _ -> Left ("Unrecognized SignatureHelpContext value: " ++ ppJSON j)
+
+data SignatureHelpContext = SignatureHelpContext { signatureHelpContextTriggerKind :: SignatureHelpTriggerKind
+                                                 , signatureHelpContextTriggerCharacter :: Maybe String
+                                                 , signatureHelpContextIsRetrigger :: Bool
+                                                 , signatureHelpContextActiveSignatureHelp :: Maybe SignatureHelp }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpOptions.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpOptions.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+                                       vs
+           parsedRetriggerCharacters <- lookupMaybeFromJSON
+                                         "retriggerCharacters"
+                                         vs
+           return
+            SignatureHelpOptions { signatureHelpOptionsTriggerCharacters = parsedTriggerCharacters
+                                 , signatureHelpOptionsRetriggerCharacters = parsedRetriggerCharacters }
+      _ -> Left ("Unrecognized SignatureHelpOptions value: " ++ ppJSON j)
+
+data SignatureHelpOptions = SignatureHelpOptions { signatureHelpOptionsTriggerCharacters :: Maybe [String]
+                                                 , signatureHelpOptionsRetriggerCharacters :: Maybe [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpParams.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SignatureHelpContext
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedContext <- lookupMaybeFromJSON "context" vs
+           return
+            SignatureHelpParams { signatureHelpParamsContext = parsedContext }
+      _ -> Left ("Unrecognized SignatureHelpParams value: " ++ ppJSON j)
+
+data SignatureHelpParams = SignatureHelpParams { signatureHelpParamsContext :: Maybe SignatureHelpContext }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return SignatureHelpRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized SignatureHelpRegistrationOptions value: " ++ ppJSON j)
+
+data SignatureHelpRegistrationOptions = SignatureHelpRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SignatureHelpTriggerKind.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpTriggerKind.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureHelpTriggerKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SignatureHelpTriggerKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right SignatureHelpTriggerKindInvoked
+         2 -> Right SignatureHelpTriggerKindTriggerCharacter
+         3 -> Right SignatureHelpTriggerKindContentChange
+         _ ->
+           Left ("Unrecognized SignatureHelpTriggerKind value: " ++ ppJSON j)
+
+data SignatureHelpTriggerKind = SignatureHelpTriggerKindInvoked
+                              | SignatureHelpTriggerKindTriggerCharacter
+                              | SignatureHelpTriggerKindContentChange
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/SignatureInformation.curry
+++ b/src/LSP/Protocol/Types/SignatureInformation.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SignatureInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.MarkupContent
+import LSP.Protocol.Types.ParameterInformation
+import LSP.Utils.JSON
+
+instance FromJSON SignatureInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLabel <- lookupFromJSON "label" vs
+           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
+           parsedParameters <- lookupMaybeFromJSON "parameters" vs
+           parsedActiveParameter <- lookupMaybeFromJSON "activeParameter" vs
+           return
+            SignatureInformation { signatureInformationLabel = parsedLabel
+                                 , signatureInformationDocumentation = parsedDocumentation
+                                 , signatureInformationParameters = parsedParameters
+                                 , signatureInformationActiveParameter = parsedActiveParameter }
+      _ -> Left ("Unrecognized SignatureInformation value: " ++ ppJSON j)
+
+data SignatureInformation = SignatureInformation { signatureInformationLabel :: String
+                                                 , signatureInformationDocumentation :: Maybe (Either String MarkupContent)
+                                                 , signatureInformationParameters :: Maybe [ParameterInformation]
+                                                 , signatureInformationActiveParameter :: Maybe (Either Int ()) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SnippetTextEdit.curry
+++ b/src/LSP/Protocol/Types/SnippetTextEdit.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SnippetTextEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.StringValue
+import LSP.Utils.JSON
+
+instance FromJSON SnippetTextEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedSnippet <- lookupFromJSON "snippet" vs
+           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
+           return
+            SnippetTextEdit { snippetTextEditRange = parsedRange
+                            , snippetTextEditSnippet = parsedSnippet
+                            , snippetTextEditAnnotationId = parsedAnnotationId }
+      _ -> Left ("Unrecognized SnippetTextEdit value: " ++ ppJSON j)
+
+data SnippetTextEdit = SnippetTextEdit { snippetTextEditRange :: Range
+                                       , snippetTextEditSnippet :: StringValue
+                                       , snippetTextEditAnnotationId :: Maybe ChangeAnnotationIdentifier }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/StaleRequestSupportOptions.curry
+++ b/src/LSP/Protocol/Types/StaleRequestSupportOptions.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.StaleRequestSupportOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON StaleRequestSupportOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedCancel <- lookupFromJSON "cancel" vs
+           parsedRetryOnContentModified <- lookupFromJSON
+                                            "retryOnContentModified"
+                                            vs
+           return
+            StaleRequestSupportOptions { staleRequestSupportOptionsCancel = parsedCancel
+                                       , staleRequestSupportOptionsRetryOnContentModified = parsedRetryOnContentModified }
+      _ ->
+        Left ("Unrecognized StaleRequestSupportOptions value: " ++ ppJSON j)
+
+data StaleRequestSupportOptions = StaleRequestSupportOptions { staleRequestSupportOptionsCancel :: Bool
+                                                             , staleRequestSupportOptionsRetryOnContentModified :: [String] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/StaticRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/StaticRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.StaticRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON StaticRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            StaticRegistrationOptions { staticRegistrationOptionsId = parsedId }
+      _ -> Left ("Unrecognized StaticRegistrationOptions value: " ++ ppJSON j)
+
+data StaticRegistrationOptions = StaticRegistrationOptions { staticRegistrationOptionsId :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/StringValue.curry
+++ b/src/LSP/Protocol/Types/StringValue.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.StringValue where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON StringValue where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedValue <- lookupFromJSON "value" vs
+           return
+            StringValue { stringValueKind = parsedKind
+                        , stringValueValue = parsedValue }
+      _ -> Left ("Unrecognized StringValue value: " ++ ppJSON j)
+
+data StringValue = StringValue { stringValueKind :: String
+                               , stringValueValue :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SymbolInformation.curry
+++ b/src/LSP/Protocol/Types/SymbolInformation.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SymbolInformation where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Location
+import LSP.Utils.JSON
+
+instance FromJSON SymbolInformation where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
+           parsedLocation <- lookupFromJSON "location" vs
+           return
+            SymbolInformation { symbolInformationDeprecated = parsedDeprecated
+                              , symbolInformationLocation = parsedLocation }
+      _ -> Left ("Unrecognized SymbolInformation value: " ++ ppJSON j)
+
+data SymbolInformation = SymbolInformation { symbolInformationDeprecated :: Maybe Bool
+                                           , symbolInformationLocation :: Location }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/SymbolKind.curry
+++ b/src/LSP/Protocol/Types/SymbolKind.curry
@@ -1,0 +1,68 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SymbolKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SymbolKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right SymbolKindFile
+         2 -> Right SymbolKindModule
+         3 -> Right SymbolKindNamespace
+         4 -> Right SymbolKindPackage
+         5 -> Right SymbolKindClass
+         6 -> Right SymbolKindMethod
+         7 -> Right SymbolKindProperty
+         8 -> Right SymbolKindField
+         9 -> Right SymbolKindConstructor
+         10 -> Right SymbolKindEnum
+         11 -> Right SymbolKindInterface
+         12 -> Right SymbolKindFunction
+         13 -> Right SymbolKindVariable
+         14 -> Right SymbolKindConstant
+         15 -> Right SymbolKindString
+         16 -> Right SymbolKindNumber
+         17 -> Right SymbolKindBoolean
+         18 -> Right SymbolKindArray
+         19 -> Right SymbolKindObject
+         20 -> Right SymbolKindKey
+         21 -> Right SymbolKindNull
+         22 -> Right SymbolKindEnumMember
+         23 -> Right SymbolKindStruct
+         24 -> Right SymbolKindEvent
+         25 -> Right SymbolKindOperator
+         26 -> Right SymbolKindTypeParameter
+         _ -> Left ("Unrecognized SymbolKind value: " ++ ppJSON j)
+
+data SymbolKind = SymbolKindFile
+                | SymbolKindModule
+                | SymbolKindNamespace
+                | SymbolKindPackage
+                | SymbolKindClass
+                | SymbolKindMethod
+                | SymbolKindProperty
+                | SymbolKindField
+                | SymbolKindConstructor
+                | SymbolKindEnum
+                | SymbolKindInterface
+                | SymbolKindFunction
+                | SymbolKindVariable
+                | SymbolKindConstant
+                | SymbolKindString
+                | SymbolKindNumber
+                | SymbolKindBoolean
+                | SymbolKindArray
+                | SymbolKindObject
+                | SymbolKindKey
+                | SymbolKindNull
+                | SymbolKindEnumMember
+                | SymbolKindStruct
+                | SymbolKindEvent
+                | SymbolKindOperator
+                | SymbolKindTypeParameter
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/SymbolTag.curry
+++ b/src/LSP/Protocol/Types/SymbolTag.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.SymbolTag where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON SymbolTag where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right SymbolTagDeprecated
+         _ -> Left ("Unrecognized SymbolTag value: " ++ ppJSON j)
+
+data SymbolTag = SymbolTagDeprecated
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/TextDocumentChangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentChangeRegistrationOptions.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentChangeRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentSyncKind
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentChangeRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSyncKind <- lookupFromJSON "syncKind" vs
+           return
+            TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind = parsedSyncKind }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentChangeRegistrationOptions value: "
+           ++ ppJSON j)
+
+data TextDocumentChangeRegistrationOptions = TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind :: TextDocumentSyncKind }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/TextDocumentClientCapabilities.curry
@@ -1,0 +1,148 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CallHierarchyClientCapabilities
+import LSP.Protocol.Types.CodeActionClientCapabilities
+import LSP.Protocol.Types.CodeLensClientCapabilities
+import LSP.Protocol.Types.CompletionClientCapabilities
+import LSP.Protocol.Types.DeclarationClientCapabilities
+import LSP.Protocol.Types.DefinitionClientCapabilities
+import LSP.Protocol.Types.DiagnosticClientCapabilities
+import LSP.Protocol.Types.DocumentColorClientCapabilities
+import LSP.Protocol.Types.DocumentFormattingClientCapabilities
+import LSP.Protocol.Types.DocumentHighlightClientCapabilities
+import LSP.Protocol.Types.DocumentLinkClientCapabilities
+import LSP.Protocol.Types.DocumentOnTypeFormattingClientCapabilities
+import LSP.Protocol.Types.DocumentRangeFormattingClientCapabilities
+import LSP.Protocol.Types.DocumentSymbolClientCapabilities
+import LSP.Protocol.Types.FoldingRangeClientCapabilities
+import LSP.Protocol.Types.HoverClientCapabilities
+import LSP.Protocol.Types.ImplementationClientCapabilities
+import LSP.Protocol.Types.InlayHintClientCapabilities
+import LSP.Protocol.Types.InlineCompletionClientCapabilities
+import LSP.Protocol.Types.InlineValueClientCapabilities
+import LSP.Protocol.Types.LinkedEditingRangeClientCapabilities
+import LSP.Protocol.Types.MonikerClientCapabilities
+import LSP.Protocol.Types.PublishDiagnosticsClientCapabilities
+import LSP.Protocol.Types.ReferenceClientCapabilities
+import LSP.Protocol.Types.RenameClientCapabilities
+import LSP.Protocol.Types.SelectionRangeClientCapabilities
+import LSP.Protocol.Types.SemanticTokensClientCapabilities
+import LSP.Protocol.Types.SignatureHelpClientCapabilities
+import LSP.Protocol.Types.TextDocumentSyncClientCapabilities
+import LSP.Protocol.Types.TypeDefinitionClientCapabilities
+import LSP.Protocol.Types.TypeHierarchyClientCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSynchronization <- lookupMaybeFromJSON "synchronization" vs
+           parsedCompletion <- lookupMaybeFromJSON "completion" vs
+           parsedHover <- lookupMaybeFromJSON "hover" vs
+           parsedSignatureHelp <- lookupMaybeFromJSON "signatureHelp" vs
+           parsedDeclaration <- lookupMaybeFromJSON "declaration" vs
+           parsedDefinition <- lookupMaybeFromJSON "definition" vs
+           parsedTypeDefinition <- lookupMaybeFromJSON "typeDefinition" vs
+           parsedImplementation <- lookupMaybeFromJSON "implementation" vs
+           parsedReferences <- lookupMaybeFromJSON "references" vs
+           parsedDocumentHighlight <- lookupMaybeFromJSON "documentHighlight"
+                                       vs
+           parsedDocumentSymbol <- lookupMaybeFromJSON "documentSymbol" vs
+           parsedCodeAction <- lookupMaybeFromJSON "codeAction" vs
+           parsedCodeLens <- lookupMaybeFromJSON "codeLens" vs
+           parsedDocumentLink <- lookupMaybeFromJSON "documentLink" vs
+           parsedColorProvider <- lookupMaybeFromJSON "colorProvider" vs
+           parsedFormatting <- lookupMaybeFromJSON "formatting" vs
+           parsedRangeFormatting <- lookupMaybeFromJSON "rangeFormatting" vs
+           parsedOnTypeFormatting <- lookupMaybeFromJSON "onTypeFormatting" vs
+           parsedRename <- lookupMaybeFromJSON "rename" vs
+           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
+           parsedSelectionRange <- lookupMaybeFromJSON "selectionRange" vs
+           parsedPublishDiagnostics <- lookupMaybeFromJSON
+                                        "publishDiagnostics"
+                                        vs
+           parsedCallHierarchy <- lookupMaybeFromJSON "callHierarchy" vs
+           parsedSemanticTokens <- lookupMaybeFromJSON "semanticTokens" vs
+           parsedLinkedEditingRange <- lookupMaybeFromJSON
+                                        "linkedEditingRange"
+                                        vs
+           parsedMoniker <- lookupMaybeFromJSON "moniker" vs
+           parsedTypeHierarchy <- lookupMaybeFromJSON "typeHierarchy" vs
+           parsedInlineValue <- lookupMaybeFromJSON "inlineValue" vs
+           parsedInlayHint <- lookupMaybeFromJSON "inlayHint" vs
+           parsedDiagnostic <- lookupMaybeFromJSON "diagnostic" vs
+           parsedInlineCompletion <- lookupMaybeFromJSON "inlineCompletion" vs
+           return
+            TextDocumentClientCapabilities { textDocumentClientCapabilitiesSynchronization = parsedSynchronization
+                                           , textDocumentClientCapabilitiesCompletion = parsedCompletion
+                                           , textDocumentClientCapabilitiesHover = parsedHover
+                                           , textDocumentClientCapabilitiesSignatureHelp = parsedSignatureHelp
+                                           , textDocumentClientCapabilitiesDeclaration = parsedDeclaration
+                                           , textDocumentClientCapabilitiesDefinition = parsedDefinition
+                                           , textDocumentClientCapabilitiesTypeDefinition = parsedTypeDefinition
+                                           , textDocumentClientCapabilitiesImplementation = parsedImplementation
+                                           , textDocumentClientCapabilitiesReferences = parsedReferences
+                                           , textDocumentClientCapabilitiesDocumentHighlight = parsedDocumentHighlight
+                                           , textDocumentClientCapabilitiesDocumentSymbol = parsedDocumentSymbol
+                                           , textDocumentClientCapabilitiesCodeAction = parsedCodeAction
+                                           , textDocumentClientCapabilitiesCodeLens = parsedCodeLens
+                                           , textDocumentClientCapabilitiesDocumentLink = parsedDocumentLink
+                                           , textDocumentClientCapabilitiesColorProvider = parsedColorProvider
+                                           , textDocumentClientCapabilitiesFormatting = parsedFormatting
+                                           , textDocumentClientCapabilitiesRangeFormatting = parsedRangeFormatting
+                                           , textDocumentClientCapabilitiesOnTypeFormatting = parsedOnTypeFormatting
+                                           , textDocumentClientCapabilitiesRename = parsedRename
+                                           , textDocumentClientCapabilitiesFoldingRange = parsedFoldingRange
+                                           , textDocumentClientCapabilitiesSelectionRange = parsedSelectionRange
+                                           , textDocumentClientCapabilitiesPublishDiagnostics = parsedPublishDiagnostics
+                                           , textDocumentClientCapabilitiesCallHierarchy = parsedCallHierarchy
+                                           , textDocumentClientCapabilitiesSemanticTokens = parsedSemanticTokens
+                                           , textDocumentClientCapabilitiesLinkedEditingRange = parsedLinkedEditingRange
+                                           , textDocumentClientCapabilitiesMoniker = parsedMoniker
+                                           , textDocumentClientCapabilitiesTypeHierarchy = parsedTypeHierarchy
+                                           , textDocumentClientCapabilitiesInlineValue = parsedInlineValue
+                                           , textDocumentClientCapabilitiesInlayHint = parsedInlayHint
+                                           , textDocumentClientCapabilitiesDiagnostic = parsedDiagnostic
+                                           , textDocumentClientCapabilitiesInlineCompletion = parsedInlineCompletion }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentClientCapabilities value: " ++ ppJSON j)
+
+data TextDocumentClientCapabilities = TextDocumentClientCapabilities { textDocumentClientCapabilitiesSynchronization :: Maybe TextDocumentSyncClientCapabilities
+                                                                     , textDocumentClientCapabilitiesCompletion :: Maybe CompletionClientCapabilities
+                                                                     , textDocumentClientCapabilitiesHover :: Maybe HoverClientCapabilities
+                                                                     , textDocumentClientCapabilitiesSignatureHelp :: Maybe SignatureHelpClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDeclaration :: Maybe DeclarationClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDefinition :: Maybe DefinitionClientCapabilities
+                                                                     , textDocumentClientCapabilitiesTypeDefinition :: Maybe TypeDefinitionClientCapabilities
+                                                                     , textDocumentClientCapabilitiesImplementation :: Maybe ImplementationClientCapabilities
+                                                                     , textDocumentClientCapabilitiesReferences :: Maybe ReferenceClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDocumentHighlight :: Maybe DocumentHighlightClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDocumentSymbol :: Maybe DocumentSymbolClientCapabilities
+                                                                     , textDocumentClientCapabilitiesCodeAction :: Maybe CodeActionClientCapabilities
+                                                                     , textDocumentClientCapabilitiesCodeLens :: Maybe CodeLensClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDocumentLink :: Maybe DocumentLinkClientCapabilities
+                                                                     , textDocumentClientCapabilitiesColorProvider :: Maybe DocumentColorClientCapabilities
+                                                                     , textDocumentClientCapabilitiesFormatting :: Maybe DocumentFormattingClientCapabilities
+                                                                     , textDocumentClientCapabilitiesRangeFormatting :: Maybe DocumentRangeFormattingClientCapabilities
+                                                                     , textDocumentClientCapabilitiesOnTypeFormatting :: Maybe DocumentOnTypeFormattingClientCapabilities
+                                                                     , textDocumentClientCapabilitiesRename :: Maybe RenameClientCapabilities
+                                                                     , textDocumentClientCapabilitiesFoldingRange :: Maybe FoldingRangeClientCapabilities
+                                                                     , textDocumentClientCapabilitiesSelectionRange :: Maybe SelectionRangeClientCapabilities
+                                                                     , textDocumentClientCapabilitiesPublishDiagnostics :: Maybe PublishDiagnosticsClientCapabilities
+                                                                     , textDocumentClientCapabilitiesCallHierarchy :: Maybe CallHierarchyClientCapabilities
+                                                                     , textDocumentClientCapabilitiesSemanticTokens :: Maybe SemanticTokensClientCapabilities
+                                                                     , textDocumentClientCapabilitiesLinkedEditingRange :: Maybe LinkedEditingRangeClientCapabilities
+                                                                     , textDocumentClientCapabilitiesMoniker :: Maybe MonikerClientCapabilities
+                                                                     , textDocumentClientCapabilitiesTypeHierarchy :: Maybe TypeHierarchyClientCapabilities
+                                                                     , textDocumentClientCapabilitiesInlineValue :: Maybe InlineValueClientCapabilities
+                                                                     , textDocumentClientCapabilitiesInlayHint :: Maybe InlayHintClientCapabilities
+                                                                     , textDocumentClientCapabilitiesDiagnostic :: Maybe DiagnosticClientCapabilities
+                                                                     , textDocumentClientCapabilitiesInlineCompletion :: Maybe InlineCompletionClientCapabilities }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentContentChangeEvent.curry
+++ b/src/LSP/Protocol/Types/TextDocumentContentChangeEvent.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentContentChangeEvent where
+
+import LSP.Protocol.Types.TextDocumentContentChangePartial
+import LSP.Protocol.Types.TextDocumentContentChangeWholeDocument
+
+type TextDocumentContentChangeEvent = Either TextDocumentContentChangePartial TextDocumentContentChangeWholeDocument
+

--- a/src/LSP/Protocol/Types/TextDocumentContentChangePartial.curry
+++ b/src/LSP/Protocol/Types/TextDocumentContentChangePartial.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentContentChangePartial where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentContentChangePartial where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedRangeLength <- lookupMaybeFromJSON "rangeLength" vs
+           parsedText <- lookupFromJSON "text" vs
+           return
+            TextDocumentContentChangePartial { textDocumentContentChangePartialRange = parsedRange
+                                             , textDocumentContentChangePartialRangeLength = parsedRangeLength
+                                             , textDocumentContentChangePartialText = parsedText }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentContentChangePartial value: " ++ ppJSON j)
+
+data TextDocumentContentChangePartial = TextDocumentContentChangePartial { textDocumentContentChangePartialRange :: Range
+                                                                         , textDocumentContentChangePartialRangeLength :: Maybe Int
+                                                                         , textDocumentContentChangePartialText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentContentChangeWholeDocument.curry
+++ b/src/LSP/Protocol/Types/TextDocumentContentChangeWholeDocument.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentContentChangeWholeDocument where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentContentChangeWholeDocument where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedText <- lookupFromJSON "text" vs
+           return
+            TextDocumentContentChangeWholeDocument { textDocumentContentChangeWholeDocumentText = parsedText }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentContentChangeWholeDocument value: "
+           ++ ppJSON j)
+
+data TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument { textDocumentContentChangeWholeDocumentText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentEdit.curry
+++ b/src/LSP/Protocol/Types/TextDocumentEdit.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.AnnotatedTextEdit
+import LSP.Protocol.Types.OptionalVersionedTextDocumentIdentifier
+import LSP.Protocol.Types.SnippetTextEdit
+import LSP.Protocol.Types.TextEdit
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedEdits <- lookupFromJSON "edits" vs
+           return
+            TextDocumentEdit { textDocumentEditTextDocument = parsedTextDocument
+                             , textDocumentEditEdits = parsedEdits }
+      _ -> Left ("Unrecognized TextDocumentEdit value: " ++ ppJSON j)
+
+data TextDocumentEdit = TextDocumentEdit { textDocumentEditTextDocument :: OptionalVersionedTextDocumentIdentifier
+                                         , textDocumentEditEdits :: [Either (Either TextEdit AnnotatedTextEdit) SnippetTextEdit] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentFilter.curry
+++ b/src/LSP/Protocol/Types/TextDocumentFilter.curry
@@ -1,0 +1,10 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentFilter where
+
+import LSP.Protocol.Types.TextDocumentFilterLanguage
+import LSP.Protocol.Types.TextDocumentFilterPattern
+import LSP.Protocol.Types.TextDocumentFilterScheme
+
+type TextDocumentFilter = Either (Either TextDocumentFilterLanguage TextDocumentFilterScheme) TextDocumentFilterPattern
+

--- a/src/LSP/Protocol/Types/TextDocumentFilterLanguage.curry
+++ b/src/LSP/Protocol/Types/TextDocumentFilterLanguage.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentFilterLanguage where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentFilterLanguage where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLanguage <- lookupFromJSON "language" vs
+           parsedScheme <- lookupMaybeFromJSON "scheme" vs
+           parsedPattern <- lookupMaybeFromJSON "pattern" vs
+           return
+            TextDocumentFilterLanguage { textDocumentFilterLanguageLanguage = parsedLanguage
+                                       , textDocumentFilterLanguageScheme = parsedScheme
+                                       , textDocumentFilterLanguagePattern = parsedPattern }
+      _ ->
+        Left ("Unrecognized TextDocumentFilterLanguage value: " ++ ppJSON j)
+
+data TextDocumentFilterLanguage = TextDocumentFilterLanguage { textDocumentFilterLanguageLanguage :: String
+                                                             , textDocumentFilterLanguageScheme :: Maybe String
+                                                             , textDocumentFilterLanguagePattern :: Maybe GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentFilterPattern.curry
+++ b/src/LSP/Protocol/Types/TextDocumentFilterPattern.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentFilterPattern where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentFilterPattern where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLanguage <- lookupMaybeFromJSON "language" vs
+           parsedScheme <- lookupMaybeFromJSON "scheme" vs
+           parsedPattern <- lookupFromJSON "pattern" vs
+           return
+            TextDocumentFilterPattern { textDocumentFilterPatternLanguage = parsedLanguage
+                                      , textDocumentFilterPatternScheme = parsedScheme
+                                      , textDocumentFilterPatternPattern = parsedPattern }
+      _ -> Left ("Unrecognized TextDocumentFilterPattern value: " ++ ppJSON j)
+
+data TextDocumentFilterPattern = TextDocumentFilterPattern { textDocumentFilterPatternLanguage :: Maybe String
+                                                           , textDocumentFilterPatternScheme :: Maybe String
+                                                           , textDocumentFilterPatternPattern :: GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentFilterScheme.curry
+++ b/src/LSP/Protocol/Types/TextDocumentFilterScheme.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentFilterScheme where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.GlobPattern
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentFilterScheme where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLanguage <- lookupMaybeFromJSON "language" vs
+           parsedScheme <- lookupFromJSON "scheme" vs
+           parsedPattern <- lookupMaybeFromJSON "pattern" vs
+           return
+            TextDocumentFilterScheme { textDocumentFilterSchemeLanguage = parsedLanguage
+                                     , textDocumentFilterSchemeScheme = parsedScheme
+                                     , textDocumentFilterSchemePattern = parsedPattern }
+      _ -> Left ("Unrecognized TextDocumentFilterScheme value: " ++ ppJSON j)
+
+data TextDocumentFilterScheme = TextDocumentFilterScheme { textDocumentFilterSchemeLanguage :: Maybe String
+                                                         , textDocumentFilterSchemeScheme :: String
+                                                         , textDocumentFilterSchemePattern :: Maybe GlobPattern }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/TextDocumentIdentifier.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentIdentifier where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentIdentifier where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           return
+            TextDocumentIdentifier { textDocumentIdentifierUri = parsedUri }
+      _ -> Left ("Unrecognized TextDocumentIdentifier value: " ++ ppJSON j)
+
+data TextDocumentIdentifier = TextDocumentIdentifier { textDocumentIdentifierUri :: DocumentUri }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentItem.curry
+++ b/src/LSP/Protocol/Types/TextDocumentItem.curry
@@ -1,0 +1,31 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.LanguageKind
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedLanguageId <- lookupFromJSON "languageId" vs
+           parsedVersion <- lookupFromJSON "version" vs
+           parsedText <- lookupFromJSON "text" vs
+           return
+            TextDocumentItem { textDocumentItemUri = parsedUri
+                             , textDocumentItemLanguageId = parsedLanguageId
+                             , textDocumentItemVersion = parsedVersion
+                             , textDocumentItemText = parsedText }
+      _ -> Left ("Unrecognized TextDocumentItem value: " ++ ppJSON j)
+
+data TextDocumentItem = TextDocumentItem { textDocumentItemUri :: DocumentUri
+                                         , textDocumentItemLanguageId :: LanguageKind
+                                         , textDocumentItemVersion :: Int
+                                         , textDocumentItemText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentPositionParams.curry
+++ b/src/LSP/Protocol/Types/TextDocumentPositionParams.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentPositionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentPositionParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           return
+            TextDocumentPositionParams { textDocumentPositionParamsTextDocument = parsedTextDocument
+                                       , textDocumentPositionParamsPosition = parsedPosition }
+      _ ->
+        Left ("Unrecognized TextDocumentPositionParams value: " ++ ppJSON j)
+
+data TextDocumentPositionParams = TextDocumentPositionParams { textDocumentPositionParamsTextDocument :: TextDocumentIdentifier
+                                                             , textDocumentPositionParamsPosition :: Position }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentRegistrationOptions.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           return
+            TextDocumentRegistrationOptions { textDocumentRegistrationOptionsDocumentSelector = parsedDocumentSelector }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentRegistrationOptions value: " ++ ppJSON j)
+
+data TextDocumentRegistrationOptions = TextDocumentRegistrationOptions { textDocumentRegistrationOptionsDocumentSelector :: Either DocumentSelector () }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentSaveReason.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSaveReason.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentSaveReason where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentSaveReason where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right TextDocumentSaveReasonManual
+         2 -> Right TextDocumentSaveReasonAfterDelay
+         3 -> Right TextDocumentSaveReasonFocusOut
+         _ -> Left ("Unrecognized TextDocumentSaveReason value: " ++ ppJSON j)
+
+data TextDocumentSaveReason = TextDocumentSaveReasonManual
+                            | TextDocumentSaveReasonAfterDelay
+                            | TextDocumentSaveReasonFocusOut
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/TextDocumentSaveRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSaveRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentSaveRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentSaveRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TextDocumentSaveRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentSaveRegistrationOptions value: "
+           ++ ppJSON j)
+
+data TextDocumentSaveRegistrationOptions = TextDocumentSaveRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentSyncClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSyncClientCapabilities.curry
@@ -1,0 +1,35 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentSyncClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentSyncClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedWillSave <- lookupMaybeFromJSON "willSave" vs
+           parsedWillSaveWaitUntil <- lookupMaybeFromJSON "willSaveWaitUntil"
+                                       vs
+           parsedDidSave <- lookupMaybeFromJSON "didSave" vs
+           return
+            TextDocumentSyncClientCapabilities { textDocumentSyncClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                               , textDocumentSyncClientCapabilitiesWillSave = parsedWillSave
+                                               , textDocumentSyncClientCapabilitiesWillSaveWaitUntil = parsedWillSaveWaitUntil
+                                               , textDocumentSyncClientCapabilitiesDidSave = parsedDidSave }
+      _ ->
+        Left
+         ("Unrecognized TextDocumentSyncClientCapabilities value: "
+           ++ ppJSON j)
+
+data TextDocumentSyncClientCapabilities = TextDocumentSyncClientCapabilities { textDocumentSyncClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                             , textDocumentSyncClientCapabilitiesWillSave :: Maybe Bool
+                                                                             , textDocumentSyncClientCapabilitiesWillSaveWaitUntil :: Maybe Bool
+                                                                             , textDocumentSyncClientCapabilitiesDidSave :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextDocumentSyncKind.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSyncKind.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentSyncKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentSyncKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         0 -> Right TextDocumentSyncKindNone
+         1 -> Right TextDocumentSyncKindFull
+         2 -> Right TextDocumentSyncKindIncremental
+         _ -> Left ("Unrecognized TextDocumentSyncKind value: " ++ ppJSON j)
+
+data TextDocumentSyncKind = TextDocumentSyncKindNone
+                          | TextDocumentSyncKindFull
+                          | TextDocumentSyncKindIncremental
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/TextDocumentSyncOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSyncOptions.curry
@@ -1,0 +1,35 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextDocumentSyncOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.SaveOptions
+import LSP.Protocol.Types.TextDocumentSyncKind
+import LSP.Utils.JSON
+
+instance FromJSON TextDocumentSyncOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedOpenClose <- lookupMaybeFromJSON "openClose" vs
+           parsedChange <- lookupMaybeFromJSON "change" vs
+           parsedWillSave <- lookupMaybeFromJSON "willSave" vs
+           parsedWillSaveWaitUntil <- lookupMaybeFromJSON "willSaveWaitUntil"
+                                       vs
+           parsedSave <- lookupMaybeFromJSON "save" vs
+           return
+            TextDocumentSyncOptions { textDocumentSyncOptionsOpenClose = parsedOpenClose
+                                    , textDocumentSyncOptionsChange = parsedChange
+                                    , textDocumentSyncOptionsWillSave = parsedWillSave
+                                    , textDocumentSyncOptionsWillSaveWaitUntil = parsedWillSaveWaitUntil
+                                    , textDocumentSyncOptionsSave = parsedSave }
+      _ -> Left ("Unrecognized TextDocumentSyncOptions value: " ++ ppJSON j)
+
+data TextDocumentSyncOptions = TextDocumentSyncOptions { textDocumentSyncOptionsOpenClose :: Maybe Bool
+                                                       , textDocumentSyncOptionsChange :: Maybe TextDocumentSyncKind
+                                                       , textDocumentSyncOptionsWillSave :: Maybe Bool
+                                                       , textDocumentSyncOptionsWillSaveWaitUntil :: Maybe Bool
+                                                       , textDocumentSyncOptionsSave :: Maybe (Either Bool SaveOptions) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TextEdit.curry
+++ b/src/LSP/Protocol/Types/TextEdit.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TextEdit where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Range
+import LSP.Utils.JSON
+
+instance FromJSON TextEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedNewText <- lookupFromJSON "newText" vs
+           return
+            TextEdit { textEditRange = parsedRange
+                     , textEditNewText = parsedNewText }
+      _ -> Left ("Unrecognized TextEdit value: " ++ ppJSON j)
+
+data TextEdit = TextEdit { textEditRange :: Range, textEditNewText :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TokenFormat.curry
+++ b/src/LSP/Protocol/Types/TokenFormat.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TokenFormat where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TokenFormat where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "relative" -> Right TokenFormatRelative
+         _ -> Left ("Unrecognized TokenFormat value: " ++ ppJSON j)
+
+data TokenFormat = TokenFormatRelative
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/TraceValue.curry
+++ b/src/LSP/Protocol/Types/TraceValue.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TraceValue where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TraceValue where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "off" -> Right TraceValueOff
+         "messages" -> Right TraceValueMessages
+         "verbose" -> Right TraceValueVerbose
+         _ -> Left ("Unrecognized TraceValue value: " ++ ppJSON j)
+
+data TraceValue = TraceValueOff | TraceValueMessages | TraceValueVerbose
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/TypeDefinitionClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionClientCapabilities.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeDefinitionClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeDefinitionClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedLinkSupport <- lookupMaybeFromJSON "linkSupport" vs
+           return
+            TypeDefinitionClientCapabilities { typeDefinitionClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                             , typeDefinitionClientCapabilitiesLinkSupport = parsedLinkSupport }
+      _ ->
+        Left
+         ("Unrecognized TypeDefinitionClientCapabilities value: " ++ ppJSON j)
+
+data TypeDefinitionClientCapabilities = TypeDefinitionClientCapabilities { typeDefinitionClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                         , typeDefinitionClientCapabilitiesLinkSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeDefinitionOptions.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeDefinitionOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeDefinitionOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeDefinitionOptions {  }
+      _ -> Left ("Unrecognized TypeDefinitionOptions value: " ++ ppJSON j)
+
+data TypeDefinitionOptions = TypeDefinitionOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeDefinitionParams.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionParams.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeDefinitionParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeDefinitionParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeDefinitionParams {  }
+      _ -> Left ("Unrecognized TypeDefinitionParams value: " ++ ppJSON j)
+
+data TypeDefinitionParams = TypeDefinitionParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeDefinitionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeDefinitionRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeDefinitionRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeDefinitionRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized TypeDefinitionRegistrationOptions value: "
+           ++ ppJSON j)
+
+data TypeDefinitionRegistrationOptions = TypeDefinitionRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchyClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyClientCapabilities.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchyClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchyClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           return
+            TypeHierarchyClientCapabilities { typeHierarchyClientCapabilitiesDynamicRegistration = parsedDynamicRegistration }
+      _ ->
+        Left
+         ("Unrecognized TypeHierarchyClientCapabilities value: " ++ ppJSON j)
+
+data TypeHierarchyClientCapabilities = TypeHierarchyClientCapabilities { typeHierarchyClientCapabilitiesDynamicRegistration :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchyItem.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyItem.curry
@@ -1,0 +1,45 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchyItem where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Range
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchyItem where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedName <- lookupFromJSON "name" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedDetail <- lookupMaybeFromJSON "detail" vs
+           parsedUri <- lookupFromJSON "uri" vs
+           parsedRange <- lookupFromJSON "range" vs
+           parsedSelectionRange <- lookupFromJSON "selectionRange" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            TypeHierarchyItem { typeHierarchyItemName = parsedName
+                              , typeHierarchyItemKind = parsedKind
+                              , typeHierarchyItemTags = parsedTags
+                              , typeHierarchyItemDetail = parsedDetail
+                              , typeHierarchyItemUri = parsedUri
+                              , typeHierarchyItemRange = parsedRange
+                              , typeHierarchyItemSelectionRange = parsedSelectionRange
+                              , typeHierarchyItemData = parsedData }
+      _ -> Left ("Unrecognized TypeHierarchyItem value: " ++ ppJSON j)
+
+data TypeHierarchyItem = TypeHierarchyItem { typeHierarchyItemName :: String
+                                           , typeHierarchyItemKind :: SymbolKind
+                                           , typeHierarchyItemTags :: Maybe [SymbolTag]
+                                           , typeHierarchyItemDetail :: Maybe String
+                                           , typeHierarchyItemUri :: DocumentUri
+                                           , typeHierarchyItemRange :: Range
+                                           , typeHierarchyItemSelectionRange :: Range
+                                           , typeHierarchyItemData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchyOptions.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyOptions.curry
@@ -1,0 +1,17 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchyOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchyOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeHierarchyOptions {  }
+      _ -> Left ("Unrecognized TypeHierarchyOptions value: " ++ ppJSON j)
+
+data TypeHierarchyOptions = TypeHierarchyOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchyPrepareParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyPrepareParams.curry
@@ -1,0 +1,18 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchyPrepareParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchyPrepareParams where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeHierarchyPrepareParams {  }
+      _ ->
+        Left ("Unrecognized TypeHierarchyPrepareParams value: " ++ ppJSON j)
+
+data TypeHierarchyPrepareParams = TypeHierarchyPrepareParams {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchyRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyRegistrationOptions.curry
@@ -1,0 +1,19 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchyRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchyRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return TypeHierarchyRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized TypeHierarchyRegistrationOptions value: " ++ ppJSON j)
+
+data TypeHierarchyRegistrationOptions = TypeHierarchyRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchySubtypesParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchySubtypesParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchySubtypesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TypeHierarchyItem
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchySubtypesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItem <- lookupFromJSON "item" vs
+           return
+            TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem = parsedItem }
+      _ ->
+        Left ("Unrecognized TypeHierarchySubtypesParams value: " ++ ppJSON j)
+
+data TypeHierarchySubtypesParams = TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem :: TypeHierarchyItem }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/TypeHierarchySupertypesParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchySupertypesParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.TypeHierarchySupertypesParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TypeHierarchyItem
+import LSP.Utils.JSON
+
+instance FromJSON TypeHierarchySupertypesParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItem <- lookupFromJSON "item" vs
+           return
+            TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem = parsedItem }
+      _ ->
+        Left
+         ("Unrecognized TypeHierarchySupertypesParams value: " ++ ppJSON j)
+
+data TypeHierarchySupertypesParams = TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem :: TypeHierarchyItem }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/UnchangedDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/UnchangedDocumentDiagnosticReport.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.UnchangedDocumentDiagnosticReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON UnchangedDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupFromJSON "resultId" vs
+           return
+            UnchangedDocumentDiagnosticReport { unchangedDocumentDiagnosticReportKind = parsedKind
+                                              , unchangedDocumentDiagnosticReportResultId = parsedResultId }
+      _ ->
+        Left
+         ("Unrecognized UnchangedDocumentDiagnosticReport value: "
+           ++ ppJSON j)
+
+data UnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnosticReport { unchangedDocumentDiagnosticReportKind :: String
+                                                                           , unchangedDocumentDiagnosticReportResultId :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/UniquenessLevel.curry
+++ b/src/LSP/Protocol/Types/UniquenessLevel.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.UniquenessLevel where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON UniquenessLevel where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: String of
+         "document" -> Right UniquenessLevelDocument
+         "project" -> Right UniquenessLevelProject
+         "group" -> Right UniquenessLevelGroup
+         "scheme" -> Right UniquenessLevelScheme
+         "global" -> Right UniquenessLevelGlobal
+         _ -> Left ("Unrecognized UniquenessLevel value: " ++ ppJSON j)
+
+data UniquenessLevel = UniquenessLevelDocument
+                     | UniquenessLevelProject
+                     | UniquenessLevelGroup
+                     | UniquenessLevelScheme
+                     | UniquenessLevelGlobal
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/Unregistration.curry
+++ b/src/LSP/Protocol/Types/Unregistration.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.Unregistration where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON Unregistration where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedId <- lookupFromJSON "id" vs
+           parsedMethod <- lookupFromJSON "method" vs
+           return
+            Unregistration { unregistrationId = parsedId
+                           , unregistrationMethod = parsedMethod }
+      _ -> Left ("Unrecognized Unregistration value: " ++ ppJSON j)
+
+data Unregistration = Unregistration { unregistrationId :: String
+                                     , unregistrationMethod :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/UnregistrationParams.curry
+++ b/src/LSP/Protocol/Types/UnregistrationParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.UnregistrationParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.Unregistration
+import LSP.Utils.JSON
+
+instance FromJSON UnregistrationParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUnregisterations <- lookupFromJSON "unregisterations" vs
+           return
+            UnregistrationParams { unregistrationParamsUnregisterations = parsedUnregisterations }
+      _ -> Left ("Unrecognized UnregistrationParams value: " ++ ppJSON j)
+
+data UnregistrationParams = UnregistrationParams { unregistrationParamsUnregisterations :: [Unregistration] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/VersionedNotebookDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/VersionedNotebookDocumentIdentifier.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.VersionedNotebookDocumentIdentifier where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON VersionedNotebookDocumentIdentifier where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedVersion <- lookupFromJSON "version" vs
+           parsedUri <- lookupFromJSON "uri" vs
+           return
+            VersionedNotebookDocumentIdentifier { versionedNotebookDocumentIdentifierVersion = parsedVersion
+                                                , versionedNotebookDocumentIdentifierUri = parsedUri }
+      _ ->
+        Left
+         ("Unrecognized VersionedNotebookDocumentIdentifier value: "
+           ++ ppJSON j)
+
+data VersionedNotebookDocumentIdentifier = VersionedNotebookDocumentIdentifier { versionedNotebookDocumentIdentifierVersion :: Int
+                                                                               , versionedNotebookDocumentIdentifierUri :: Uri }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/VersionedTextDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/VersionedTextDocumentIdentifier.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.VersionedTextDocumentIdentifier where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON VersionedTextDocumentIdentifier where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedVersion <- lookupFromJSON "version" vs
+           return
+            VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion = parsedVersion }
+      _ ->
+        Left
+         ("Unrecognized VersionedTextDocumentIdentifier value: " ++ ppJSON j)
+
+data VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion :: Int }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WatchKind.curry
+++ b/src/LSP/Protocol/Types/WatchKind.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WatchKind where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WatchKind where
+  fromJSON j =
+    do raw <- fromJSON j
+       case raw :: Int of
+         1 -> Right WatchKindCreate
+         2 -> Right WatchKindChange
+         4 -> Right WatchKindDelete
+         _ -> Left ("Unrecognized WatchKind value: " ++ ppJSON j)
+
+data WatchKind = WatchKindCreate | WatchKindChange | WatchKindDelete
+ deriving (Show,Eq,Enum,Bounded,Ord)
+

--- a/src/LSP/Protocol/Types/WillSaveTextDocumentParams.curry
+++ b/src/LSP/Protocol/Types/WillSaveTextDocumentParams.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WillSaveTextDocumentParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.TextDocumentIdentifier
+import LSP.Protocol.Types.TextDocumentSaveReason
+import LSP.Utils.JSON
+
+instance FromJSON WillSaveTextDocumentParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedReason <- lookupFromJSON "reason" vs
+           return
+            WillSaveTextDocumentParams { willSaveTextDocumentParamsTextDocument = parsedTextDocument
+                                       , willSaveTextDocumentParamsReason = parsedReason }
+      _ ->
+        Left ("Unrecognized WillSaveTextDocumentParams value: " ++ ppJSON j)
+
+data WillSaveTextDocumentParams = WillSaveTextDocumentParams { willSaveTextDocumentParamsTextDocument :: TextDocumentIdentifier
+                                                             , willSaveTextDocumentParamsReason :: TextDocumentSaveReason }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WindowClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/WindowClientCapabilities.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WindowClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ShowDocumentClientCapabilities
+import LSP.Protocol.Types.ShowMessageRequestClientCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON WindowClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedShowMessage <- lookupMaybeFromJSON "showMessage" vs
+           parsedShowDocument <- lookupMaybeFromJSON "showDocument" vs
+           return
+            WindowClientCapabilities { windowClientCapabilitiesWorkDoneProgress = parsedWorkDoneProgress
+                                     , windowClientCapabilitiesShowMessage = parsedShowMessage
+                                     , windowClientCapabilitiesShowDocument = parsedShowDocument }
+      _ -> Left ("Unrecognized WindowClientCapabilities value: " ++ ppJSON j)
+
+data WindowClientCapabilities = WindowClientCapabilities { windowClientCapabilitiesWorkDoneProgress :: Maybe Bool
+                                                         , windowClientCapabilitiesShowMessage :: Maybe ShowMessageRequestClientCapabilities
+                                                         , windowClientCapabilitiesShowDocument :: Maybe ShowDocumentClientCapabilities }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressBegin.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressBegin.curry
@@ -1,0 +1,32 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressBegin where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressBegin where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedTitle <- lookupFromJSON "title" vs
+           parsedCancellable <- lookupMaybeFromJSON "cancellable" vs
+           parsedMessage <- lookupMaybeFromJSON "message" vs
+           parsedPercentage <- lookupMaybeFromJSON "percentage" vs
+           return
+            WorkDoneProgressBegin { workDoneProgressBeginKind = parsedKind
+                                  , workDoneProgressBeginTitle = parsedTitle
+                                  , workDoneProgressBeginCancellable = parsedCancellable
+                                  , workDoneProgressBeginMessage = parsedMessage
+                                  , workDoneProgressBeginPercentage = parsedPercentage }
+      _ -> Left ("Unrecognized WorkDoneProgressBegin value: " ++ ppJSON j)
+
+data WorkDoneProgressBegin = WorkDoneProgressBegin { workDoneProgressBeginKind :: String
+                                                   , workDoneProgressBeginTitle :: String
+                                                   , workDoneProgressBeginCancellable :: Maybe Bool
+                                                   , workDoneProgressBeginMessage :: Maybe String
+                                                   , workDoneProgressBeginPercentage :: Maybe Int }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressCancelParams.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressCancelParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressCancelParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressCancelParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedToken <- lookupFromJSON "token" vs
+           return
+            WorkDoneProgressCancelParams { workDoneProgressCancelParamsToken = parsedToken }
+      _ ->
+        Left ("Unrecognized WorkDoneProgressCancelParams value: " ++ ppJSON j)
+
+data WorkDoneProgressCancelParams = WorkDoneProgressCancelParams { workDoneProgressCancelParamsToken :: ProgressToken }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressCreateParams.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressCreateParams.curry
@@ -1,0 +1,22 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressCreateParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressCreateParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedToken <- lookupFromJSON "token" vs
+           return
+            WorkDoneProgressCreateParams { workDoneProgressCreateParamsToken = parsedToken }
+      _ ->
+        Left ("Unrecognized WorkDoneProgressCreateParams value: " ++ ppJSON j)
+
+data WorkDoneProgressCreateParams = WorkDoneProgressCreateParams { workDoneProgressCreateParamsToken :: ProgressToken }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressEnd.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressEnd.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressEnd where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressEnd where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedMessage <- lookupMaybeFromJSON "message" vs
+           return
+            WorkDoneProgressEnd { workDoneProgressEndKind = parsedKind
+                                , workDoneProgressEndMessage = parsedMessage }
+      _ -> Left ("Unrecognized WorkDoneProgressEnd value: " ++ ppJSON j)
+
+data WorkDoneProgressEnd = WorkDoneProgressEnd { workDoneProgressEndKind :: String
+                                               , workDoneProgressEndMessage :: Maybe String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressOptions.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            WorkDoneProgressOptions { workDoneProgressOptionsWorkDoneProgress = parsedWorkDoneProgress }
+      _ -> Left ("Unrecognized WorkDoneProgressOptions value: " ++ ppJSON j)
+
+data WorkDoneProgressOptions = WorkDoneProgressOptions { workDoneProgressOptionsWorkDoneProgress :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressParams.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressParams.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            WorkDoneProgressParams { workDoneProgressParamsWorkDoneToken = parsedWorkDoneToken }
+      _ -> Left ("Unrecognized WorkDoneProgressParams value: " ++ ppJSON j)
+
+data WorkDoneProgressParams = WorkDoneProgressParams { workDoneProgressParamsWorkDoneToken :: Maybe ProgressToken }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkDoneProgressReport.curry
+++ b/src/LSP/Protocol/Types/WorkDoneProgressReport.curry
@@ -1,0 +1,29 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkDoneProgressReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkDoneProgressReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedCancellable <- lookupMaybeFromJSON "cancellable" vs
+           parsedMessage <- lookupMaybeFromJSON "message" vs
+           parsedPercentage <- lookupMaybeFromJSON "percentage" vs
+           return
+            WorkDoneProgressReport { workDoneProgressReportKind = parsedKind
+                                   , workDoneProgressReportCancellable = parsedCancellable
+                                   , workDoneProgressReportMessage = parsedMessage
+                                   , workDoneProgressReportPercentage = parsedPercentage }
+      _ -> Left ("Unrecognized WorkDoneProgressReport value: " ++ ppJSON j)
+
+data WorkDoneProgressReport = WorkDoneProgressReport { workDoneProgressReportKind :: String
+                                                     , workDoneProgressReportCancellable :: Maybe Bool
+                                                     , workDoneProgressReportMessage :: Maybe String
+                                                     , workDoneProgressReportPercentage :: Maybe Int }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/WorkspaceClientCapabilities.curry
@@ -1,0 +1,79 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.CodeLensWorkspaceClientCapabilities
+import LSP.Protocol.Types.DiagnosticWorkspaceClientCapabilities
+import LSP.Protocol.Types.DidChangeConfigurationClientCapabilities
+import LSP.Protocol.Types.DidChangeWatchedFilesClientCapabilities
+import LSP.Protocol.Types.ExecuteCommandClientCapabilities
+import LSP.Protocol.Types.FileOperationClientCapabilities
+import LSP.Protocol.Types.FoldingRangeWorkspaceClientCapabilities
+import LSP.Protocol.Types.InlayHintWorkspaceClientCapabilities
+import LSP.Protocol.Types.InlineValueWorkspaceClientCapabilities
+import LSP.Protocol.Types.SemanticTokensWorkspaceClientCapabilities
+import LSP.Protocol.Types.WorkspaceEditClientCapabilities
+import LSP.Protocol.Types.WorkspaceSymbolClientCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedApplyEdit <- lookupMaybeFromJSON "applyEdit" vs
+           parsedWorkspaceEdit <- lookupMaybeFromJSON "workspaceEdit" vs
+           parsedDidChangeConfiguration <- lookupMaybeFromJSON
+                                            "didChangeConfiguration"
+                                            vs
+           parsedDidChangeWatchedFiles <- lookupMaybeFromJSON
+                                           "didChangeWatchedFiles"
+                                           vs
+           parsedSymbol <- lookupMaybeFromJSON "symbol" vs
+           parsedExecuteCommand <- lookupMaybeFromJSON "executeCommand" vs
+           parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
+           parsedConfiguration <- lookupMaybeFromJSON "configuration" vs
+           parsedSemanticTokens <- lookupMaybeFromJSON "semanticTokens" vs
+           parsedCodeLens <- lookupMaybeFromJSON "codeLens" vs
+           parsedFileOperations <- lookupMaybeFromJSON "fileOperations" vs
+           parsedInlineValue <- lookupMaybeFromJSON "inlineValue" vs
+           parsedInlayHint <- lookupMaybeFromJSON "inlayHint" vs
+           parsedDiagnostics <- lookupMaybeFromJSON "diagnostics" vs
+           parsedFoldingRange <- lookupMaybeFromJSON "foldingRange" vs
+           return
+            WorkspaceClientCapabilities { workspaceClientCapabilitiesApplyEdit = parsedApplyEdit
+                                        , workspaceClientCapabilitiesWorkspaceEdit = parsedWorkspaceEdit
+                                        , workspaceClientCapabilitiesDidChangeConfiguration = parsedDidChangeConfiguration
+                                        , workspaceClientCapabilitiesDidChangeWatchedFiles = parsedDidChangeWatchedFiles
+                                        , workspaceClientCapabilitiesSymbol = parsedSymbol
+                                        , workspaceClientCapabilitiesExecuteCommand = parsedExecuteCommand
+                                        , workspaceClientCapabilitiesWorkspaceFolders = parsedWorkspaceFolders
+                                        , workspaceClientCapabilitiesConfiguration = parsedConfiguration
+                                        , workspaceClientCapabilitiesSemanticTokens = parsedSemanticTokens
+                                        , workspaceClientCapabilitiesCodeLens = parsedCodeLens
+                                        , workspaceClientCapabilitiesFileOperations = parsedFileOperations
+                                        , workspaceClientCapabilitiesInlineValue = parsedInlineValue
+                                        , workspaceClientCapabilitiesInlayHint = parsedInlayHint
+                                        , workspaceClientCapabilitiesDiagnostics = parsedDiagnostics
+                                        , workspaceClientCapabilitiesFoldingRange = parsedFoldingRange }
+      _ ->
+        Left ("Unrecognized WorkspaceClientCapabilities value: " ++ ppJSON j)
+
+data WorkspaceClientCapabilities = WorkspaceClientCapabilities { workspaceClientCapabilitiesApplyEdit :: Maybe Bool
+                                                               , workspaceClientCapabilitiesWorkspaceEdit :: Maybe WorkspaceEditClientCapabilities
+                                                               , workspaceClientCapabilitiesDidChangeConfiguration :: Maybe DidChangeConfigurationClientCapabilities
+                                                               , workspaceClientCapabilitiesDidChangeWatchedFiles :: Maybe DidChangeWatchedFilesClientCapabilities
+                                                               , workspaceClientCapabilitiesSymbol :: Maybe WorkspaceSymbolClientCapabilities
+                                                               , workspaceClientCapabilitiesExecuteCommand :: Maybe ExecuteCommandClientCapabilities
+                                                               , workspaceClientCapabilitiesWorkspaceFolders :: Maybe Bool
+                                                               , workspaceClientCapabilitiesConfiguration :: Maybe Bool
+                                                               , workspaceClientCapabilitiesSemanticTokens :: Maybe SemanticTokensWorkspaceClientCapabilities
+                                                               , workspaceClientCapabilitiesCodeLens :: Maybe CodeLensWorkspaceClientCapabilities
+                                                               , workspaceClientCapabilitiesFileOperations :: Maybe FileOperationClientCapabilities
+                                                               , workspaceClientCapabilitiesInlineValue :: Maybe InlineValueWorkspaceClientCapabilities
+                                                               , workspaceClientCapabilitiesInlayHint :: Maybe InlayHintWorkspaceClientCapabilities
+                                                               , workspaceClientCapabilitiesDiagnostics :: Maybe DiagnosticWorkspaceClientCapabilities
+                                                               , workspaceClientCapabilitiesFoldingRange :: Maybe FoldingRangeWorkspaceClientCapabilities }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceDiagnosticParams.curry
+++ b/src/LSP/Protocol/Types/WorkspaceDiagnosticParams.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceDiagnosticParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.PreviousResultId
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceDiagnosticParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+           parsedPreviousResultIds <- lookupFromJSON "previousResultIds" vs
+           return
+            WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier = parsedIdentifier
+                                      , workspaceDiagnosticParamsPreviousResultIds = parsedPreviousResultIds }
+      _ -> Left ("Unrecognized WorkspaceDiagnosticParams value: " ++ ppJSON j)
+
+data WorkspaceDiagnosticParams = WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier :: Maybe String
+                                                           , workspaceDiagnosticParamsPreviousResultIds :: [PreviousResultId] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceDiagnosticReport.curry
@@ -1,0 +1,21 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceDiagnosticReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceDocumentDiagnosticReport
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItems <- lookupFromJSON "items" vs
+           return
+            WorkspaceDiagnosticReport { workspaceDiagnosticReportItems = parsedItems }
+      _ -> Left ("Unrecognized WorkspaceDiagnosticReport value: " ++ ppJSON j)
+
+data WorkspaceDiagnosticReport = WorkspaceDiagnosticReport { workspaceDiagnosticReportItems :: [WorkspaceDocumentDiagnosticReport] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceDiagnosticReportPartialResult.curry
+++ b/src/LSP/Protocol/Types/WorkspaceDiagnosticReportPartialResult.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceDiagnosticReportPartialResult where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceDocumentDiagnosticReport
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceDiagnosticReportPartialResult where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedItems <- lookupFromJSON "items" vs
+           return
+            WorkspaceDiagnosticReportPartialResult { workspaceDiagnosticReportPartialResultItems = parsedItems }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceDiagnosticReportPartialResult value: "
+           ++ ppJSON j)
+
+data WorkspaceDiagnosticReportPartialResult = WorkspaceDiagnosticReportPartialResult { workspaceDiagnosticReportPartialResultItems :: [WorkspaceDocumentDiagnosticReport] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceDocumentDiagnosticReport.curry
@@ -1,0 +1,9 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceDocumentDiagnosticReport where
+
+import LSP.Protocol.Types.WorkspaceFullDocumentDiagnosticReport
+import LSP.Protocol.Types.WorkspaceUnchangedDocumentDiagnosticReport
+
+type WorkspaceDocumentDiagnosticReport = Either WorkspaceFullDocumentDiagnosticReport WorkspaceUnchangedDocumentDiagnosticReport
+

--- a/src/LSP/Protocol/Types/WorkspaceEdit.curry
+++ b/src/LSP/Protocol/Types/WorkspaceEdit.curry
@@ -1,0 +1,36 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceEdit where
+
+import Data.Map
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.ChangeAnnotation
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Protocol.Types.CreateFile
+import LSP.Protocol.Types.DeleteFile
+import LSP.Protocol.Types.RenameFile
+import LSP.Protocol.Types.TextDocumentEdit
+import LSP.Protocol.Types.TextEdit
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceEdit where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedChanges <- lookupMaybeFromJSON "changes" vs
+           parsedDocumentChanges <- lookupMaybeFromJSON "documentChanges" vs
+           parsedChangeAnnotations <- lookupMaybeFromJSON "changeAnnotations"
+                                       vs
+           return
+            WorkspaceEdit { workspaceEditChanges = parsedChanges
+                          , workspaceEditDocumentChanges = parsedDocumentChanges
+                          , workspaceEditChangeAnnotations = parsedChangeAnnotations }
+      _ -> Left ("Unrecognized WorkspaceEdit value: " ++ ppJSON j)
+
+data WorkspaceEdit = WorkspaceEdit { workspaceEditChanges :: Maybe (Map DocumentUri [TextEdit])
+                                   , workspaceEditDocumentChanges :: Maybe [Either (Either (Either TextDocumentEdit CreateFile) RenameFile) DeleteFile]
+                                   , workspaceEditChangeAnnotations :: Maybe (Map ChangeAnnotationIdentifier ChangeAnnotation) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceEditClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/WorkspaceEditClientCapabilities.curry
@@ -1,0 +1,51 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceEditClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ChangeAnnotationsSupportOptions
+import LSP.Protocol.Types.FailureHandlingKind
+import LSP.Protocol.Types.ResourceOperationKind
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceEditClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDocumentChanges <- lookupMaybeFromJSON "documentChanges" vs
+           parsedResourceOperations <- lookupMaybeFromJSON
+                                        "resourceOperations"
+                                        vs
+           parsedFailureHandling <- lookupMaybeFromJSON "failureHandling" vs
+           parsedNormalizesLineEndings <- lookupMaybeFromJSON
+                                           "normalizesLineEndings"
+                                           vs
+           parsedChangeAnnotationSupport <- lookupMaybeFromJSON
+                                             "changeAnnotationSupport"
+                                             vs
+           parsedMetadataSupport <- lookupMaybeFromJSON "metadataSupport" vs
+           parsedSnippetEditSupport <- lookupMaybeFromJSON
+                                        "snippetEditSupport"
+                                        vs
+           return
+            WorkspaceEditClientCapabilities { workspaceEditClientCapabilitiesDocumentChanges = parsedDocumentChanges
+                                            , workspaceEditClientCapabilitiesResourceOperations = parsedResourceOperations
+                                            , workspaceEditClientCapabilitiesFailureHandling = parsedFailureHandling
+                                            , workspaceEditClientCapabilitiesNormalizesLineEndings = parsedNormalizesLineEndings
+                                            , workspaceEditClientCapabilitiesChangeAnnotationSupport = parsedChangeAnnotationSupport
+                                            , workspaceEditClientCapabilitiesMetadataSupport = parsedMetadataSupport
+                                            , workspaceEditClientCapabilitiesSnippetEditSupport = parsedSnippetEditSupport }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceEditClientCapabilities value: " ++ ppJSON j)
+
+data WorkspaceEditClientCapabilities = WorkspaceEditClientCapabilities { workspaceEditClientCapabilitiesDocumentChanges :: Maybe Bool
+                                                                       , workspaceEditClientCapabilitiesResourceOperations :: Maybe [ResourceOperationKind]
+                                                                       , workspaceEditClientCapabilitiesFailureHandling :: Maybe FailureHandlingKind
+                                                                       , workspaceEditClientCapabilitiesNormalizesLineEndings :: Maybe Bool
+                                                                       , workspaceEditClientCapabilitiesChangeAnnotationSupport :: Maybe ChangeAnnotationsSupportOptions
+                                                                       , workspaceEditClientCapabilitiesMetadataSupport :: Maybe Bool
+                                                                       , workspaceEditClientCapabilitiesSnippetEditSupport :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceEditMetadata.curry
+++ b/src/LSP/Protocol/Types/WorkspaceEditMetadata.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceEditMetadata where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceEditMetadata where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedIsRefactoring <- lookupMaybeFromJSON "isRefactoring" vs
+           return
+            WorkspaceEditMetadata { workspaceEditMetadataIsRefactoring = parsedIsRefactoring }
+      _ -> Left ("Unrecognized WorkspaceEditMetadata value: " ++ ppJSON j)
+
+data WorkspaceEditMetadata = WorkspaceEditMetadata { workspaceEditMetadataIsRefactoring :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceFolder.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFolder.curry
@@ -1,0 +1,24 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceFolder where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceFolder where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedName <- lookupFromJSON "name" vs
+           return
+            WorkspaceFolder { workspaceFolderUri = parsedUri
+                            , workspaceFolderName = parsedName }
+      _ -> Left ("Unrecognized WorkspaceFolder value: " ++ ppJSON j)
+
+data WorkspaceFolder = WorkspaceFolder { workspaceFolderUri :: Uri
+                                       , workspaceFolderName :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceFoldersChangeEvent.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFoldersChangeEvent.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceFoldersChangeEvent where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceFolder
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceFoldersChangeEvent where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedAdded <- lookupFromJSON "added" vs
+           parsedRemoved <- lookupFromJSON "removed" vs
+           return
+            WorkspaceFoldersChangeEvent { workspaceFoldersChangeEventAdded = parsedAdded
+                                        , workspaceFoldersChangeEventRemoved = parsedRemoved }
+      _ ->
+        Left ("Unrecognized WorkspaceFoldersChangeEvent value: " ++ ppJSON j)
+
+data WorkspaceFoldersChangeEvent = WorkspaceFoldersChangeEvent { workspaceFoldersChangeEventAdded :: [WorkspaceFolder]
+                                                               , workspaceFoldersChangeEventRemoved :: [WorkspaceFolder] }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceFoldersInitializeParams.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFoldersInitializeParams.curry
@@ -1,0 +1,23 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceFoldersInitializeParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.WorkspaceFolder
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceFoldersInitializeParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
+           return
+            WorkspaceFoldersInitializeParams { workspaceFoldersInitializeParamsWorkspaceFolders = parsedWorkspaceFolders }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceFoldersInitializeParams value: " ++ ppJSON j)
+
+data WorkspaceFoldersInitializeParams = WorkspaceFoldersInitializeParams { workspaceFoldersInitializeParamsWorkspaceFolders :: Maybe (Either [WorkspaceFolder] ()) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceFoldersServerCapabilities.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFoldersServerCapabilities.curry
@@ -1,0 +1,28 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceFoldersServerCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceFoldersServerCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedSupported <- lookupMaybeFromJSON "supported" vs
+           parsedChangeNotifications <- lookupMaybeFromJSON
+                                         "changeNotifications"
+                                         vs
+           return
+            WorkspaceFoldersServerCapabilities { workspaceFoldersServerCapabilitiesSupported = parsedSupported
+                                               , workspaceFoldersServerCapabilitiesChangeNotifications = parsedChangeNotifications }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceFoldersServerCapabilities value: "
+           ++ ppJSON j)
+
+data WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities { workspaceFoldersServerCapabilitiesSupported :: Maybe Bool
+                                                                             , workspaceFoldersServerCapabilitiesChangeNotifications :: Maybe (Either String Bool) }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceFullDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFullDocumentDiagnosticReport.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceFullDocumentDiagnosticReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceFullDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedVersion <- lookupFromJSON "version" vs
+           return
+            WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri = parsedUri
+                                                  , workspaceFullDocumentDiagnosticReportVersion = parsedVersion }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceFullDocumentDiagnosticReport value: "
+           ++ ppJSON j)
+
+data WorkspaceFullDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri :: DocumentUri
+                                                                                   , workspaceFullDocumentDiagnosticReportVersion :: Either Int () }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceOptions.curry
+++ b/src/LSP/Protocol/Types/WorkspaceOptions.curry
@@ -1,0 +1,25 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.FileOperationOptions
+import LSP.Protocol.Types.WorkspaceFoldersServerCapabilities
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
+           parsedFileOperations <- lookupMaybeFromJSON "fileOperations" vs
+           return
+            WorkspaceOptions { workspaceOptionsWorkspaceFolders = parsedWorkspaceFolders
+                             , workspaceOptionsFileOperations = parsedFileOperations }
+      _ -> Left ("Unrecognized WorkspaceOptions value: " ++ ppJSON j)
+
+data WorkspaceOptions = WorkspaceOptions { workspaceOptionsWorkspaceFolders :: Maybe WorkspaceFoldersServerCapabilities
+                                         , workspaceOptionsFileOperations :: Maybe FileOperationOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceSymbol.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbol.curry
@@ -1,0 +1,26 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceSymbol where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.Location
+import LSP.Protocol.Types.LocationUriOnly
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceSymbol where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedLocation <- lookupFromJSON "location" vs
+           parsedData <- lookupMaybeFromJSON "data" vs
+           return
+            WorkspaceSymbol { workspaceSymbolLocation = parsedLocation
+                            , workspaceSymbolData = parsedData }
+      _ -> Left ("Unrecognized WorkspaceSymbol value: " ++ ppJSON j)
+
+data WorkspaceSymbol = WorkspaceSymbol { workspaceSymbolLocation :: Either Location LocationUriOnly
+                                       , workspaceSymbolData :: Maybe LSPAny }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceSymbolClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolClientCapabilities.curry
@@ -1,0 +1,37 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceSymbolClientCapabilities where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Types.ClientSymbolKindOptions
+import LSP.Protocol.Types.ClientSymbolResolveOptions
+import LSP.Protocol.Types.ClientSymbolTagOptions
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceSymbolClientCapabilities where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedDynamicRegistration <- lookupMaybeFromJSON
+                                         "dynamicRegistration"
+                                         vs
+           parsedSymbolKind <- lookupMaybeFromJSON "symbolKind" vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedResolveSupport <- lookupMaybeFromJSON "resolveSupport" vs
+           return
+            WorkspaceSymbolClientCapabilities { workspaceSymbolClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+                                              , workspaceSymbolClientCapabilitiesSymbolKind = parsedSymbolKind
+                                              , workspaceSymbolClientCapabilitiesTagSupport = parsedTagSupport
+                                              , workspaceSymbolClientCapabilitiesResolveSupport = parsedResolveSupport }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceSymbolClientCapabilities value: "
+           ++ ppJSON j)
+
+data WorkspaceSymbolClientCapabilities = WorkspaceSymbolClientCapabilities { workspaceSymbolClientCapabilitiesDynamicRegistration :: Maybe Bool
+                                                                           , workspaceSymbolClientCapabilitiesSymbolKind :: Maybe ClientSymbolKindOptions
+                                                                           , workspaceSymbolClientCapabilitiesTagSupport :: Maybe ClientSymbolTagOptions
+                                                                           , workspaceSymbolClientCapabilitiesResolveSupport :: Maybe ClientSymbolResolveOptions }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceSymbolOptions.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceSymbolOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceSymbolOptions where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider = parsedResolveProvider }
+      _ -> Left ("Unrecognized WorkspaceSymbolOptions value: " ++ ppJSON j)
+
+data WorkspaceSymbolOptions = WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider :: Maybe Bool }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceSymbolParams.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolParams.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceSymbolParams where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceSymbolParams where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedQuery <- lookupFromJSON "query" vs
+           return
+            WorkspaceSymbolParams { workspaceSymbolParamsQuery = parsedQuery }
+      _ -> Left ("Unrecognized WorkspaceSymbolParams value: " ++ ppJSON j)
+
+data WorkspaceSymbolParams = WorkspaceSymbolParams { workspaceSymbolParamsQuery :: String }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceSymbolRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolRegistrationOptions.curry
@@ -1,0 +1,20 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceSymbolRegistrationOptions where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceSymbolRegistrationOptions where
+  fromJSON j =
+    case j of
+      JObject vs -> do return WorkspaceSymbolRegistrationOptions {  }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceSymbolRegistrationOptions value: "
+           ++ ppJSON j)
+
+data WorkspaceSymbolRegistrationOptions = WorkspaceSymbolRegistrationOptions {  }
+ deriving (Show,Eq)
+

--- a/src/LSP/Protocol/Types/WorkspaceUnchangedDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceUnchangedDocumentDiagnosticReport.curry
@@ -1,0 +1,27 @@
+-- NOTE: This file is generated automatically and should not be edited manually!
+{-# OPTIONS_FRONTEND -Wno-unused-bindings -Wno-overlapping #-}
+module LSP.Protocol.Types.WorkspaceUnchangedDocumentDiagnosticReport where
+
+import JSON.Data
+import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Utils.JSON
+
+instance FromJSON WorkspaceUnchangedDocumentDiagnosticReport where
+  fromJSON j =
+    case j of
+      JObject vs ->
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedVersion <- lookupFromJSON "version" vs
+           return
+            WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri = parsedUri
+                                                       , workspaceUnchangedDocumentDiagnosticReportVersion = parsedVersion }
+      _ ->
+        Left
+         ("Unrecognized WorkspaceUnchangedDocumentDiagnosticReport value: "
+           ++ ppJSON j)
+
+data WorkspaceUnchangedDocumentDiagnosticReport = WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri :: DocumentUri
+                                                                                             , workspaceUnchangedDocumentDiagnosticReportVersion :: Either Int () }
+ deriving (Show,Eq)
+

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -1,12 +1,17 @@
 module LSP.Utils.General
-  ( lookup', fromJust', fromRight'
+  ( forM_
+  , lookup', fromJust', fromRight'
   , rightToMaybe, maybeToRight
   , capitalize, uncapitalize
-  , replaceSingle
+  , replace, replaceSingle
   , (<.$>), (<$.>)
   ) where
 
 import Data.Char ( toUpper, toLower )
+
+-- | Flipped version of mapM_.
+forM_ :: Monad m => [a] -> (a -> m b) -> m ()
+forM_ = flip mapM_
 
 -- | A version of fromJust that throws a descriptive error message.
 fromJust' :: String -> Maybe a -> a
@@ -45,6 +50,10 @@ capitalize (c:cs) = toUpper c : cs
 uncapitalize :: String -> String
 uncapitalize [] = []
 uncapitalize (c:cs) = toLower c : cs
+
+-- | Replaces an element with another.
+replace :: Eq a => a -> a -> [a] -> [a]
+replace x y = fmap $ \x' -> if x == x' then y else x'
 
 -- | Replaces an element with a list.
 replaceSingle :: Eq a => a -> [a] -> [a] -> [a]

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -3,7 +3,8 @@ module LSP.Utils.General
   , lookup', fromJust', fromRight'
   , rightToMaybe, maybeToRight
   , capitalize, uncapitalize
-  , replace, replaceSingle, unions
+  , replace, replaceSingle
+  , unions, unionMap
   , (<.$>), (<$.>)
   ) where
 
@@ -65,6 +66,10 @@ replaceSingle y ys (x:xs) | x == y    = ys ++ xs
 -- | The union over all sets.
 unions :: Ord a => [S.Set a] -> S.Set a
 unions = foldr S.union S.empty
+
+-- | Maps and forms a union. Analogous to concatMap for lists.
+unionMap :: Ord b => (a -> S.Set b) -> [a] -> S.Set b
+unionMap f = unions . map f
 
 -- | Maps over the first element of a tuple.
 (<.$>) :: Functor f => (a -> c) -> f (a, b) -> f (c, b)

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -3,11 +3,12 @@ module LSP.Utils.General
   , lookup', fromJust', fromRight'
   , rightToMaybe, maybeToRight
   , capitalize, uncapitalize
-  , replace, replaceSingle
+  , replace, replaceSingle, unions
   , (<.$>), (<$.>)
   ) where
 
 import Data.Char ( toUpper, toLower )
+import qualified Data.Set as S
 
 -- | Flipped version of mapM_.
 forM_ :: Monad m => [a] -> (a -> m b) -> m ()
@@ -60,6 +61,10 @@ replaceSingle :: Eq a => a -> [a] -> [a] -> [a]
 replaceSingle _ _ [] = []
 replaceSingle y ys (x:xs) | x == y    = ys ++ xs
                           | otherwise = x : replaceSingle y ys xs
+
+-- | The union over all sets.
+unions :: Ord a => [S.Set a] -> S.Set a
+unions = foldr S.union S.empty
 
 -- | Maps over the first element of a tuple.
 (<.$>) :: Functor f => (a -> c) -> f (a, b) -> f (c, b)

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -6,6 +6,7 @@ module LSP.Utils.General
   , replace, replaceSingle
   , unions, unionMap
   , (<.$>), (<$.>)
+  , keyBy
   ) where
 
 import Data.Char ( toUpper, toLower )
@@ -78,3 +79,7 @@ unionMap f = unions . map f
 -- | Maps over the second element of a tuple.
 (<$.>) :: Functor f => (b -> c) -> f (a, b) -> f (a, c)
 (<$.>) f = ((\(x, y) -> (x, f y)) <$>)
+
+-- | Associates the given value with the given key.
+keyBy :: (a -> k) -> a -> (k, a)
+keyBy f x = (f x, x)


### PR DESCRIPTION
Previously all types were generated into a single file with ~6k lines of Curry code that compiled to a ~280k line Haskell file. This was too large for KiCS2/GHC to handle, therefore we now generate a separate module for each LSP type (438 in total). Separate modules are easier to deal with incrementally and potentially parallelizable, thus much more efficient in practice.

The central challenge in doing this is figuring out the right imports, though this turns to out to be a simple AST traversal (see `LSP.Generation.Deps`). `LSP.Protocol.Types` is now an umbrella module that reexports the individual modules, unfortunately upstream `AbstractCurry` cannot not represent reexported modules yet, however, therefore we vendor and patch it (f58d75fa2ecc16709289c360ad774c1bf3fbb532).