### PR TITLE
Include inherited properties in generated LSP structures

### DIFF
--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -16,7 +16,7 @@ import qualified LSP.Generation.AbstractCurry.Build as ACB
 import qualified LSP.Generation.AbstractCurry.Pretty as ACP
 import LSP.Generation.Deps
 import LSP.Generation.Model
-import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), (<<$>>), unions, unionMap, keyBy )
+import LSP.Utils.General ( capitalize, uncapitalize, replaceSingle, (<$.>), (<<$>>), unions, unionMap, keyOn )
 
 -- TODO: Generate documentation
 -- See https://git.ps.informatik.uni-kiel.de/curry-packages/abstract-curry/-/issues/1
@@ -35,7 +35,7 @@ type GM = Reader GeneratorEnv
 -- | Creates the generator environment.
 generatorEnv :: String -> MetaModel -> GeneratorEnv
 generatorEnv mprefix m = GeneratorEnv
-  { geMetaStructures = M.fromList $ keyBy msName <$> mmStructures m
+  { geMetaStructures = M.fromList $ keyOn msName <$> mmStructures m
   , geModulePrefix = mprefix
   , geBuiltInTypeAliases = M.fromList
     [ ("LSPAny", support "LSPAny")
@@ -84,7 +84,7 @@ metaModelToProgs m = do
   mprefix <- asks geModulePrefix
   let progs = structs ++ enums ++ aliases
       umbrella = mkUmbrellaProg mprefix (ACS.progName <$> progs)
-  return $ keyBy ACS.progName <$> (umbrella : progs)
+  return $ keyOn ACS.progName <$> (umbrella : progs)
 
 -- | Generates an umbrella module that reexports the given modules.
 mkUmbrellaProg :: String -> [String] -> AC.CurryProg

--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -103,7 +103,7 @@ metaStructureToProg s = do
       vis = AC.Public
   fs <- mapM (metaPropertyToField mname name) props
   derivs <- asks geStandardDerivings
-  fromJSONInst <- metaStructureToFromJSONInstance mname name s
+  fromJSONInst <- flatMetaStructureToFromJSONInstance mname name s'
   let cdecl = AC.CRecord qn vis fs
       ty = AC.CType qn vis [] [cdecl] derivs
       insts = [fromJSONInst]
@@ -132,11 +132,9 @@ metaEnumerationToProg e = do
   return $ AC.CurryProg mname [] imps Nothing [] insts [ty] [] []
 
 -- | Converts a meta structure to a FromJSON instance.
-metaStructureToFromJSONInstance :: String -> String -> MetaStructure -> GM AC.CInstanceDecl
-metaStructureToFromJSONInstance mname prefix s = do
-  structs <- asks geMetaStructures
-  let s' = flattenMetaStructure structs s
-      name = escapeName $ msName s'
+flatMetaStructureToFromJSONInstance :: String -> String -> MetaStructure -> GM AC.CInstanceDecl
+flatMetaStructureToFromJSONInstance mname prefix s' = do
+  let name = escapeName $ msName s'
       qn = (mname, name)
       ctx = AC.CContext []
       vis = AC.Public

--- a/src/LSP/Generation/Model.curry
+++ b/src/LSP/Generation/Model.curry
@@ -10,9 +10,12 @@ module LSP.Generation.Model
   , MetaEnumeration (..)
   , MetaTypeAlias (..)
   , MetaModel (..)
+  , flattenMetaStructure
   ) where
 
-import Data.Maybe ( fromMaybe )
+import Data.List ( nub )
+import Data.Maybe ( fromMaybe, maybeToList )
+import qualified Data.Map as M
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
 import LSP.Utils.JSON ( FromJSON (..)
@@ -123,6 +126,20 @@ data MetaModel = MetaModel
   , mmTypeAliases :: [MetaTypeAlias]
   }
   deriving (Show, Eq)
+
+-- Utilities
+
+flattenMetaStructure :: M.Map String MetaStructure -> MetaStructure -> MetaStructure
+flattenMetaStructure structs s = s
+  { msProperties = nub $ inheritedProps ++ msProperties s
+  , msExtends = []
+  , msMixins = []
+  }
+  where
+    inheritedProps = do
+      MetaTypeReference n <- msExtends s ++ msMixins s
+      s' <- maybeToList $ M.lookup n structs
+      msProperties $ flattenMetaStructure structs s'
 
 -- JSON conversions
 
@@ -307,4 +324,3 @@ instance FromJSON MetaTypeAlias where
         , mtaDocumentation = doc
         }
     _ -> Left $ "Unrecognized MetaTypeAlias value: " ++ ppJSON j
-

--- a/src/LSP/Generation/Model.curry
+++ b/src/LSP/Generation/Model.curry
@@ -13,11 +13,11 @@ module LSP.Generation.Model
   , flattenMetaStructure
   ) where
 
-import Data.List ( nub )
 import Data.Maybe ( fromMaybe, maybeToList )
 import qualified Data.Map as M
 import JSON.Data ( JValue (..) )
 import JSON.Pretty ( ppJSON )
+import LSP.Utils.General ( nubOrdOn )
 import LSP.Utils.JSON ( FromJSON (..)
                       , lookupFromJSON, lookupFromJSON, lookupObjectFromJSON
                       , lookupMaybeFromJSON, lookupMaybeFromJSON, lookupPathFromJSON
@@ -131,7 +131,7 @@ data MetaModel = MetaModel
 
 flattenMetaStructure :: M.Map String MetaStructure -> MetaStructure -> MetaStructure
 flattenMetaStructure structs s = s
-  { msProperties = nub $ inheritedProps ++ msProperties s
+  { msProperties = nubOrdOn mpName $ inheritedProps ++ msProperties s
   , msExtends = []
   , msMixins = []
   }

--- a/src/LSP/Protocol/Types/AnnotatedTextEdit.curry
+++ b/src/LSP/Protocol/Types/AnnotatedTextEdit.curry
@@ -5,17 +5,24 @@ module LSP.Protocol.Types.AnnotatedTextEdit where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.ChangeAnnotationIdentifier
+import LSP.Protocol.Types.Range
 import LSP.Utils.JSON
 
 instance FromJSON AnnotatedTextEdit where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedAnnotationId <- lookupFromJSON "annotationId" vs
+        do parsedRange <- lookupFromJSON "range" vs
+           parsedNewText <- lookupFromJSON "newText" vs
+           parsedAnnotationId <- lookupFromJSON "annotationId" vs
            return
-            AnnotatedTextEdit { annotatedTextEditAnnotationId = parsedAnnotationId }
+            AnnotatedTextEdit { annotatedTextEditRange = parsedRange
+                              , annotatedTextEditNewText = parsedNewText
+                              , annotatedTextEditAnnotationId = parsedAnnotationId }
       _ -> Left ("Unrecognized AnnotatedTextEdit value: " ++ ppJSON j)
 
-data AnnotatedTextEdit = AnnotatedTextEdit { annotatedTextEditAnnotationId :: ChangeAnnotationIdentifier }
+data AnnotatedTextEdit = AnnotatedTextEdit { annotatedTextEditRange :: Range
+                                           , annotatedTextEditNewText :: String
+                                           , annotatedTextEditAnnotationId :: ChangeAnnotationIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/BaseInitializeParams.curry
+++ b/src/LSP/Protocol/Types/BaseInitializeParams.curry
@@ -7,6 +7,7 @@ import JSON.Pretty
 import LSP.Protocol.Support
 import LSP.Protocol.Types.ClientCapabilities
 import LSP.Protocol.Types.ClientInfo
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TraceValue
 import LSP.Utils.JSON
 
@@ -14,7 +15,8 @@ instance FromJSON BaseInitializeParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedProcessId <- lookupFromJSON "processId" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedProcessId <- lookupFromJSON "processId" vs
            parsedClientInfo <- lookupMaybeFromJSON "clientInfo" vs
            parsedLocale <- lookupMaybeFromJSON "locale" vs
            parsedRootPath <- lookupMaybeFromJSON "rootPath" vs
@@ -25,7 +27,8 @@ instance FromJSON BaseInitializeParams where
                                            vs
            parsedTrace <- lookupMaybeFromJSON "trace" vs
            return
-            BaseInitializeParams { baseInitializeParamsProcessId = parsedProcessId
+            BaseInitializeParams { baseInitializeParamsWorkDoneToken = parsedWorkDoneToken
+                                 , baseInitializeParamsProcessId = parsedProcessId
                                  , baseInitializeParamsClientInfo = parsedClientInfo
                                  , baseInitializeParamsLocale = parsedLocale
                                  , baseInitializeParamsRootPath = parsedRootPath
@@ -35,7 +38,8 @@ instance FromJSON BaseInitializeParams where
                                  , baseInitializeParamsTrace = parsedTrace }
       _ -> Left ("Unrecognized BaseInitializeParams value: " ++ ppJSON j)
 
-data BaseInitializeParams = BaseInitializeParams { baseInitializeParamsProcessId :: Either Int ()
+data BaseInitializeParams = BaseInitializeParams { baseInitializeParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , baseInitializeParamsProcessId :: Either Int ()
                                                  , baseInitializeParamsClientInfo :: Maybe ClientInfo
                                                  , baseInitializeParamsLocale :: Maybe String
                                                  , baseInitializeParamsRootPath :: Maybe (Either String ())

--- a/src/LSP/Protocol/Types/CallHierarchyIncomingCallsParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyIncomingCallsParams.curry
@@ -5,19 +5,28 @@ module LSP.Protocol.Types.CallHierarchyIncomingCallsParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Protocol.Types.ProgressToken
 import LSP.Utils.JSON
 
 instance FromJSON CallHierarchyIncomingCallsParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedItem <- lookupFromJSON "item" vs
            return
-            CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem = parsedItem }
+            CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsWorkDoneToken = parsedWorkDoneToken
+                                             , callHierarchyIncomingCallsParamsPartialResultToken = parsedPartialResultToken
+                                             , callHierarchyIncomingCallsParamsItem = parsedItem }
       _ ->
         Left
          ("Unrecognized CallHierarchyIncomingCallsParams value: " ++ ppJSON j)
 
-data CallHierarchyIncomingCallsParams = CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsItem :: CallHierarchyItem }
+data CallHierarchyIncomingCallsParams = CallHierarchyIncomingCallsParams { callHierarchyIncomingCallsParamsWorkDoneToken :: Maybe ProgressToken
+                                                                         , callHierarchyIncomingCallsParamsPartialResultToken :: Maybe ProgressToken
+                                                                         , callHierarchyIncomingCallsParamsItem :: CallHierarchyItem }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CallHierarchyOptions.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON CallHierarchyOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return CallHierarchyOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            CallHierarchyOptions { callHierarchyOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized CallHierarchyOptions value: " ++ ppJSON j)
 
-data CallHierarchyOptions = CallHierarchyOptions {  }
+data CallHierarchyOptions = CallHierarchyOptions { callHierarchyOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CallHierarchyOutgoingCallsParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyOutgoingCallsParams.curry
@@ -5,19 +5,28 @@ module LSP.Protocol.Types.CallHierarchyOutgoingCallsParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.CallHierarchyItem
+import LSP.Protocol.Types.ProgressToken
 import LSP.Utils.JSON
 
 instance FromJSON CallHierarchyOutgoingCallsParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedItem <- lookupFromJSON "item" vs
            return
-            CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem = parsedItem }
+            CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsWorkDoneToken = parsedWorkDoneToken
+                                             , callHierarchyOutgoingCallsParamsPartialResultToken = parsedPartialResultToken
+                                             , callHierarchyOutgoingCallsParamsItem = parsedItem }
       _ ->
         Left
          ("Unrecognized CallHierarchyOutgoingCallsParams value: " ++ ppJSON j)
 
-data CallHierarchyOutgoingCallsParams = CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsItem :: CallHierarchyItem }
+data CallHierarchyOutgoingCallsParams = CallHierarchyOutgoingCallsParams { callHierarchyOutgoingCallsParamsWorkDoneToken :: Maybe ProgressToken
+                                                                         , callHierarchyOutgoingCallsParamsPartialResultToken :: Maybe ProgressToken
+                                                                         , callHierarchyOutgoingCallsParamsItem :: CallHierarchyItem }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CallHierarchyPrepareParams.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyPrepareParams.curry
@@ -4,15 +4,27 @@ module LSP.Protocol.Types.CallHierarchyPrepareParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON CallHierarchyPrepareParams where
   fromJSON j =
     case j of
-      JObject vs -> do return CallHierarchyPrepareParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            CallHierarchyPrepareParams { callHierarchyPrepareParamsTextDocument = parsedTextDocument
+                                       , callHierarchyPrepareParamsPosition = parsedPosition
+                                       , callHierarchyPrepareParamsWorkDoneToken = parsedWorkDoneToken }
       _ ->
         Left ("Unrecognized CallHierarchyPrepareParams value: " ++ ppJSON j)
 
-data CallHierarchyPrepareParams = CallHierarchyPrepareParams {  }
+data CallHierarchyPrepareParams = CallHierarchyPrepareParams { callHierarchyPrepareParamsTextDocument :: TextDocumentIdentifier
+                                                             , callHierarchyPrepareParamsPosition :: Position
+                                                             , callHierarchyPrepareParamsWorkDoneToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CallHierarchyRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CallHierarchyRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.CallHierarchyRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON CallHierarchyRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return CallHierarchyRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            CallHierarchyRegistrationOptions { callHierarchyRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                             , callHierarchyRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                             , callHierarchyRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized CallHierarchyRegistrationOptions value: " ++ ppJSON j)
 
-data CallHierarchyRegistrationOptions = CallHierarchyRegistrationOptions {  }
+data CallHierarchyRegistrationOptions = CallHierarchyRegistrationOptions { callHierarchyRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                         , callHierarchyRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                         , callHierarchyRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CodeActionOptions.curry
+++ b/src/LSP/Protocol/Types/CodeActionOptions.curry
@@ -12,16 +12,19 @@ instance FromJSON CodeActionOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedCodeActionKinds <- lookupMaybeFromJSON "codeActionKinds" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedCodeActionKinds <- lookupMaybeFromJSON "codeActionKinds" vs
            parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
            parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            return
-            CodeActionOptions { codeActionOptionsCodeActionKinds = parsedCodeActionKinds
+            CodeActionOptions { codeActionOptionsWorkDoneProgress = parsedWorkDoneProgress
+                              , codeActionOptionsCodeActionKinds = parsedCodeActionKinds
                               , codeActionOptionsDocumentation = parsedDocumentation
                               , codeActionOptionsResolveProvider = parsedResolveProvider }
       _ -> Left ("Unrecognized CodeActionOptions value: " ++ ppJSON j)
 
-data CodeActionOptions = CodeActionOptions { codeActionOptionsCodeActionKinds :: Maybe [CodeActionKind]
+data CodeActionOptions = CodeActionOptions { codeActionOptionsWorkDoneProgress :: Maybe Bool
+                                           , codeActionOptionsCodeActionKinds :: Maybe [CodeActionKind]
                                            , codeActionOptionsDocumentation :: Maybe [CodeActionKindDocumentation]
                                            , codeActionOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/CodeActionParams.curry
+++ b/src/LSP/Protocol/Types/CodeActionParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.CodeActionParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.CodeActionContext
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -13,16 +14,24 @@ instance FromJSON CodeActionParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRange <- lookupFromJSON "range" vs
            parsedContext <- lookupFromJSON "context" vs
            return
-            CodeActionParams { codeActionParamsTextDocument = parsedTextDocument
+            CodeActionParams { codeActionParamsWorkDoneToken = parsedWorkDoneToken
+                             , codeActionParamsPartialResultToken = parsedPartialResultToken
+                             , codeActionParamsTextDocument = parsedTextDocument
                              , codeActionParamsRange = parsedRange
                              , codeActionParamsContext = parsedContext }
       _ -> Left ("Unrecognized CodeActionParams value: " ++ ppJSON j)
 
-data CodeActionParams = CodeActionParams { codeActionParamsTextDocument :: TextDocumentIdentifier
+data CodeActionParams = CodeActionParams { codeActionParamsWorkDoneToken :: Maybe ProgressToken
+                                         , codeActionParamsPartialResultToken :: Maybe ProgressToken
+                                         , codeActionParamsTextDocument :: TextDocumentIdentifier
                                          , codeActionParamsRange :: Range
                                          , codeActionParamsContext :: CodeActionContext }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/CodeActionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CodeActionRegistrationOptions.curry
@@ -4,16 +4,34 @@ module LSP.Protocol.Types.CodeActionRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.CodeActionKind
+import LSP.Protocol.Types.CodeActionKindDocumentation
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON CodeActionRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return CodeActionRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedCodeActionKinds <- lookupMaybeFromJSON "codeActionKinds" vs
+           parsedDocumentation <- lookupMaybeFromJSON "documentation" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            CodeActionRegistrationOptions { codeActionRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                          , codeActionRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                          , codeActionRegistrationOptionsCodeActionKinds = parsedCodeActionKinds
+                                          , codeActionRegistrationOptionsDocumentation = parsedDocumentation
+                                          , codeActionRegistrationOptionsResolveProvider = parsedResolveProvider }
       _ ->
         Left
          ("Unrecognized CodeActionRegistrationOptions value: " ++ ppJSON j)
 
-data CodeActionRegistrationOptions = CodeActionRegistrationOptions {  }
+data CodeActionRegistrationOptions = CodeActionRegistrationOptions { codeActionRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                   , codeActionRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                   , codeActionRegistrationOptionsCodeActionKinds :: Maybe [CodeActionKind]
+                                                                   , codeActionRegistrationOptionsDocumentation :: Maybe [CodeActionKindDocumentation]
+                                                                   , codeActionRegistrationOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CodeLensOptions.curry
+++ b/src/LSP/Protocol/Types/CodeLensOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON CodeLensOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            return
-            CodeLensOptions { codeLensOptionsResolveProvider = parsedResolveProvider }
+            CodeLensOptions { codeLensOptionsWorkDoneProgress = parsedWorkDoneProgress
+                            , codeLensOptionsResolveProvider = parsedResolveProvider }
       _ -> Left ("Unrecognized CodeLensOptions value: " ++ ppJSON j)
 
-data CodeLensOptions = CodeLensOptions { codeLensOptionsResolveProvider :: Maybe Bool }
+data CodeLensOptions = CodeLensOptions { codeLensOptionsWorkDoneProgress :: Maybe Bool
+                                       , codeLensOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CodeLensParams.curry
+++ b/src/LSP/Protocol/Types/CodeLensParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.CodeLensParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON CodeLensParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            CodeLensParams { codeLensParamsTextDocument = parsedTextDocument }
+            CodeLensParams { codeLensParamsWorkDoneToken = parsedWorkDoneToken
+                           , codeLensParamsPartialResultToken = parsedPartialResultToken
+                           , codeLensParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized CodeLensParams value: " ++ ppJSON j)
 
-data CodeLensParams = CodeLensParams { codeLensParamsTextDocument :: TextDocumentIdentifier }
+data CodeLensParams = CodeLensParams { codeLensParamsWorkDoneToken :: Maybe ProgressToken
+                                     , codeLensParamsPartialResultToken :: Maybe ProgressToken
+                                     , codeLensParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CodeLensRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CodeLensRegistrationOptions.curry
@@ -4,15 +4,25 @@ module LSP.Protocol.Types.CodeLensRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON CodeLensRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return CodeLensRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            CodeLensRegistrationOptions { codeLensRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                        , codeLensRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                        , codeLensRegistrationOptionsResolveProvider = parsedResolveProvider }
       _ ->
         Left ("Unrecognized CodeLensRegistrationOptions value: " ++ ppJSON j)
 
-data CodeLensRegistrationOptions = CodeLensRegistrationOptions {  }
+data CodeLensRegistrationOptions = CodeLensRegistrationOptions { codeLensRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                               , codeLensRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                               , codeLensRegistrationOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ColorPresentationParams.curry
+++ b/src/LSP/Protocol/Types/ColorPresentationParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.ColorPresentationParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.Color
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -13,16 +14,24 @@ instance FromJSON ColorPresentationParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedColor <- lookupFromJSON "color" vs
            parsedRange <- lookupFromJSON "range" vs
            return
-            ColorPresentationParams { colorPresentationParamsTextDocument = parsedTextDocument
+            ColorPresentationParams { colorPresentationParamsWorkDoneToken = parsedWorkDoneToken
+                                    , colorPresentationParamsPartialResultToken = parsedPartialResultToken
+                                    , colorPresentationParamsTextDocument = parsedTextDocument
                                     , colorPresentationParamsColor = parsedColor
                                     , colorPresentationParamsRange = parsedRange }
       _ -> Left ("Unrecognized ColorPresentationParams value: " ++ ppJSON j)
 
-data ColorPresentationParams = ColorPresentationParams { colorPresentationParamsTextDocument :: TextDocumentIdentifier
+data ColorPresentationParams = ColorPresentationParams { colorPresentationParamsWorkDoneToken :: Maybe ProgressToken
+                                                       , colorPresentationParamsPartialResultToken :: Maybe ProgressToken
+                                                       , colorPresentationParamsTextDocument :: TextDocumentIdentifier
                                                        , colorPresentationParamsColor :: Color
                                                        , colorPresentationParamsRange :: Range }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/CompletionOptions.curry
+++ b/src/LSP/Protocol/Types/CompletionOptions.curry
@@ -11,7 +11,8 @@ instance FromJSON CompletionOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
                                        vs
            parsedAllCommitCharacters <- lookupMaybeFromJSON
                                          "allCommitCharacters"
@@ -19,13 +20,15 @@ instance FromJSON CompletionOptions where
            parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
            return
-            CompletionOptions { completionOptionsTriggerCharacters = parsedTriggerCharacters
+            CompletionOptions { completionOptionsWorkDoneProgress = parsedWorkDoneProgress
+                              , completionOptionsTriggerCharacters = parsedTriggerCharacters
                               , completionOptionsAllCommitCharacters = parsedAllCommitCharacters
                               , completionOptionsResolveProvider = parsedResolveProvider
                               , completionOptionsCompletionItem = parsedCompletionItem }
       _ -> Left ("Unrecognized CompletionOptions value: " ++ ppJSON j)
 
-data CompletionOptions = CompletionOptions { completionOptionsTriggerCharacters :: Maybe [String]
+data CompletionOptions = CompletionOptions { completionOptionsWorkDoneProgress :: Maybe Bool
+                                           , completionOptionsTriggerCharacters :: Maybe [String]
                                            , completionOptionsAllCommitCharacters :: Maybe [String]
                                            , completionOptionsResolveProvider :: Maybe Bool
                                            , completionOptionsCompletionItem :: Maybe ServerCompletionItemOptions }

--- a/src/LSP/Protocol/Types/CompletionParams.curry
+++ b/src/LSP/Protocol/Types/CompletionParams.curry
@@ -5,16 +5,34 @@ module LSP.Protocol.Types.CompletionParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.CompletionContext
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON CompletionParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedContext <- lookupMaybeFromJSON "context" vs
-           return CompletionParams { completionParamsContext = parsedContext }
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedContext <- lookupMaybeFromJSON "context" vs
+           return
+            CompletionParams { completionParamsTextDocument = parsedTextDocument
+                             , completionParamsPosition = parsedPosition
+                             , completionParamsWorkDoneToken = parsedWorkDoneToken
+                             , completionParamsPartialResultToken = parsedPartialResultToken
+                             , completionParamsContext = parsedContext }
       _ -> Left ("Unrecognized CompletionParams value: " ++ ppJSON j)
 
-data CompletionParams = CompletionParams { completionParamsContext :: Maybe CompletionContext }
+data CompletionParams = CompletionParams { completionParamsTextDocument :: TextDocumentIdentifier
+                                         , completionParamsPosition :: Position
+                                         , completionParamsWorkDoneToken :: Maybe ProgressToken
+                                         , completionParamsPartialResultToken :: Maybe ProgressToken
+                                         , completionParamsContext :: Maybe CompletionContext }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CompletionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/CompletionRegistrationOptions.curry
@@ -4,16 +4,39 @@ module LSP.Protocol.Types.CompletionRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
+import LSP.Protocol.Types.ServerCompletionItemOptions
 import LSP.Utils.JSON
 
 instance FromJSON CompletionRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return CompletionRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+                                       vs
+           parsedAllCommitCharacters <- lookupMaybeFromJSON
+                                         "allCommitCharacters"
+                                         vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           parsedCompletionItem <- lookupMaybeFromJSON "completionItem" vs
+           return
+            CompletionRegistrationOptions { completionRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                          , completionRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                          , completionRegistrationOptionsTriggerCharacters = parsedTriggerCharacters
+                                          , completionRegistrationOptionsAllCommitCharacters = parsedAllCommitCharacters
+                                          , completionRegistrationOptionsResolveProvider = parsedResolveProvider
+                                          , completionRegistrationOptionsCompletionItem = parsedCompletionItem }
       _ ->
         Left
          ("Unrecognized CompletionRegistrationOptions value: " ++ ppJSON j)
 
-data CompletionRegistrationOptions = CompletionRegistrationOptions {  }
+data CompletionRegistrationOptions = CompletionRegistrationOptions { completionRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                   , completionRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                   , completionRegistrationOptionsTriggerCharacters :: Maybe [String]
+                                                                   , completionRegistrationOptionsAllCommitCharacters :: Maybe [String]
+                                                                   , completionRegistrationOptionsResolveProvider :: Maybe Bool
+                                                                   , completionRegistrationOptionsCompletionItem :: Maybe ServerCompletionItemOptions }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/CreateFile.curry
+++ b/src/LSP/Protocol/Types/CreateFile.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.CreateFile where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
 import LSP.Protocol.Types.CreateFileOptions
 import LSP.Utils.JSON
 
@@ -13,15 +14,18 @@ instance FromJSON CreateFile where
     case j of
       JObject vs ->
         do parsedKind <- lookupFromJSON "kind" vs
+           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
            parsedUri <- lookupFromJSON "uri" vs
            parsedOptions <- lookupMaybeFromJSON "options" vs
            return
             CreateFile { createFileKind = parsedKind
+                       , createFileAnnotationId = parsedAnnotationId
                        , createFileUri = parsedUri
                        , createFileOptions = parsedOptions }
       _ -> Left ("Unrecognized CreateFile value: " ++ ppJSON j)
 
 data CreateFile = CreateFile { createFileKind :: String
+                             , createFileAnnotationId :: Maybe ChangeAnnotationIdentifier
                              , createFileUri :: DocumentUri
                              , createFileOptions :: Maybe CreateFileOptions }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DeclarationOptions.curry
+++ b/src/LSP/Protocol/Types/DeclarationOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON DeclarationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DeclarationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DeclarationOptions { declarationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized DeclarationOptions value: " ++ ppJSON j)
 
-data DeclarationOptions = DeclarationOptions {  }
+data DeclarationOptions = DeclarationOptions { declarationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DeclarationParams.curry
+++ b/src/LSP/Protocol/Types/DeclarationParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.DeclarationParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON DeclarationParams where
   fromJSON j =
     case j of
-      JObject vs -> do return DeclarationParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            DeclarationParams { declarationParamsTextDocument = parsedTextDocument
+                              , declarationParamsPosition = parsedPosition
+                              , declarationParamsWorkDoneToken = parsedWorkDoneToken
+                              , declarationParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized DeclarationParams value: " ++ ppJSON j)
 
-data DeclarationParams = DeclarationParams {  }
+data DeclarationParams = DeclarationParams { declarationParamsTextDocument :: TextDocumentIdentifier
+                                           , declarationParamsPosition :: Position
+                                           , declarationParamsWorkDoneToken :: Maybe ProgressToken
+                                           , declarationParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DeclarationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DeclarationRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.DeclarationRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DeclarationRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DeclarationRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            DeclarationRegistrationOptions { declarationRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                           , declarationRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                           , declarationRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized DeclarationRegistrationOptions value: " ++ ppJSON j)
 
-data DeclarationRegistrationOptions = DeclarationRegistrationOptions {  }
+data DeclarationRegistrationOptions = DeclarationRegistrationOptions { declarationRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                     , declarationRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                     , declarationRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DefinitionOptions.curry
+++ b/src/LSP/Protocol/Types/DefinitionOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON DefinitionOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DefinitionOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DefinitionOptions { definitionOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized DefinitionOptions value: " ++ ppJSON j)
 
-data DefinitionOptions = DefinitionOptions {  }
+data DefinitionOptions = DefinitionOptions { definitionOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DefinitionParams.curry
+++ b/src/LSP/Protocol/Types/DefinitionParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.DefinitionParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON DefinitionParams where
   fromJSON j =
     case j of
-      JObject vs -> do return DefinitionParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            DefinitionParams { definitionParamsTextDocument = parsedTextDocument
+                             , definitionParamsPosition = parsedPosition
+                             , definitionParamsWorkDoneToken = parsedWorkDoneToken
+                             , definitionParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized DefinitionParams value: " ++ ppJSON j)
 
-data DefinitionParams = DefinitionParams {  }
+data DefinitionParams = DefinitionParams { definitionParamsTextDocument :: TextDocumentIdentifier
+                                         , definitionParamsPosition :: Position
+                                         , definitionParamsWorkDoneToken :: Maybe ProgressToken
+                                         , definitionParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DefinitionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DefinitionRegistrationOptions.curry
@@ -4,16 +4,23 @@ module LSP.Protocol.Types.DefinitionRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DefinitionRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DefinitionRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DefinitionRegistrationOptions { definitionRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                          , definitionRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ ->
         Left
          ("Unrecognized DefinitionRegistrationOptions value: " ++ ppJSON j)
 
-data DefinitionRegistrationOptions = DefinitionRegistrationOptions {  }
+data DefinitionRegistrationOptions = DefinitionRegistrationOptions { definitionRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                   , definitionRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DeleteFile.curry
+++ b/src/LSP/Protocol/Types/DeleteFile.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.DeleteFile where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
 import LSP.Protocol.Types.DeleteFileOptions
 import LSP.Utils.JSON
 
@@ -13,15 +14,18 @@ instance FromJSON DeleteFile where
     case j of
       JObject vs ->
         do parsedKind <- lookupFromJSON "kind" vs
+           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
            parsedUri <- lookupFromJSON "uri" vs
            parsedOptions <- lookupMaybeFromJSON "options" vs
            return
             DeleteFile { deleteFileKind = parsedKind
+                       , deleteFileAnnotationId = parsedAnnotationId
                        , deleteFileUri = parsedUri
                        , deleteFileOptions = parsedOptions }
       _ -> Left ("Unrecognized DeleteFile value: " ++ ppJSON j)
 
 data DeleteFile = DeleteFile { deleteFileKind :: String
+                             , deleteFileAnnotationId :: Maybe ChangeAnnotationIdentifier
                              , deleteFileUri :: DocumentUri
                              , deleteFileOptions :: Maybe DeleteFileOptions }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DiagnosticClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/DiagnosticClientCapabilities.curry
@@ -4,25 +4,42 @@ module LSP.Protocol.Types.DiagnosticClientCapabilities where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ClientDiagnosticsTagOptions
 import LSP.Utils.JSON
 
 instance FromJSON DiagnosticClientCapabilities where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedDynamicRegistration <- lookupMaybeFromJSON
+        do parsedRelatedInformation <- lookupMaybeFromJSON
+                                        "relatedInformation"
+                                        vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedCodeDescriptionSupport <- lookupMaybeFromJSON
+                                            "codeDescriptionSupport"
+                                            vs
+           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
+           parsedDynamicRegistration <- lookupMaybeFromJSON
                                          "dynamicRegistration"
                                          vs
            parsedRelatedDocumentSupport <- lookupMaybeFromJSON
                                             "relatedDocumentSupport"
                                             vs
            return
-            DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
+            DiagnosticClientCapabilities { diagnosticClientCapabilitiesRelatedInformation = parsedRelatedInformation
+                                         , diagnosticClientCapabilitiesTagSupport = parsedTagSupport
+                                         , diagnosticClientCapabilitiesCodeDescriptionSupport = parsedCodeDescriptionSupport
+                                         , diagnosticClientCapabilitiesDataSupport = parsedDataSupport
+                                         , diagnosticClientCapabilitiesDynamicRegistration = parsedDynamicRegistration
                                          , diagnosticClientCapabilitiesRelatedDocumentSupport = parsedRelatedDocumentSupport }
       _ ->
         Left ("Unrecognized DiagnosticClientCapabilities value: " ++ ppJSON j)
 
-data DiagnosticClientCapabilities = DiagnosticClientCapabilities { diagnosticClientCapabilitiesDynamicRegistration :: Maybe Bool
+data DiagnosticClientCapabilities = DiagnosticClientCapabilities { diagnosticClientCapabilitiesRelatedInformation :: Maybe Bool
+                                                                 , diagnosticClientCapabilitiesTagSupport :: Maybe ClientDiagnosticsTagOptions
+                                                                 , diagnosticClientCapabilitiesCodeDescriptionSupport :: Maybe Bool
+                                                                 , diagnosticClientCapabilitiesDataSupport :: Maybe Bool
+                                                                 , diagnosticClientCapabilitiesDynamicRegistration :: Maybe Bool
                                                                  , diagnosticClientCapabilitiesRelatedDocumentSupport :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DiagnosticOptions.curry
+++ b/src/LSP/Protocol/Types/DiagnosticOptions.curry
@@ -10,19 +10,22 @@ instance FromJSON DiagnosticOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
            parsedInterFileDependencies <- lookupFromJSON
                                            "interFileDependencies"
                                            vs
            parsedWorkspaceDiagnostics <- lookupFromJSON "workspaceDiagnostics"
                                           vs
            return
-            DiagnosticOptions { diagnosticOptionsIdentifier = parsedIdentifier
+            DiagnosticOptions { diagnosticOptionsWorkDoneProgress = parsedWorkDoneProgress
+                              , diagnosticOptionsIdentifier = parsedIdentifier
                               , diagnosticOptionsInterFileDependencies = parsedInterFileDependencies
                               , diagnosticOptionsWorkspaceDiagnostics = parsedWorkspaceDiagnostics }
       _ -> Left ("Unrecognized DiagnosticOptions value: " ++ ppJSON j)
 
-data DiagnosticOptions = DiagnosticOptions { diagnosticOptionsIdentifier :: Maybe String
+data DiagnosticOptions = DiagnosticOptions { diagnosticOptionsWorkDoneProgress :: Maybe Bool
+                                           , diagnosticOptionsIdentifier :: Maybe String
                                            , diagnosticOptionsInterFileDependencies :: Bool
                                            , diagnosticOptionsWorkspaceDiagnostics :: Bool }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DiagnosticRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DiagnosticRegistrationOptions.curry
@@ -4,16 +4,38 @@ module LSP.Protocol.Types.DiagnosticRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DiagnosticRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DiagnosticRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+           parsedInterFileDependencies <- lookupFromJSON
+                                           "interFileDependencies"
+                                           vs
+           parsedWorkspaceDiagnostics <- lookupFromJSON "workspaceDiagnostics"
+                                          vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            DiagnosticRegistrationOptions { diagnosticRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                          , diagnosticRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                          , diagnosticRegistrationOptionsIdentifier = parsedIdentifier
+                                          , diagnosticRegistrationOptionsInterFileDependencies = parsedInterFileDependencies
+                                          , diagnosticRegistrationOptionsWorkspaceDiagnostics = parsedWorkspaceDiagnostics
+                                          , diagnosticRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized DiagnosticRegistrationOptions value: " ++ ppJSON j)
 
-data DiagnosticRegistrationOptions = DiagnosticRegistrationOptions {  }
+data DiagnosticRegistrationOptions = DiagnosticRegistrationOptions { diagnosticRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                   , diagnosticRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                   , diagnosticRegistrationOptionsIdentifier :: Maybe String
+                                                                   , diagnosticRegistrationOptionsInterFileDependencies :: Bool
+                                                                   , diagnosticRegistrationOptionsWorkspaceDiagnostics :: Bool
+                                                                   , diagnosticRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentColorOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentColorOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON DocumentColorOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentColorOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DocumentColorOptions { documentColorOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized DocumentColorOptions value: " ++ ppJSON j)
 
-data DocumentColorOptions = DocumentColorOptions {  }
+data DocumentColorOptions = DocumentColorOptions { documentColorOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentColorParams.curry
+++ b/src/LSP/Protocol/Types/DocumentColorParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.DocumentColorParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON DocumentColorParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            DocumentColorParams { documentColorParamsTextDocument = parsedTextDocument }
+            DocumentColorParams { documentColorParamsWorkDoneToken = parsedWorkDoneToken
+                                , documentColorParamsPartialResultToken = parsedPartialResultToken
+                                , documentColorParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized DocumentColorParams value: " ++ ppJSON j)
 
-data DocumentColorParams = DocumentColorParams { documentColorParamsTextDocument :: TextDocumentIdentifier }
+data DocumentColorParams = DocumentColorParams { documentColorParamsWorkDoneToken :: Maybe ProgressToken
+                                               , documentColorParamsPartialResultToken :: Maybe ProgressToken
+                                               , documentColorParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentColorRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentColorRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.DocumentColorRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentColorRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentColorRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            DocumentColorRegistrationOptions { documentColorRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                             , documentColorRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                             , documentColorRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized DocumentColorRegistrationOptions value: " ++ ppJSON j)
 
-data DocumentColorRegistrationOptions = DocumentColorRegistrationOptions {  }
+data DocumentColorRegistrationOptions = DocumentColorRegistrationOptions { documentColorRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                         , documentColorRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                         , documentColorRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentDiagnosticParams.curry
+++ b/src/LSP/Protocol/Types/DocumentDiagnosticParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.DocumentDiagnosticParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,16 +12,24 @@ instance FromJSON DocumentDiagnosticParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
            parsedPreviousResultId <- lookupMaybeFromJSON "previousResultId" vs
            return
-            DocumentDiagnosticParams { documentDiagnosticParamsTextDocument = parsedTextDocument
+            DocumentDiagnosticParams { documentDiagnosticParamsWorkDoneToken = parsedWorkDoneToken
+                                     , documentDiagnosticParamsPartialResultToken = parsedPartialResultToken
+                                     , documentDiagnosticParamsTextDocument = parsedTextDocument
                                      , documentDiagnosticParamsIdentifier = parsedIdentifier
                                      , documentDiagnosticParamsPreviousResultId = parsedPreviousResultId }
       _ -> Left ("Unrecognized DocumentDiagnosticParams value: " ++ ppJSON j)
 
-data DocumentDiagnosticParams = DocumentDiagnosticParams { documentDiagnosticParamsTextDocument :: TextDocumentIdentifier
+data DocumentDiagnosticParams = DocumentDiagnosticParams { documentDiagnosticParamsWorkDoneToken :: Maybe ProgressToken
+                                                         , documentDiagnosticParamsPartialResultToken :: Maybe ProgressToken
+                                                         , documentDiagnosticParamsTextDocument :: TextDocumentIdentifier
                                                          , documentDiagnosticParamsIdentifier :: Maybe String
                                                          , documentDiagnosticParamsPreviousResultId :: Maybe String }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DocumentFormattingOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON DocumentFormattingOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentFormattingOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DocumentFormattingOptions { documentFormattingOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized DocumentFormattingOptions value: " ++ ppJSON j)
 
-data DocumentFormattingOptions = DocumentFormattingOptions {  }
+data DocumentFormattingOptions = DocumentFormattingOptions { documentFormattingOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.DocumentFormattingParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -12,14 +13,17 @@ instance FromJSON DocumentFormattingParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedOptions <- lookupFromJSON "options" vs
            return
-            DocumentFormattingParams { documentFormattingParamsTextDocument = parsedTextDocument
+            DocumentFormattingParams { documentFormattingParamsWorkDoneToken = parsedWorkDoneToken
+                                     , documentFormattingParamsTextDocument = parsedTextDocument
                                      , documentFormattingParamsOptions = parsedOptions }
       _ -> Left ("Unrecognized DocumentFormattingParams value: " ++ ppJSON j)
 
-data DocumentFormattingParams = DocumentFormattingParams { documentFormattingParamsTextDocument :: TextDocumentIdentifier
+data DocumentFormattingParams = DocumentFormattingParams { documentFormattingParamsWorkDoneToken :: Maybe ProgressToken
+                                                         , documentFormattingParamsTextDocument :: TextDocumentIdentifier
                                                          , documentFormattingParamsOptions :: FormattingOptions }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentFormattingRegistrationOptions.curry
@@ -4,17 +4,24 @@ module LSP.Protocol.Types.DocumentFormattingRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentFormattingRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentFormattingRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DocumentFormattingRegistrationOptions { documentFormattingRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                  , documentFormattingRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ ->
         Left
          ("Unrecognized DocumentFormattingRegistrationOptions value: "
            ++ ppJSON j)
 
-data DocumentFormattingRegistrationOptions = DocumentFormattingRegistrationOptions {  }
+data DocumentFormattingRegistrationOptions = DocumentFormattingRegistrationOptions { documentFormattingRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                   , documentFormattingRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentHighlightOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON DocumentHighlightOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentHighlightOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DocumentHighlightOptions { documentHighlightOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized DocumentHighlightOptions value: " ++ ppJSON j)
 
-data DocumentHighlightOptions = DocumentHighlightOptions {  }
+data DocumentHighlightOptions = DocumentHighlightOptions { documentHighlightOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentHighlightParams.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.DocumentHighlightParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON DocumentHighlightParams where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentHighlightParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            DocumentHighlightParams { documentHighlightParamsTextDocument = parsedTextDocument
+                                    , documentHighlightParamsPosition = parsedPosition
+                                    , documentHighlightParamsWorkDoneToken = parsedWorkDoneToken
+                                    , documentHighlightParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized DocumentHighlightParams value: " ++ ppJSON j)
 
-data DocumentHighlightParams = DocumentHighlightParams {  }
+data DocumentHighlightParams = DocumentHighlightParams { documentHighlightParamsTextDocument :: TextDocumentIdentifier
+                                                       , documentHighlightParamsPosition :: Position
+                                                       , documentHighlightParamsWorkDoneToken :: Maybe ProgressToken
+                                                       , documentHighlightParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentHighlightRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentHighlightRegistrationOptions.curry
@@ -4,17 +4,24 @@ module LSP.Protocol.Types.DocumentHighlightRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentHighlightRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentHighlightRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            DocumentHighlightRegistrationOptions { documentHighlightRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                 , documentHighlightRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ ->
         Left
          ("Unrecognized DocumentHighlightRegistrationOptions value: "
            ++ ppJSON j)
 
-data DocumentHighlightRegistrationOptions = DocumentHighlightRegistrationOptions {  }
+data DocumentHighlightRegistrationOptions = DocumentHighlightRegistrationOptions { documentHighlightRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                 , documentHighlightRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentLinkOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON DocumentLinkOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            return
-            DocumentLinkOptions { documentLinkOptionsResolveProvider = parsedResolveProvider }
+            DocumentLinkOptions { documentLinkOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                , documentLinkOptionsResolveProvider = parsedResolveProvider }
       _ -> Left ("Unrecognized DocumentLinkOptions value: " ++ ppJSON j)
 
-data DocumentLinkOptions = DocumentLinkOptions { documentLinkOptionsResolveProvider :: Maybe Bool }
+data DocumentLinkOptions = DocumentLinkOptions { documentLinkOptionsWorkDoneProgress :: Maybe Bool
+                                               , documentLinkOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentLinkParams.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.DocumentLinkParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON DocumentLinkParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            DocumentLinkParams { documentLinkParamsTextDocument = parsedTextDocument }
+            DocumentLinkParams { documentLinkParamsWorkDoneToken = parsedWorkDoneToken
+                               , documentLinkParamsPartialResultToken = parsedPartialResultToken
+                               , documentLinkParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized DocumentLinkParams value: " ++ ppJSON j)
 
-data DocumentLinkParams = DocumentLinkParams { documentLinkParamsTextDocument :: TextDocumentIdentifier }
+data DocumentLinkParams = DocumentLinkParams { documentLinkParamsWorkDoneToken :: Maybe ProgressToken
+                                             , documentLinkParamsPartialResultToken :: Maybe ProgressToken
+                                             , documentLinkParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentLinkRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentLinkRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.DocumentLinkRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentLinkRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentLinkRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            DocumentLinkRegistrationOptions { documentLinkRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                            , documentLinkRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                            , documentLinkRegistrationOptionsResolveProvider = parsedResolveProvider }
       _ ->
         Left
          ("Unrecognized DocumentLinkRegistrationOptions value: " ++ ppJSON j)
 
-data DocumentLinkRegistrationOptions = DocumentLinkRegistrationOptions {  }
+data DocumentLinkRegistrationOptions = DocumentLinkRegistrationOptions { documentLinkRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                       , documentLinkRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                       , documentLinkRegistrationOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentOnTypeFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentOnTypeFormattingRegistrationOptions.curry
@@ -4,17 +4,31 @@ module LSP.Protocol.Types.DocumentOnTypeFormattingRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentOnTypeFormattingRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentOnTypeFormattingRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedFirstTriggerCharacter <- lookupFromJSON
+                                           "firstTriggerCharacter"
+                                           vs
+           parsedMoreTriggerCharacter <- lookupMaybeFromJSON
+                                          "moreTriggerCharacter"
+                                          vs
+           return
+            DocumentOnTypeFormattingRegistrationOptions { documentOnTypeFormattingRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                        , documentOnTypeFormattingRegistrationOptionsFirstTriggerCharacter = parsedFirstTriggerCharacter
+                                                        , documentOnTypeFormattingRegistrationOptionsMoreTriggerCharacter = parsedMoreTriggerCharacter }
       _ ->
         Left
          ("Unrecognized DocumentOnTypeFormattingRegistrationOptions value: "
            ++ ppJSON j)
 
-data DocumentOnTypeFormattingRegistrationOptions = DocumentOnTypeFormattingRegistrationOptions {  }
+data DocumentOnTypeFormattingRegistrationOptions = DocumentOnTypeFormattingRegistrationOptions { documentOnTypeFormattingRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                               , documentOnTypeFormattingRegistrationOptionsFirstTriggerCharacter :: String
+                                                                                               , documentOnTypeFormattingRegistrationOptionsMoreTriggerCharacter :: Maybe [String] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingOptions.curry
@@ -10,13 +10,16 @@ instance FromJSON DocumentRangeFormattingOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
            return
-            DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport = parsedRangesSupport }
+            DocumentRangeFormattingOptions { documentRangeFormattingOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                           , documentRangeFormattingOptionsRangesSupport = parsedRangesSupport }
       _ ->
         Left
          ("Unrecognized DocumentRangeFormattingOptions value: " ++ ppJSON j)
 
-data DocumentRangeFormattingOptions = DocumentRangeFormattingOptions { documentRangeFormattingOptionsRangesSupport :: Maybe Bool }
+data DocumentRangeFormattingOptions = DocumentRangeFormattingOptions { documentRangeFormattingOptionsWorkDoneProgress :: Maybe Bool
+                                                                     , documentRangeFormattingOptionsRangesSupport :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.DocumentRangeFormattingParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -13,18 +14,21 @@ instance FromJSON DocumentRangeFormattingParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRange <- lookupFromJSON "range" vs
            parsedOptions <- lookupFromJSON "options" vs
            return
-            DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument = parsedTextDocument
+            DocumentRangeFormattingParams { documentRangeFormattingParamsWorkDoneToken = parsedWorkDoneToken
+                                          , documentRangeFormattingParamsTextDocument = parsedTextDocument
                                           , documentRangeFormattingParamsRange = parsedRange
                                           , documentRangeFormattingParamsOptions = parsedOptions }
       _ ->
         Left
          ("Unrecognized DocumentRangeFormattingParams value: " ++ ppJSON j)
 
-data DocumentRangeFormattingParams = DocumentRangeFormattingParams { documentRangeFormattingParamsTextDocument :: TextDocumentIdentifier
+data DocumentRangeFormattingParams = DocumentRangeFormattingParams { documentRangeFormattingParamsWorkDoneToken :: Maybe ProgressToken
+                                                                   , documentRangeFormattingParamsTextDocument :: TextDocumentIdentifier
                                                                    , documentRangeFormattingParamsRange :: Range
                                                                    , documentRangeFormattingParamsOptions :: FormattingOptions }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DocumentRangeFormattingRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentRangeFormattingRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.DocumentRangeFormattingRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentRangeFormattingRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentRangeFormattingRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedRangesSupport <- lookupMaybeFromJSON "rangesSupport" vs
+           return
+            DocumentRangeFormattingRegistrationOptions { documentRangeFormattingRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                       , documentRangeFormattingRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                                       , documentRangeFormattingRegistrationOptionsRangesSupport = parsedRangesSupport }
       _ ->
         Left
          ("Unrecognized DocumentRangeFormattingRegistrationOptions value: "
            ++ ppJSON j)
 
-data DocumentRangeFormattingRegistrationOptions = DocumentRangeFormattingRegistrationOptions {  }
+data DocumentRangeFormattingRegistrationOptions = DocumentRangeFormattingRegistrationOptions { documentRangeFormattingRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                             , documentRangeFormattingRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                                             , documentRangeFormattingRegistrationOptionsRangesSupport :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentRangesFormattingParams.curry
+++ b/src/LSP/Protocol/Types/DocumentRangesFormattingParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.DocumentRangesFormattingParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.FormattingOptions
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -13,18 +14,21 @@ instance FromJSON DocumentRangesFormattingParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRanges <- lookupFromJSON "ranges" vs
            parsedOptions <- lookupFromJSON "options" vs
            return
-            DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument = parsedTextDocument
+            DocumentRangesFormattingParams { documentRangesFormattingParamsWorkDoneToken = parsedWorkDoneToken
+                                           , documentRangesFormattingParamsTextDocument = parsedTextDocument
                                            , documentRangesFormattingParamsRanges = parsedRanges
                                            , documentRangesFormattingParamsOptions = parsedOptions }
       _ ->
         Left
          ("Unrecognized DocumentRangesFormattingParams value: " ++ ppJSON j)
 
-data DocumentRangesFormattingParams = DocumentRangesFormattingParams { documentRangesFormattingParamsTextDocument :: TextDocumentIdentifier
+data DocumentRangesFormattingParams = DocumentRangesFormattingParams { documentRangesFormattingParamsWorkDoneToken :: Maybe ProgressToken
+                                                                     , documentRangesFormattingParamsTextDocument :: TextDocumentIdentifier
                                                                      , documentRangesFormattingParamsRanges :: [Range]
                                                                      , documentRangesFormattingParamsOptions :: FormattingOptions }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/DocumentSymbolOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON DocumentSymbolOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedLabel <- lookupMaybeFromJSON "label" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedLabel <- lookupMaybeFromJSON "label" vs
            return
-            DocumentSymbolOptions { documentSymbolOptionsLabel = parsedLabel }
+            DocumentSymbolOptions { documentSymbolOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                  , documentSymbolOptionsLabel = parsedLabel }
       _ -> Left ("Unrecognized DocumentSymbolOptions value: " ++ ppJSON j)
 
-data DocumentSymbolOptions = DocumentSymbolOptions { documentSymbolOptionsLabel :: Maybe String }
+data DocumentSymbolOptions = DocumentSymbolOptions { documentSymbolOptionsWorkDoneProgress :: Maybe Bool
+                                                   , documentSymbolOptionsLabel :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentSymbolParams.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.DocumentSymbolParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON DocumentSymbolParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            DocumentSymbolParams { documentSymbolParamsTextDocument = parsedTextDocument }
+            DocumentSymbolParams { documentSymbolParamsWorkDoneToken = parsedWorkDoneToken
+                                 , documentSymbolParamsPartialResultToken = parsedPartialResultToken
+                                 , documentSymbolParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized DocumentSymbolParams value: " ++ ppJSON j)
 
-data DocumentSymbolParams = DocumentSymbolParams { documentSymbolParamsTextDocument :: TextDocumentIdentifier }
+data DocumentSymbolParams = DocumentSymbolParams { documentSymbolParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , documentSymbolParamsPartialResultToken :: Maybe ProgressToken
+                                                 , documentSymbolParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/DocumentSymbolRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/DocumentSymbolRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.DocumentSymbolRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON DocumentSymbolRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return DocumentSymbolRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedLabel <- lookupMaybeFromJSON "label" vs
+           return
+            DocumentSymbolRegistrationOptions { documentSymbolRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                              , documentSymbolRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , documentSymbolRegistrationOptionsLabel = parsedLabel }
       _ ->
         Left
          ("Unrecognized DocumentSymbolRegistrationOptions value: "
            ++ ppJSON j)
 
-data DocumentSymbolRegistrationOptions = DocumentSymbolRegistrationOptions {  }
+data DocumentSymbolRegistrationOptions = DocumentSymbolRegistrationOptions { documentSymbolRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                           , documentSymbolRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , documentSymbolRegistrationOptionsLabel :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ExecuteCommandOptions.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON ExecuteCommandOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedCommands <- lookupFromJSON "commands" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedCommands <- lookupFromJSON "commands" vs
            return
-            ExecuteCommandOptions { executeCommandOptionsCommands = parsedCommands }
+            ExecuteCommandOptions { executeCommandOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                  , executeCommandOptionsCommands = parsedCommands }
       _ -> Left ("Unrecognized ExecuteCommandOptions value: " ++ ppJSON j)
 
-data ExecuteCommandOptions = ExecuteCommandOptions { executeCommandOptionsCommands :: [String] }
+data ExecuteCommandOptions = ExecuteCommandOptions { executeCommandOptionsWorkDoneProgress :: Maybe Bool
+                                                   , executeCommandOptionsCommands :: [String] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ExecuteCommandParams.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandParams.curry
@@ -5,20 +5,24 @@ module LSP.Protocol.Types.ExecuteCommandParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.ProgressToken
 import LSP.Utils.JSON
 
 instance FromJSON ExecuteCommandParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedCommand <- lookupFromJSON "command" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedCommand <- lookupFromJSON "command" vs
            parsedArguments <- lookupMaybeFromJSON "arguments" vs
            return
-            ExecuteCommandParams { executeCommandParamsCommand = parsedCommand
+            ExecuteCommandParams { executeCommandParamsWorkDoneToken = parsedWorkDoneToken
+                                 , executeCommandParamsCommand = parsedCommand
                                  , executeCommandParamsArguments = parsedArguments }
       _ -> Left ("Unrecognized ExecuteCommandParams value: " ++ ppJSON j)
 
-data ExecuteCommandParams = ExecuteCommandParams { executeCommandParamsCommand :: String
+data ExecuteCommandParams = ExecuteCommandParams { executeCommandParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , executeCommandParamsCommand :: String
                                                  , executeCommandParamsArguments :: Maybe [LSPAny] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ExecuteCommandRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ExecuteCommandRegistrationOptions.curry
@@ -9,12 +9,18 @@ import LSP.Utils.JSON
 instance FromJSON ExecuteCommandRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return ExecuteCommandRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedCommands <- lookupFromJSON "commands" vs
+           return
+            ExecuteCommandRegistrationOptions { executeCommandRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , executeCommandRegistrationOptionsCommands = parsedCommands }
       _ ->
         Left
          ("Unrecognized ExecuteCommandRegistrationOptions value: "
            ++ ppJSON j)
 
-data ExecuteCommandRegistrationOptions = ExecuteCommandRegistrationOptions {  }
+data ExecuteCommandRegistrationOptions = ExecuteCommandRegistrationOptions { executeCommandRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , executeCommandRegistrationOptionsCommands :: [String] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/FoldingRangeOptions.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON FoldingRangeOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return FoldingRangeOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            FoldingRangeOptions { foldingRangeOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized FoldingRangeOptions value: " ++ ppJSON j)
 
-data FoldingRangeOptions = FoldingRangeOptions {  }
+data FoldingRangeOptions = FoldingRangeOptions { foldingRangeOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/FoldingRangeParams.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.FoldingRangeParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON FoldingRangeParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            FoldingRangeParams { foldingRangeParamsTextDocument = parsedTextDocument }
+            FoldingRangeParams { foldingRangeParamsWorkDoneToken = parsedWorkDoneToken
+                               , foldingRangeParamsPartialResultToken = parsedPartialResultToken
+                               , foldingRangeParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized FoldingRangeParams value: " ++ ppJSON j)
 
-data FoldingRangeParams = FoldingRangeParams { foldingRangeParamsTextDocument :: TextDocumentIdentifier }
+data FoldingRangeParams = FoldingRangeParams { foldingRangeParamsWorkDoneToken :: Maybe ProgressToken
+                                             , foldingRangeParamsPartialResultToken :: Maybe ProgressToken
+                                             , foldingRangeParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/FoldingRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/FoldingRangeRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.FoldingRangeRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON FoldingRangeRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return FoldingRangeRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            FoldingRangeRegistrationOptions { foldingRangeRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                            , foldingRangeRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                            , foldingRangeRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized FoldingRangeRegistrationOptions value: " ++ ppJSON j)
 
-data FoldingRangeRegistrationOptions = FoldingRangeRegistrationOptions {  }
+data FoldingRangeRegistrationOptions = FoldingRangeRegistrationOptions { foldingRangeRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                       , foldingRangeRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                       , foldingRangeRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/HoverOptions.curry
+++ b/src/LSP/Protocol/Types/HoverOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON HoverOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return HoverOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            HoverOptions { hoverOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized HoverOptions value: " ++ ppJSON j)
 
-data HoverOptions = HoverOptions {  }
+data HoverOptions = HoverOptions { hoverOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/HoverParams.curry
+++ b/src/LSP/Protocol/Types/HoverParams.curry
@@ -4,14 +4,26 @@ module LSP.Protocol.Types.HoverParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON HoverParams where
   fromJSON j =
     case j of
-      JObject vs -> do return HoverParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            HoverParams { hoverParamsTextDocument = parsedTextDocument
+                        , hoverParamsPosition = parsedPosition
+                        , hoverParamsWorkDoneToken = parsedWorkDoneToken }
       _ -> Left ("Unrecognized HoverParams value: " ++ ppJSON j)
 
-data HoverParams = HoverParams {  }
+data HoverParams = HoverParams { hoverParamsTextDocument :: TextDocumentIdentifier
+                               , hoverParamsPosition :: Position
+                               , hoverParamsWorkDoneToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/HoverRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/HoverRegistrationOptions.curry
@@ -4,14 +4,21 @@ module LSP.Protocol.Types.HoverRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON HoverRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return HoverRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            HoverRegistrationOptions { hoverRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                     , hoverRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized HoverRegistrationOptions value: " ++ ppJSON j)
 
-data HoverRegistrationOptions = HoverRegistrationOptions {  }
+data HoverRegistrationOptions = HoverRegistrationOptions { hoverRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                         , hoverRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ImplementationOptions.curry
+++ b/src/LSP/Protocol/Types/ImplementationOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON ImplementationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return ImplementationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            ImplementationOptions { implementationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized ImplementationOptions value: " ++ ppJSON j)
 
-data ImplementationOptions = ImplementationOptions {  }
+data ImplementationOptions = ImplementationOptions { implementationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ImplementationParams.curry
+++ b/src/LSP/Protocol/Types/ImplementationParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.ImplementationParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON ImplementationParams where
   fromJSON j =
     case j of
-      JObject vs -> do return ImplementationParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            ImplementationParams { implementationParamsTextDocument = parsedTextDocument
+                                 , implementationParamsPosition = parsedPosition
+                                 , implementationParamsWorkDoneToken = parsedWorkDoneToken
+                                 , implementationParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized ImplementationParams value: " ++ ppJSON j)
 
-data ImplementationParams = ImplementationParams {  }
+data ImplementationParams = ImplementationParams { implementationParamsTextDocument :: TextDocumentIdentifier
+                                                 , implementationParamsPosition :: Position
+                                                 , implementationParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , implementationParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ImplementationRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ImplementationRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.ImplementationRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON ImplementationRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return ImplementationRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            ImplementationRegistrationOptions { implementationRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                              , implementationRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , implementationRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized ImplementationRegistrationOptions value: "
            ++ ppJSON j)
 
-data ImplementationRegistrationOptions = ImplementationRegistrationOptions {  }
+data ImplementationRegistrationOptions = ImplementationRegistrationOptions { implementationRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                           , implementationRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , implementationRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InitializeParams.curry
+++ b/src/LSP/Protocol/Types/InitializeParams.curry
@@ -4,14 +4,52 @@ module LSP.Protocol.Types.InitializeParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Support
+import LSP.Protocol.Types.ClientCapabilities
+import LSP.Protocol.Types.ClientInfo
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TraceValue
+import LSP.Protocol.Types.WorkspaceFolder
 import LSP.Utils.JSON
 
 instance FromJSON InitializeParams where
   fromJSON j =
     case j of
-      JObject vs -> do return InitializeParams {  }
+      JObject vs ->
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedProcessId <- lookupFromJSON "processId" vs
+           parsedClientInfo <- lookupMaybeFromJSON "clientInfo" vs
+           parsedLocale <- lookupMaybeFromJSON "locale" vs
+           parsedRootPath <- lookupMaybeFromJSON "rootPath" vs
+           parsedRootUri <- lookupFromJSON "rootUri" vs
+           parsedCapabilities <- lookupFromJSON "capabilities" vs
+           parsedInitializationOptions <- lookupMaybeFromJSON
+                                           "initializationOptions"
+                                           vs
+           parsedTrace <- lookupMaybeFromJSON "trace" vs
+           parsedWorkspaceFolders <- lookupMaybeFromJSON "workspaceFolders" vs
+           return
+            InitializeParams { initializeParamsWorkDoneToken = parsedWorkDoneToken
+                             , initializeParamsProcessId = parsedProcessId
+                             , initializeParamsClientInfo = parsedClientInfo
+                             , initializeParamsLocale = parsedLocale
+                             , initializeParamsRootPath = parsedRootPath
+                             , initializeParamsRootUri = parsedRootUri
+                             , initializeParamsCapabilities = parsedCapabilities
+                             , initializeParamsInitializationOptions = parsedInitializationOptions
+                             , initializeParamsTrace = parsedTrace
+                             , initializeParamsWorkspaceFolders = parsedWorkspaceFolders }
       _ -> Left ("Unrecognized InitializeParams value: " ++ ppJSON j)
 
-data InitializeParams = InitializeParams {  }
+data InitializeParams = InitializeParams { initializeParamsWorkDoneToken :: Maybe ProgressToken
+                                         , initializeParamsProcessId :: Either Int ()
+                                         , initializeParamsClientInfo :: Maybe ClientInfo
+                                         , initializeParamsLocale :: Maybe String
+                                         , initializeParamsRootPath :: Maybe (Either String ())
+                                         , initializeParamsRootUri :: Either DocumentUri ()
+                                         , initializeParamsCapabilities :: ClientCapabilities
+                                         , initializeParamsInitializationOptions :: Maybe LSPAny
+                                         , initializeParamsTrace :: Maybe TraceValue
+                                         , initializeParamsWorkspaceFolders :: Maybe (Either [WorkspaceFolder] ()) }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlayHintOptions.curry
+++ b/src/LSP/Protocol/Types/InlayHintOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON InlayHintOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            return
-            InlayHintOptions { inlayHintOptionsResolveProvider = parsedResolveProvider }
+            InlayHintOptions { inlayHintOptionsWorkDoneProgress = parsedWorkDoneProgress
+                             , inlayHintOptionsResolveProvider = parsedResolveProvider }
       _ -> Left ("Unrecognized InlayHintOptions value: " ++ ppJSON j)
 
-data InlayHintOptions = InlayHintOptions { inlayHintOptionsResolveProvider :: Maybe Bool }
+data InlayHintOptions = InlayHintOptions { inlayHintOptionsWorkDoneProgress :: Maybe Bool
+                                         , inlayHintOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlayHintParams.curry
+++ b/src/LSP/Protocol/Types/InlayHintParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.InlayHintParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -12,14 +13,17 @@ instance FromJSON InlayHintParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRange <- lookupFromJSON "range" vs
            return
-            InlayHintParams { inlayHintParamsTextDocument = parsedTextDocument
+            InlayHintParams { inlayHintParamsWorkDoneToken = parsedWorkDoneToken
+                            , inlayHintParamsTextDocument = parsedTextDocument
                             , inlayHintParamsRange = parsedRange }
       _ -> Left ("Unrecognized InlayHintParams value: " ++ ppJSON j)
 
-data InlayHintParams = InlayHintParams { inlayHintParamsTextDocument :: TextDocumentIdentifier
+data InlayHintParams = InlayHintParams { inlayHintParamsWorkDoneToken :: Maybe ProgressToken
+                                       , inlayHintParamsTextDocument :: TextDocumentIdentifier
                                        , inlayHintParamsRange :: Range }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlayHintRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlayHintRegistrationOptions.curry
@@ -4,15 +4,28 @@ module LSP.Protocol.Types.InlayHintRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON InlayHintRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return InlayHintRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            InlayHintRegistrationOptions { inlayHintRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                         , inlayHintRegistrationOptionsResolveProvider = parsedResolveProvider
+                                         , inlayHintRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                         , inlayHintRegistrationOptionsId = parsedId }
       _ ->
         Left ("Unrecognized InlayHintRegistrationOptions value: " ++ ppJSON j)
 
-data InlayHintRegistrationOptions = InlayHintRegistrationOptions {  }
+data InlayHintRegistrationOptions = InlayHintRegistrationOptions { inlayHintRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                 , inlayHintRegistrationOptionsResolveProvider :: Maybe Bool
+                                                                 , inlayHintRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                 , inlayHintRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlineCompletionOptions.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON InlineCompletionOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return InlineCompletionOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            InlineCompletionOptions { inlineCompletionOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized InlineCompletionOptions value: " ++ ppJSON j)
 
-data InlineCompletionOptions = InlineCompletionOptions {  }
+data InlineCompletionOptions = InlineCompletionOptions { inlineCompletionOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlineCompletionParams.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionParams.curry
@@ -5,17 +5,29 @@ module LSP.Protocol.Types.InlineCompletionParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.InlineCompletionContext
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON InlineCompletionParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedContext <- lookupFromJSON "context" vs
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedContext <- lookupFromJSON "context" vs
            return
-            InlineCompletionParams { inlineCompletionParamsContext = parsedContext }
+            InlineCompletionParams { inlineCompletionParamsTextDocument = parsedTextDocument
+                                   , inlineCompletionParamsPosition = parsedPosition
+                                   , inlineCompletionParamsWorkDoneToken = parsedWorkDoneToken
+                                   , inlineCompletionParamsContext = parsedContext }
       _ -> Left ("Unrecognized InlineCompletionParams value: " ++ ppJSON j)
 
-data InlineCompletionParams = InlineCompletionParams { inlineCompletionParamsContext :: InlineCompletionContext }
+data InlineCompletionParams = InlineCompletionParams { inlineCompletionParamsTextDocument :: TextDocumentIdentifier
+                                                     , inlineCompletionParamsPosition :: Position
+                                                     , inlineCompletionParamsWorkDoneToken :: Maybe ProgressToken
+                                                     , inlineCompletionParamsContext :: InlineCompletionContext }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlineCompletionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlineCompletionRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.InlineCompletionRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON InlineCompletionRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return InlineCompletionRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            InlineCompletionRegistrationOptions { inlineCompletionRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                                , inlineCompletionRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                , inlineCompletionRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized InlineCompletionRegistrationOptions value: "
            ++ ppJSON j)
 
-data InlineCompletionRegistrationOptions = InlineCompletionRegistrationOptions {  }
+data InlineCompletionRegistrationOptions = InlineCompletionRegistrationOptions { inlineCompletionRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                               , inlineCompletionRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                               , inlineCompletionRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlineValueOptions.curry
+++ b/src/LSP/Protocol/Types/InlineValueOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON InlineValueOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return InlineValueOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            InlineValueOptions { inlineValueOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized InlineValueOptions value: " ++ ppJSON j)
 
-data InlineValueOptions = InlineValueOptions {  }
+data InlineValueOptions = InlineValueOptions { inlineValueOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/InlineValueParams.curry
+++ b/src/LSP/Protocol/Types/InlineValueParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.InlineValueParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.InlineValueContext
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -13,16 +14,19 @@ instance FromJSON InlineValueParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRange <- lookupFromJSON "range" vs
            parsedContext <- lookupFromJSON "context" vs
            return
-            InlineValueParams { inlineValueParamsTextDocument = parsedTextDocument
+            InlineValueParams { inlineValueParamsWorkDoneToken = parsedWorkDoneToken
+                              , inlineValueParamsTextDocument = parsedTextDocument
                               , inlineValueParamsRange = parsedRange
                               , inlineValueParamsContext = parsedContext }
       _ -> Left ("Unrecognized InlineValueParams value: " ++ ppJSON j)
 
-data InlineValueParams = InlineValueParams { inlineValueParamsTextDocument :: TextDocumentIdentifier
+data InlineValueParams = InlineValueParams { inlineValueParamsWorkDoneToken :: Maybe ProgressToken
+                                           , inlineValueParamsTextDocument :: TextDocumentIdentifier
                                            , inlineValueParamsRange :: Range
                                            , inlineValueParamsContext :: InlineValueContext }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/InlineValueRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/InlineValueRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.InlineValueRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON InlineValueRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return InlineValueRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            InlineValueRegistrationOptions { inlineValueRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                           , inlineValueRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                           , inlineValueRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized InlineValueRegistrationOptions value: " ++ ppJSON j)
 
-data InlineValueRegistrationOptions = InlineValueRegistrationOptions {  }
+data InlineValueRegistrationOptions = InlineValueRegistrationOptions { inlineValueRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                     , inlineValueRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                     , inlineValueRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/LinkedEditingRangeOptions.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON LinkedEditingRangeOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return LinkedEditingRangeOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            LinkedEditingRangeOptions { linkedEditingRangeOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized LinkedEditingRangeOptions value: " ++ ppJSON j)
 
-data LinkedEditingRangeOptions = LinkedEditingRangeOptions {  }
+data LinkedEditingRangeOptions = LinkedEditingRangeOptions { linkedEditingRangeOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/LinkedEditingRangeParams.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeParams.curry
@@ -4,14 +4,26 @@ module LSP.Protocol.Types.LinkedEditingRangeParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON LinkedEditingRangeParams where
   fromJSON j =
     case j of
-      JObject vs -> do return LinkedEditingRangeParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            LinkedEditingRangeParams { linkedEditingRangeParamsTextDocument = parsedTextDocument
+                                     , linkedEditingRangeParamsPosition = parsedPosition
+                                     , linkedEditingRangeParamsWorkDoneToken = parsedWorkDoneToken }
       _ -> Left ("Unrecognized LinkedEditingRangeParams value: " ++ ppJSON j)
 
-data LinkedEditingRangeParams = LinkedEditingRangeParams {  }
+data LinkedEditingRangeParams = LinkedEditingRangeParams { linkedEditingRangeParamsTextDocument :: TextDocumentIdentifier
+                                                         , linkedEditingRangeParamsPosition :: Position
+                                                         , linkedEditingRangeParamsWorkDoneToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/LinkedEditingRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/LinkedEditingRangeRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.LinkedEditingRangeRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON LinkedEditingRangeRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return LinkedEditingRangeRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            LinkedEditingRangeRegistrationOptions { linkedEditingRangeRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                  , linkedEditingRangeRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                                  , linkedEditingRangeRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized LinkedEditingRangeRegistrationOptions value: "
            ++ ppJSON j)
 
-data LinkedEditingRangeRegistrationOptions = LinkedEditingRangeRegistrationOptions {  }
+data LinkedEditingRangeRegistrationOptions = LinkedEditingRangeRegistrationOptions { linkedEditingRangeRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                   , linkedEditingRangeRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                                   , linkedEditingRangeRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/MonikerOptions.curry
+++ b/src/LSP/Protocol/Types/MonikerOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON MonikerOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return MonikerOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            MonikerOptions { monikerOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized MonikerOptions value: " ++ ppJSON j)
 
-data MonikerOptions = MonikerOptions {  }
+data MonikerOptions = MonikerOptions { monikerOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/MonikerParams.curry
+++ b/src/LSP/Protocol/Types/MonikerParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.MonikerParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON MonikerParams where
   fromJSON j =
     case j of
-      JObject vs -> do return MonikerParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            MonikerParams { monikerParamsTextDocument = parsedTextDocument
+                          , monikerParamsPosition = parsedPosition
+                          , monikerParamsWorkDoneToken = parsedWorkDoneToken
+                          , monikerParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized MonikerParams value: " ++ ppJSON j)
 
-data MonikerParams = MonikerParams {  }
+data MonikerParams = MonikerParams { monikerParamsTextDocument :: TextDocumentIdentifier
+                                   , monikerParamsPosition :: Position
+                                   , monikerParamsWorkDoneToken :: Maybe ProgressToken
+                                   , monikerParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/MonikerRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/MonikerRegistrationOptions.curry
@@ -4,15 +4,22 @@ module LSP.Protocol.Types.MonikerRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON MonikerRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return MonikerRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            MonikerRegistrationOptions { monikerRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                       , monikerRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ ->
         Left ("Unrecognized MonikerRegistrationOptions value: " ++ ppJSON j)
 
-data MonikerRegistrationOptions = MonikerRegistrationOptions {  }
+data MonikerRegistrationOptions = MonikerRegistrationOptions { monikerRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                             , monikerRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/NotebookDocumentSyncRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/NotebookDocumentSyncRegistrationOptions.curry
@@ -4,17 +4,28 @@ module LSP.Protocol.Types.NotebookDocumentSyncRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.NotebookDocumentFilterWithCells
+import LSP.Protocol.Types.NotebookDocumentFilterWithNotebook
 import LSP.Utils.JSON
 
 instance FromJSON NotebookDocumentSyncRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return NotebookDocumentSyncRegistrationOptions {  }
+      JObject vs ->
+        do parsedNotebookSelector <- lookupFromJSON "notebookSelector" vs
+           parsedSave <- lookupMaybeFromJSON "save" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            NotebookDocumentSyncRegistrationOptions { notebookDocumentSyncRegistrationOptionsNotebookSelector = parsedNotebookSelector
+                                                    , notebookDocumentSyncRegistrationOptionsSave = parsedSave
+                                                    , notebookDocumentSyncRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized NotebookDocumentSyncRegistrationOptions value: "
            ++ ppJSON j)
 
-data NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncRegistrationOptions {  }
+data NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncRegistrationOptions { notebookDocumentSyncRegistrationOptionsNotebookSelector :: [Either NotebookDocumentFilterWithNotebook NotebookDocumentFilterWithCells]
+                                                                                       , notebookDocumentSyncRegistrationOptionsSave :: Maybe Bool
+                                                                                       , notebookDocumentSyncRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/OptionalVersionedTextDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/OptionalVersionedTextDocumentIdentifier.curry
@@ -4,20 +4,24 @@ module LSP.Protocol.Types.OptionalVersionedTextDocumentIdentifier where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Support
 import LSP.Utils.JSON
 
 instance FromJSON OptionalVersionedTextDocumentIdentifier where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedVersion <- lookupFromJSON "version" vs
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedVersion <- lookupFromJSON "version" vs
            return
-            OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion = parsedVersion }
+            OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierUri = parsedUri
+                                                    , optionalVersionedTextDocumentIdentifierVersion = parsedVersion }
       _ ->
         Left
          ("Unrecognized OptionalVersionedTextDocumentIdentifier value: "
            ++ ppJSON j)
 
-data OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierVersion :: Either Int () }
+data OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier { optionalVersionedTextDocumentIdentifierUri :: DocumentUri
+                                                                                       , optionalVersionedTextDocumentIdentifierVersion :: Either Int () }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/PrepareRenameParams.curry
+++ b/src/LSP/Protocol/Types/PrepareRenameParams.curry
@@ -4,14 +4,26 @@ module LSP.Protocol.Types.PrepareRenameParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON PrepareRenameParams where
   fromJSON j =
     case j of
-      JObject vs -> do return PrepareRenameParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            PrepareRenameParams { prepareRenameParamsTextDocument = parsedTextDocument
+                                , prepareRenameParamsPosition = parsedPosition
+                                , prepareRenameParamsWorkDoneToken = parsedWorkDoneToken }
       _ -> Left ("Unrecognized PrepareRenameParams value: " ++ ppJSON j)
 
-data PrepareRenameParams = PrepareRenameParams {  }
+data PrepareRenameParams = PrepareRenameParams { prepareRenameParamsTextDocument :: TextDocumentIdentifier
+                                               , prepareRenameParamsPosition :: Position
+                                               , prepareRenameParamsWorkDoneToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/PublishDiagnosticsClientCapabilities.curry
+++ b/src/LSP/Protocol/Types/PublishDiagnosticsClientCapabilities.curry
@@ -4,20 +4,37 @@ module LSP.Protocol.Types.PublishDiagnosticsClientCapabilities where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ClientDiagnosticsTagOptions
 import LSP.Utils.JSON
 
 instance FromJSON PublishDiagnosticsClientCapabilities where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedVersionSupport <- lookupMaybeFromJSON "versionSupport" vs
+        do parsedRelatedInformation <- lookupMaybeFromJSON
+                                        "relatedInformation"
+                                        vs
+           parsedTagSupport <- lookupMaybeFromJSON "tagSupport" vs
+           parsedCodeDescriptionSupport <- lookupMaybeFromJSON
+                                            "codeDescriptionSupport"
+                                            vs
+           parsedDataSupport <- lookupMaybeFromJSON "dataSupport" vs
+           parsedVersionSupport <- lookupMaybeFromJSON "versionSupport" vs
            return
-            PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport = parsedVersionSupport }
+            PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesRelatedInformation = parsedRelatedInformation
+                                                 , publishDiagnosticsClientCapabilitiesTagSupport = parsedTagSupport
+                                                 , publishDiagnosticsClientCapabilitiesCodeDescriptionSupport = parsedCodeDescriptionSupport
+                                                 , publishDiagnosticsClientCapabilitiesDataSupport = parsedDataSupport
+                                                 , publishDiagnosticsClientCapabilitiesVersionSupport = parsedVersionSupport }
       _ ->
         Left
          ("Unrecognized PublishDiagnosticsClientCapabilities value: "
            ++ ppJSON j)
 
-data PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesVersionSupport :: Maybe Bool }
+data PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities { publishDiagnosticsClientCapabilitiesRelatedInformation :: Maybe Bool
+                                                                                 , publishDiagnosticsClientCapabilitiesTagSupport :: Maybe ClientDiagnosticsTagOptions
+                                                                                 , publishDiagnosticsClientCapabilitiesCodeDescriptionSupport :: Maybe Bool
+                                                                                 , publishDiagnosticsClientCapabilitiesDataSupport :: Maybe Bool
+                                                                                 , publishDiagnosticsClientCapabilitiesVersionSupport :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ReferenceOptions.curry
+++ b/src/LSP/Protocol/Types/ReferenceOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON ReferenceOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return ReferenceOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            ReferenceOptions { referenceOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized ReferenceOptions value: " ++ ppJSON j)
 
-data ReferenceOptions = ReferenceOptions {  }
+data ReferenceOptions = ReferenceOptions { referenceOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ReferenceParams.curry
+++ b/src/LSP/Protocol/Types/ReferenceParams.curry
@@ -4,17 +4,35 @@ module LSP.Protocol.Types.ReferenceParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.ReferenceContext
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON ReferenceParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedContext <- lookupFromJSON "context" vs
-           return ReferenceParams { referenceParamsContext = parsedContext }
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedContext <- lookupFromJSON "context" vs
+           return
+            ReferenceParams { referenceParamsTextDocument = parsedTextDocument
+                            , referenceParamsPosition = parsedPosition
+                            , referenceParamsWorkDoneToken = parsedWorkDoneToken
+                            , referenceParamsPartialResultToken = parsedPartialResultToken
+                            , referenceParamsContext = parsedContext }
       _ -> Left ("Unrecognized ReferenceParams value: " ++ ppJSON j)
 
-data ReferenceParams = ReferenceParams { referenceParamsContext :: ReferenceContext }
+data ReferenceParams = ReferenceParams { referenceParamsTextDocument :: TextDocumentIdentifier
+                                       , referenceParamsPosition :: Position
+                                       , referenceParamsWorkDoneToken :: Maybe ProgressToken
+                                       , referenceParamsPartialResultToken :: Maybe ProgressToken
+                                       , referenceParamsContext :: ReferenceContext }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/ReferenceRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/ReferenceRegistrationOptions.curry
@@ -4,15 +4,22 @@ module LSP.Protocol.Types.ReferenceRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON ReferenceRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return ReferenceRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            ReferenceRegistrationOptions { referenceRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                         , referenceRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ ->
         Left ("Unrecognized ReferenceRegistrationOptions value: " ++ ppJSON j)
 
-data ReferenceRegistrationOptions = ReferenceRegistrationOptions {  }
+data ReferenceRegistrationOptions = ReferenceRegistrationOptions { referenceRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                 , referenceRegistrationOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/RelatedFullDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/RelatedFullDocumentDiagnosticReport.curry
@@ -6,6 +6,7 @@ import Data.Map
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.Diagnostic
 import LSP.Protocol.Types.FullDocumentDiagnosticReport
 import LSP.Protocol.Types.UnchangedDocumentDiagnosticReport
 import LSP.Utils.JSON
@@ -14,14 +15,23 @@ instance FromJSON RelatedFullDocumentDiagnosticReport where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupMaybeFromJSON "resultId" vs
+           parsedItems <- lookupFromJSON "items" vs
+           parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
            return
-            RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
+            RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportKind = parsedKind
+                                                , relatedFullDocumentDiagnosticReportResultId = parsedResultId
+                                                , relatedFullDocumentDiagnosticReportItems = parsedItems
+                                                , relatedFullDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
       _ ->
         Left
          ("Unrecognized RelatedFullDocumentDiagnosticReport value: "
            ++ ppJSON j)
 
-data RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
+data RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport { relatedFullDocumentDiagnosticReportKind :: String
+                                                                               , relatedFullDocumentDiagnosticReportResultId :: Maybe String
+                                                                               , relatedFullDocumentDiagnosticReportItems :: [Diagnostic]
+                                                                               , relatedFullDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/RelatedUnchangedDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/RelatedUnchangedDocumentDiagnosticReport.curry
@@ -14,14 +14,20 @@ instance FromJSON RelatedUnchangedDocumentDiagnosticReport where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupFromJSON "resultId" vs
+           parsedRelatedDocuments <- lookupMaybeFromJSON "relatedDocuments" vs
            return
-            RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
+            RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportKind = parsedKind
+                                                     , relatedUnchangedDocumentDiagnosticReportResultId = parsedResultId
+                                                     , relatedUnchangedDocumentDiagnosticReportRelatedDocuments = parsedRelatedDocuments }
       _ ->
         Left
          ("Unrecognized RelatedUnchangedDocumentDiagnosticReport value: "
            ++ ppJSON j)
 
-data RelatedUnchangedDocumentDiagnosticReport = RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
+data RelatedUnchangedDocumentDiagnosticReport = RelatedUnchangedDocumentDiagnosticReport { relatedUnchangedDocumentDiagnosticReportKind :: String
+                                                                                         , relatedUnchangedDocumentDiagnosticReportResultId :: String
+                                                                                         , relatedUnchangedDocumentDiagnosticReportRelatedDocuments :: Maybe (Map DocumentUri (Either FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport)) }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/RenameFile.curry
+++ b/src/LSP/Protocol/Types/RenameFile.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.RenameFile where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.ChangeAnnotationIdentifier
 import LSP.Protocol.Types.RenameFileOptions
 import LSP.Utils.JSON
 
@@ -13,17 +14,20 @@ instance FromJSON RenameFile where
     case j of
       JObject vs ->
         do parsedKind <- lookupFromJSON "kind" vs
+           parsedAnnotationId <- lookupMaybeFromJSON "annotationId" vs
            parsedOldUri <- lookupFromJSON "oldUri" vs
            parsedNewUri <- lookupFromJSON "newUri" vs
            parsedOptions <- lookupMaybeFromJSON "options" vs
            return
             RenameFile { renameFileKind = parsedKind
+                       , renameFileAnnotationId = parsedAnnotationId
                        , renameFileOldUri = parsedOldUri
                        , renameFileNewUri = parsedNewUri
                        , renameFileOptions = parsedOptions }
       _ -> Left ("Unrecognized RenameFile value: " ++ ppJSON j)
 
 data RenameFile = RenameFile { renameFileKind :: String
+                             , renameFileAnnotationId :: Maybe ChangeAnnotationIdentifier
                              , renameFileOldUri :: DocumentUri
                              , renameFileNewUri :: DocumentUri
                              , renameFileOptions :: Maybe RenameFileOptions }

--- a/src/LSP/Protocol/Types/RenameOptions.curry
+++ b/src/LSP/Protocol/Types/RenameOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON RenameOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedPrepareProvider <- lookupMaybeFromJSON "prepareProvider" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedPrepareProvider <- lookupMaybeFromJSON "prepareProvider" vs
            return
-            RenameOptions { renameOptionsPrepareProvider = parsedPrepareProvider }
+            RenameOptions { renameOptionsWorkDoneProgress = parsedWorkDoneProgress
+                          , renameOptionsPrepareProvider = parsedPrepareProvider }
       _ -> Left ("Unrecognized RenameOptions value: " ++ ppJSON j)
 
-data RenameOptions = RenameOptions { renameOptionsPrepareProvider :: Maybe Bool }
+data RenameOptions = RenameOptions { renameOptionsWorkDoneProgress :: Maybe Bool
+                                   , renameOptionsPrepareProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/RenameParams.curry
+++ b/src/LSP/Protocol/Types/RenameParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.RenameParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -12,16 +13,19 @@ instance FromJSON RenameParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedPosition <- lookupFromJSON "position" vs
            parsedNewName <- lookupFromJSON "newName" vs
            return
-            RenameParams { renameParamsTextDocument = parsedTextDocument
+            RenameParams { renameParamsWorkDoneToken = parsedWorkDoneToken
+                         , renameParamsTextDocument = parsedTextDocument
                          , renameParamsPosition = parsedPosition
                          , renameParamsNewName = parsedNewName }
       _ -> Left ("Unrecognized RenameParams value: " ++ ppJSON j)
 
-data RenameParams = RenameParams { renameParamsTextDocument :: TextDocumentIdentifier
+data RenameParams = RenameParams { renameParamsWorkDoneToken :: Maybe ProgressToken
+                                 , renameParamsTextDocument :: TextDocumentIdentifier
                                  , renameParamsPosition :: Position
                                  , renameParamsNewName :: String }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/RenameRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/RenameRegistrationOptions.curry
@@ -4,14 +4,24 @@ module LSP.Protocol.Types.RenameRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON RenameRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return RenameRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedPrepareProvider <- lookupMaybeFromJSON "prepareProvider" vs
+           return
+            RenameRegistrationOptions { renameRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                      , renameRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                      , renameRegistrationOptionsPrepareProvider = parsedPrepareProvider }
       _ -> Left ("Unrecognized RenameRegistrationOptions value: " ++ ppJSON j)
 
-data RenameRegistrationOptions = RenameRegistrationOptions {  }
+data RenameRegistrationOptions = RenameRegistrationOptions { renameRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                           , renameRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                           , renameRegistrationOptionsPrepareProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SelectionRangeOptions.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON SelectionRangeOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return SelectionRangeOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            SelectionRangeOptions { selectionRangeOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized SelectionRangeOptions value: " ++ ppJSON j)
 
-data SelectionRangeOptions = SelectionRangeOptions {  }
+data SelectionRangeOptions = SelectionRangeOptions { selectionRangeOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SelectionRangeParams.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeParams.curry
@@ -5,6 +5,7 @@ module LSP.Protocol.Types.SelectionRangeParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -12,14 +13,22 @@ instance FromJSON SelectionRangeParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedPositions <- lookupFromJSON "positions" vs
            return
-            SelectionRangeParams { selectionRangeParamsTextDocument = parsedTextDocument
+            SelectionRangeParams { selectionRangeParamsWorkDoneToken = parsedWorkDoneToken
+                                 , selectionRangeParamsPartialResultToken = parsedPartialResultToken
+                                 , selectionRangeParamsTextDocument = parsedTextDocument
                                  , selectionRangeParamsPositions = parsedPositions }
       _ -> Left ("Unrecognized SelectionRangeParams value: " ++ ppJSON j)
 
-data SelectionRangeParams = SelectionRangeParams { selectionRangeParamsTextDocument :: TextDocumentIdentifier
+data SelectionRangeParams = SelectionRangeParams { selectionRangeParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , selectionRangeParamsPartialResultToken :: Maybe ProgressToken
+                                                 , selectionRangeParamsTextDocument :: TextDocumentIdentifier
                                                  , selectionRangeParamsPositions :: [Position] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SelectionRangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SelectionRangeRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.SelectionRangeRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON SelectionRangeRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return SelectionRangeRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            SelectionRangeRegistrationOptions { selectionRangeRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , selectionRangeRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                              , selectionRangeRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized SelectionRangeRegistrationOptions value: "
            ++ ppJSON j)
 
-data SelectionRangeRegistrationOptions = SelectionRangeRegistrationOptions {  }
+data SelectionRangeRegistrationOptions = SelectionRangeRegistrationOptions { selectionRangeRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , selectionRangeRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                           , selectionRangeRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SemanticTokensDeltaParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensDeltaParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.SemanticTokensDeltaParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,14 +12,22 @@ instance FromJSON SemanticTokensDeltaParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedPreviousResultId <- lookupFromJSON "previousResultId" vs
            return
-            SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument = parsedTextDocument
+            SemanticTokensDeltaParams { semanticTokensDeltaParamsWorkDoneToken = parsedWorkDoneToken
+                                      , semanticTokensDeltaParamsPartialResultToken = parsedPartialResultToken
+                                      , semanticTokensDeltaParamsTextDocument = parsedTextDocument
                                       , semanticTokensDeltaParamsPreviousResultId = parsedPreviousResultId }
       _ -> Left ("Unrecognized SemanticTokensDeltaParams value: " ++ ppJSON j)
 
-data SemanticTokensDeltaParams = SemanticTokensDeltaParams { semanticTokensDeltaParamsTextDocument :: TextDocumentIdentifier
+data SemanticTokensDeltaParams = SemanticTokensDeltaParams { semanticTokensDeltaParamsWorkDoneToken :: Maybe ProgressToken
+                                                           , semanticTokensDeltaParamsPartialResultToken :: Maybe ProgressToken
+                                                           , semanticTokensDeltaParamsTextDocument :: TextDocumentIdentifier
                                                            , semanticTokensDeltaParamsPreviousResultId :: String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SemanticTokensOptions.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensOptions.curry
@@ -12,16 +12,19 @@ instance FromJSON SemanticTokensOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedLegend <- lookupFromJSON "legend" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedLegend <- lookupFromJSON "legend" vs
            parsedRange <- lookupMaybeFromJSON "range" vs
            parsedFull <- lookupMaybeFromJSON "full" vs
            return
-            SemanticTokensOptions { semanticTokensOptionsLegend = parsedLegend
+            SemanticTokensOptions { semanticTokensOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                  , semanticTokensOptionsLegend = parsedLegend
                                   , semanticTokensOptionsRange = parsedRange
                                   , semanticTokensOptionsFull = parsedFull }
       _ -> Left ("Unrecognized SemanticTokensOptions value: " ++ ppJSON j)
 
-data SemanticTokensOptions = SemanticTokensOptions { semanticTokensOptionsLegend :: SemanticTokensLegend
+data SemanticTokensOptions = SemanticTokensOptions { semanticTokensOptionsWorkDoneProgress :: Maybe Bool
+                                                   , semanticTokensOptionsLegend :: SemanticTokensLegend
                                                    , semanticTokensOptionsRange :: Maybe (Either Bool ())
                                                    , semanticTokensOptionsFull :: Maybe (Either Bool SemanticTokensFullDelta) }
  deriving (Show,Eq)

--- a/src/LSP/Protocol/Types/SemanticTokensParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.SemanticTokensParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
@@ -11,11 +12,19 @@ instance FromJSON SemanticTokensParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            return
-            SemanticTokensParams { semanticTokensParamsTextDocument = parsedTextDocument }
+            SemanticTokensParams { semanticTokensParamsWorkDoneToken = parsedWorkDoneToken
+                                 , semanticTokensParamsPartialResultToken = parsedPartialResultToken
+                                 , semanticTokensParamsTextDocument = parsedTextDocument }
       _ -> Left ("Unrecognized SemanticTokensParams value: " ++ ppJSON j)
 
-data SemanticTokensParams = SemanticTokensParams { semanticTokensParamsTextDocument :: TextDocumentIdentifier }
+data SemanticTokensParams = SemanticTokensParams { semanticTokensParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , semanticTokensParamsPartialResultToken :: Maybe ProgressToken
+                                                 , semanticTokensParamsTextDocument :: TextDocumentIdentifier }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SemanticTokensRangeParams.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensRangeParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.SemanticTokensRangeParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.Range
 import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
@@ -12,14 +13,22 @@ instance FromJSON SemanticTokensRangeParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedTextDocument <- lookupFromJSON "textDocument" vs
            parsedRange <- lookupFromJSON "range" vs
            return
-            SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument = parsedTextDocument
+            SemanticTokensRangeParams { semanticTokensRangeParamsWorkDoneToken = parsedWorkDoneToken
+                                      , semanticTokensRangeParamsPartialResultToken = parsedPartialResultToken
+                                      , semanticTokensRangeParamsTextDocument = parsedTextDocument
                                       , semanticTokensRangeParamsRange = parsedRange }
       _ -> Left ("Unrecognized SemanticTokensRangeParams value: " ++ ppJSON j)
 
-data SemanticTokensRangeParams = SemanticTokensRangeParams { semanticTokensRangeParamsTextDocument :: TextDocumentIdentifier
+data SemanticTokensRangeParams = SemanticTokensRangeParams { semanticTokensRangeParamsWorkDoneToken :: Maybe ProgressToken
+                                                           , semanticTokensRangeParamsPartialResultToken :: Maybe ProgressToken
+                                                           , semanticTokensRangeParamsTextDocument :: TextDocumentIdentifier
                                                            , semanticTokensRangeParamsRange :: Range }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SemanticTokensRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SemanticTokensRegistrationOptions.curry
@@ -4,17 +4,38 @@ module LSP.Protocol.Types.SemanticTokensRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
+import LSP.Protocol.Types.SemanticTokensFullDelta
+import LSP.Protocol.Types.SemanticTokensLegend
 import LSP.Utils.JSON
 
 instance FromJSON SemanticTokensRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return SemanticTokensRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedLegend <- lookupFromJSON "legend" vs
+           parsedRange <- lookupMaybeFromJSON "range" vs
+           parsedFull <- lookupMaybeFromJSON "full" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            SemanticTokensRegistrationOptions { semanticTokensRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                              , semanticTokensRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , semanticTokensRegistrationOptionsLegend = parsedLegend
+                                              , semanticTokensRegistrationOptionsRange = parsedRange
+                                              , semanticTokensRegistrationOptionsFull = parsedFull
+                                              , semanticTokensRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized SemanticTokensRegistrationOptions value: "
            ++ ppJSON j)
 
-data SemanticTokensRegistrationOptions = SemanticTokensRegistrationOptions {  }
+data SemanticTokensRegistrationOptions = SemanticTokensRegistrationOptions { semanticTokensRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                           , semanticTokensRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , semanticTokensRegistrationOptionsLegend :: SemanticTokensLegend
+                                                                           , semanticTokensRegistrationOptionsRange :: Maybe (Either Bool ())
+                                                                           , semanticTokensRegistrationOptionsFull :: Maybe (Either Bool SemanticTokensFullDelta)
+                                                                           , semanticTokensRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SignatureHelpOptions.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpOptions.curry
@@ -10,17 +10,20 @@ instance FromJSON SignatureHelpOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
                                        vs
            parsedRetriggerCharacters <- lookupMaybeFromJSON
                                          "retriggerCharacters"
                                          vs
            return
-            SignatureHelpOptions { signatureHelpOptionsTriggerCharacters = parsedTriggerCharacters
+            SignatureHelpOptions { signatureHelpOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                 , signatureHelpOptionsTriggerCharacters = parsedTriggerCharacters
                                  , signatureHelpOptionsRetriggerCharacters = parsedRetriggerCharacters }
       _ -> Left ("Unrecognized SignatureHelpOptions value: " ++ ppJSON j)
 
-data SignatureHelpOptions = SignatureHelpOptions { signatureHelpOptionsTriggerCharacters :: Maybe [String]
+data SignatureHelpOptions = SignatureHelpOptions { signatureHelpOptionsWorkDoneProgress :: Maybe Bool
+                                                 , signatureHelpOptionsTriggerCharacters :: Maybe [String]
                                                  , signatureHelpOptionsRetriggerCharacters :: Maybe [String] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SignatureHelpParams.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpParams.curry
@@ -4,18 +4,30 @@ module LSP.Protocol.Types.SignatureHelpParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.SignatureHelpContext
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON SignatureHelpParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedContext <- lookupMaybeFromJSON "context" vs
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedContext <- lookupMaybeFromJSON "context" vs
            return
-            SignatureHelpParams { signatureHelpParamsContext = parsedContext }
+            SignatureHelpParams { signatureHelpParamsTextDocument = parsedTextDocument
+                                , signatureHelpParamsPosition = parsedPosition
+                                , signatureHelpParamsWorkDoneToken = parsedWorkDoneToken
+                                , signatureHelpParamsContext = parsedContext }
       _ -> Left ("Unrecognized SignatureHelpParams value: " ++ ppJSON j)
 
-data SignatureHelpParams = SignatureHelpParams { signatureHelpParamsContext :: Maybe SignatureHelpContext }
+data SignatureHelpParams = SignatureHelpParams { signatureHelpParamsTextDocument :: TextDocumentIdentifier
+                                               , signatureHelpParamsPosition :: Position
+                                               , signatureHelpParamsWorkDoneToken :: Maybe ProgressToken
+                                               , signatureHelpParamsContext :: Maybe SignatureHelpContext }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SignatureHelpRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/SignatureHelpRegistrationOptions.curry
@@ -4,16 +4,32 @@ module LSP.Protocol.Types.SignatureHelpRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON SignatureHelpRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return SignatureHelpRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedTriggerCharacters <- lookupMaybeFromJSON "triggerCharacters"
+                                       vs
+           parsedRetriggerCharacters <- lookupMaybeFromJSON
+                                         "retriggerCharacters"
+                                         vs
+           return
+            SignatureHelpRegistrationOptions { signatureHelpRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                             , signatureHelpRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                             , signatureHelpRegistrationOptionsTriggerCharacters = parsedTriggerCharacters
+                                             , signatureHelpRegistrationOptionsRetriggerCharacters = parsedRetriggerCharacters }
       _ ->
         Left
          ("Unrecognized SignatureHelpRegistrationOptions value: " ++ ppJSON j)
 
-data SignatureHelpRegistrationOptions = SignatureHelpRegistrationOptions {  }
+data SignatureHelpRegistrationOptions = SignatureHelpRegistrationOptions { signatureHelpRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                         , signatureHelpRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                         , signatureHelpRegistrationOptionsTriggerCharacters :: Maybe [String]
+                                                                         , signatureHelpRegistrationOptionsRetriggerCharacters :: Maybe [String] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/SymbolInformation.curry
+++ b/src/LSP/Protocol/Types/SymbolInformation.curry
@@ -5,20 +5,34 @@ module LSP.Protocol.Types.SymbolInformation where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.Location
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
 import LSP.Utils.JSON
 
 instance FromJSON SymbolInformation where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
+        do parsedName <- lookupFromJSON "name" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedContainerName <- lookupMaybeFromJSON "containerName" vs
+           parsedDeprecated <- lookupMaybeFromJSON "deprecated" vs
            parsedLocation <- lookupFromJSON "location" vs
            return
-            SymbolInformation { symbolInformationDeprecated = parsedDeprecated
+            SymbolInformation { symbolInformationName = parsedName
+                              , symbolInformationKind = parsedKind
+                              , symbolInformationTags = parsedTags
+                              , symbolInformationContainerName = parsedContainerName
+                              , symbolInformationDeprecated = parsedDeprecated
                               , symbolInformationLocation = parsedLocation }
       _ -> Left ("Unrecognized SymbolInformation value: " ++ ppJSON j)
 
-data SymbolInformation = SymbolInformation { symbolInformationDeprecated :: Maybe Bool
+data SymbolInformation = SymbolInformation { symbolInformationName :: String
+                                           , symbolInformationKind :: SymbolKind
+                                           , symbolInformationTags :: Maybe [SymbolTag]
+                                           , symbolInformationContainerName :: Maybe String
+                                           , symbolInformationDeprecated :: Maybe Bool
                                            , symbolInformationLocation :: Location }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TextDocumentChangeRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentChangeRegistrationOptions.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.TextDocumentChangeRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Protocol.Types.TextDocumentSyncKind
 import LSP.Utils.JSON
 
@@ -11,14 +12,17 @@ instance FromJSON TextDocumentChangeRegistrationOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedSyncKind <- lookupFromJSON "syncKind" vs
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedSyncKind <- lookupFromJSON "syncKind" vs
            return
-            TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind = parsedSyncKind }
+            TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                  , textDocumentChangeRegistrationOptionsSyncKind = parsedSyncKind }
       _ ->
         Left
          ("Unrecognized TextDocumentChangeRegistrationOptions value: "
            ++ ppJSON j)
 
-data TextDocumentChangeRegistrationOptions = TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsSyncKind :: TextDocumentSyncKind }
+data TextDocumentChangeRegistrationOptions = TextDocumentChangeRegistrationOptions { textDocumentChangeRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                                   , textDocumentChangeRegistrationOptionsSyncKind :: TextDocumentSyncKind }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TextDocumentSaveRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TextDocumentSaveRegistrationOptions.curry
@@ -4,17 +4,24 @@ module LSP.Protocol.Types.TextDocumentSaveRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON TextDocumentSaveRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return TextDocumentSaveRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedIncludeText <- lookupMaybeFromJSON "includeText" vs
+           return
+            TextDocumentSaveRegistrationOptions { textDocumentSaveRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                                , textDocumentSaveRegistrationOptionsIncludeText = parsedIncludeText }
       _ ->
         Left
          ("Unrecognized TextDocumentSaveRegistrationOptions value: "
            ++ ppJSON j)
 
-data TextDocumentSaveRegistrationOptions = TextDocumentSaveRegistrationOptions {  }
+data TextDocumentSaveRegistrationOptions = TextDocumentSaveRegistrationOptions { textDocumentSaveRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                               , textDocumentSaveRegistrationOptionsIncludeText :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeDefinitionOptions.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON TypeDefinitionOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeDefinitionOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            TypeDefinitionOptions { typeDefinitionOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized TypeDefinitionOptions value: " ++ ppJSON j)
 
-data TypeDefinitionOptions = TypeDefinitionOptions {  }
+data TypeDefinitionOptions = TypeDefinitionOptions { typeDefinitionOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeDefinitionParams.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionParams.curry
@@ -4,14 +4,31 @@ module LSP.Protocol.Types.TypeDefinitionParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON TypeDefinitionParams where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeDefinitionParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           return
+            TypeDefinitionParams { typeDefinitionParamsTextDocument = parsedTextDocument
+                                 , typeDefinitionParamsPosition = parsedPosition
+                                 , typeDefinitionParamsWorkDoneToken = parsedWorkDoneToken
+                                 , typeDefinitionParamsPartialResultToken = parsedPartialResultToken }
       _ -> Left ("Unrecognized TypeDefinitionParams value: " ++ ppJSON j)
 
-data TypeDefinitionParams = TypeDefinitionParams {  }
+data TypeDefinitionParams = TypeDefinitionParams { typeDefinitionParamsTextDocument :: TextDocumentIdentifier
+                                                 , typeDefinitionParamsPosition :: Position
+                                                 , typeDefinitionParamsWorkDoneToken :: Maybe ProgressToken
+                                                 , typeDefinitionParamsPartialResultToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeDefinitionRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TypeDefinitionRegistrationOptions.curry
@@ -4,17 +4,27 @@ module LSP.Protocol.Types.TypeDefinitionRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON TypeDefinitionRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeDefinitionRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            TypeDefinitionRegistrationOptions { typeDefinitionRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                              , typeDefinitionRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                              , typeDefinitionRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized TypeDefinitionRegistrationOptions value: "
            ++ ppJSON j)
 
-data TypeDefinitionRegistrationOptions = TypeDefinitionRegistrationOptions {  }
+data TypeDefinitionRegistrationOptions = TypeDefinitionRegistrationOptions { typeDefinitionRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                           , typeDefinitionRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                           , typeDefinitionRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeHierarchyOptions.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyOptions.curry
@@ -9,9 +9,12 @@ import LSP.Utils.JSON
 instance FromJSON TypeHierarchyOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeHierarchyOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           return
+            TypeHierarchyOptions { typeHierarchyOptionsWorkDoneProgress = parsedWorkDoneProgress }
       _ -> Left ("Unrecognized TypeHierarchyOptions value: " ++ ppJSON j)
 
-data TypeHierarchyOptions = TypeHierarchyOptions {  }
+data TypeHierarchyOptions = TypeHierarchyOptions { typeHierarchyOptionsWorkDoneProgress :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeHierarchyPrepareParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyPrepareParams.curry
@@ -4,15 +4,27 @@ module LSP.Protocol.Types.TypeHierarchyPrepareParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.Position
+import LSP.Protocol.Types.ProgressToken
+import LSP.Protocol.Types.TextDocumentIdentifier
 import LSP.Utils.JSON
 
 instance FromJSON TypeHierarchyPrepareParams where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeHierarchyPrepareParams {  }
+      JObject vs ->
+        do parsedTextDocument <- lookupFromJSON "textDocument" vs
+           parsedPosition <- lookupFromJSON "position" vs
+           parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           return
+            TypeHierarchyPrepareParams { typeHierarchyPrepareParamsTextDocument = parsedTextDocument
+                                       , typeHierarchyPrepareParamsPosition = parsedPosition
+                                       , typeHierarchyPrepareParamsWorkDoneToken = parsedWorkDoneToken }
       _ ->
         Left ("Unrecognized TypeHierarchyPrepareParams value: " ++ ppJSON j)
 
-data TypeHierarchyPrepareParams = TypeHierarchyPrepareParams {  }
+data TypeHierarchyPrepareParams = TypeHierarchyPrepareParams { typeHierarchyPrepareParamsTextDocument :: TextDocumentIdentifier
+                                                             , typeHierarchyPrepareParamsPosition :: Position
+                                                             , typeHierarchyPrepareParamsWorkDoneToken :: Maybe ProgressToken }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeHierarchyRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchyRegistrationOptions.curry
@@ -4,16 +4,26 @@ module LSP.Protocol.Types.TypeHierarchyRegistrationOptions where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.DocumentSelector
 import LSP.Utils.JSON
 
 instance FromJSON TypeHierarchyRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return TypeHierarchyRegistrationOptions {  }
+      JObject vs ->
+        do parsedDocumentSelector <- lookupFromJSON "documentSelector" vs
+           parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedId <- lookupMaybeFromJSON "id" vs
+           return
+            TypeHierarchyRegistrationOptions { typeHierarchyRegistrationOptionsDocumentSelector = parsedDocumentSelector
+                                             , typeHierarchyRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                             , typeHierarchyRegistrationOptionsId = parsedId }
       _ ->
         Left
          ("Unrecognized TypeHierarchyRegistrationOptions value: " ++ ppJSON j)
 
-data TypeHierarchyRegistrationOptions = TypeHierarchyRegistrationOptions {  }
+data TypeHierarchyRegistrationOptions = TypeHierarchyRegistrationOptions { typeHierarchyRegistrationOptionsDocumentSelector :: Either DocumentSelector ()
+                                                                         , typeHierarchyRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                         , typeHierarchyRegistrationOptionsId :: Maybe String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeHierarchySubtypesParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchySubtypesParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.TypeHierarchySubtypesParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TypeHierarchyItem
 import LSP.Utils.JSON
 
@@ -11,12 +12,20 @@ instance FromJSON TypeHierarchySubtypesParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedItem <- lookupFromJSON "item" vs
            return
-            TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem = parsedItem }
+            TypeHierarchySubtypesParams { typeHierarchySubtypesParamsWorkDoneToken = parsedWorkDoneToken
+                                        , typeHierarchySubtypesParamsPartialResultToken = parsedPartialResultToken
+                                        , typeHierarchySubtypesParamsItem = parsedItem }
       _ ->
         Left ("Unrecognized TypeHierarchySubtypesParams value: " ++ ppJSON j)
 
-data TypeHierarchySubtypesParams = TypeHierarchySubtypesParams { typeHierarchySubtypesParamsItem :: TypeHierarchyItem }
+data TypeHierarchySubtypesParams = TypeHierarchySubtypesParams { typeHierarchySubtypesParamsWorkDoneToken :: Maybe ProgressToken
+                                                               , typeHierarchySubtypesParamsPartialResultToken :: Maybe ProgressToken
+                                                               , typeHierarchySubtypesParamsItem :: TypeHierarchyItem }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/TypeHierarchySupertypesParams.curry
+++ b/src/LSP/Protocol/Types/TypeHierarchySupertypesParams.curry
@@ -4,6 +4,7 @@ module LSP.Protocol.Types.TypeHierarchySupertypesParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Protocol.Types.TypeHierarchyItem
 import LSP.Utils.JSON
 
@@ -11,13 +12,21 @@ instance FromJSON TypeHierarchySupertypesParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedItem <- lookupFromJSON "item" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedItem <- lookupFromJSON "item" vs
            return
-            TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem = parsedItem }
+            TypeHierarchySupertypesParams { typeHierarchySupertypesParamsWorkDoneToken = parsedWorkDoneToken
+                                          , typeHierarchySupertypesParamsPartialResultToken = parsedPartialResultToken
+                                          , typeHierarchySupertypesParamsItem = parsedItem }
       _ ->
         Left
          ("Unrecognized TypeHierarchySupertypesParams value: " ++ ppJSON j)
 
-data TypeHierarchySupertypesParams = TypeHierarchySupertypesParams { typeHierarchySupertypesParamsItem :: TypeHierarchyItem }
+data TypeHierarchySupertypesParams = TypeHierarchySupertypesParams { typeHierarchySupertypesParamsWorkDoneToken :: Maybe ProgressToken
+                                                                   , typeHierarchySupertypesParamsPartialResultToken :: Maybe ProgressToken
+                                                                   , typeHierarchySupertypesParamsItem :: TypeHierarchyItem }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/VersionedTextDocumentIdentifier.curry
+++ b/src/LSP/Protocol/Types/VersionedTextDocumentIdentifier.curry
@@ -4,19 +4,23 @@ module LSP.Protocol.Types.VersionedTextDocumentIdentifier where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Support
 import LSP.Utils.JSON
 
 instance FromJSON VersionedTextDocumentIdentifier where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedVersion <- lookupFromJSON "version" vs
+        do parsedUri <- lookupFromJSON "uri" vs
+           parsedVersion <- lookupFromJSON "version" vs
            return
-            VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion = parsedVersion }
+            VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierUri = parsedUri
+                                            , versionedTextDocumentIdentifierVersion = parsedVersion }
       _ ->
         Left
          ("Unrecognized VersionedTextDocumentIdentifier value: " ++ ppJSON j)
 
-data VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierVersion :: Int }
+data VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier { versionedTextDocumentIdentifierUri :: DocumentUri
+                                                                       , versionedTextDocumentIdentifierVersion :: Int }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceDiagnosticParams.curry
+++ b/src/LSP/Protocol/Types/WorkspaceDiagnosticParams.curry
@@ -5,20 +5,29 @@ module LSP.Protocol.Types.WorkspaceDiagnosticParams where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Types.PreviousResultId
+import LSP.Protocol.Types.ProgressToken
 import LSP.Utils.JSON
 
 instance FromJSON WorkspaceDiagnosticParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedIdentifier <- lookupMaybeFromJSON "identifier" vs
            parsedPreviousResultIds <- lookupFromJSON "previousResultIds" vs
            return
-            WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier = parsedIdentifier
+            WorkspaceDiagnosticParams { workspaceDiagnosticParamsWorkDoneToken = parsedWorkDoneToken
+                                      , workspaceDiagnosticParamsPartialResultToken = parsedPartialResultToken
+                                      , workspaceDiagnosticParamsIdentifier = parsedIdentifier
                                       , workspaceDiagnosticParamsPreviousResultIds = parsedPreviousResultIds }
       _ -> Left ("Unrecognized WorkspaceDiagnosticParams value: " ++ ppJSON j)
 
-data WorkspaceDiagnosticParams = WorkspaceDiagnosticParams { workspaceDiagnosticParamsIdentifier :: Maybe String
+data WorkspaceDiagnosticParams = WorkspaceDiagnosticParams { workspaceDiagnosticParamsWorkDoneToken :: Maybe ProgressToken
+                                                           , workspaceDiagnosticParamsPartialResultToken :: Maybe ProgressToken
+                                                           , workspaceDiagnosticParamsIdentifier :: Maybe String
                                                            , workspaceDiagnosticParamsPreviousResultIds :: [PreviousResultId] }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceFullDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceFullDocumentDiagnosticReport.curry
@@ -5,23 +5,33 @@ module LSP.Protocol.Types.WorkspaceFullDocumentDiagnosticReport where
 import JSON.Data
 import JSON.Pretty
 import LSP.Protocol.Support
+import LSP.Protocol.Types.Diagnostic
 import LSP.Utils.JSON
 
 instance FromJSON WorkspaceFullDocumentDiagnosticReport where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupMaybeFromJSON "resultId" vs
+           parsedItems <- lookupFromJSON "items" vs
+           parsedUri <- lookupFromJSON "uri" vs
            parsedVersion <- lookupFromJSON "version" vs
            return
-            WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri = parsedUri
+            WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportKind = parsedKind
+                                                  , workspaceFullDocumentDiagnosticReportResultId = parsedResultId
+                                                  , workspaceFullDocumentDiagnosticReportItems = parsedItems
+                                                  , workspaceFullDocumentDiagnosticReportUri = parsedUri
                                                   , workspaceFullDocumentDiagnosticReportVersion = parsedVersion }
       _ ->
         Left
          ("Unrecognized WorkspaceFullDocumentDiagnosticReport value: "
            ++ ppJSON j)
 
-data WorkspaceFullDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportUri :: DocumentUri
+data WorkspaceFullDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticReport { workspaceFullDocumentDiagnosticReportKind :: String
+                                                                                   , workspaceFullDocumentDiagnosticReportResultId :: Maybe String
+                                                                                   , workspaceFullDocumentDiagnosticReportItems :: [Diagnostic]
+                                                                                   , workspaceFullDocumentDiagnosticReportUri :: DocumentUri
                                                                                    , workspaceFullDocumentDiagnosticReportVersion :: Either Int () }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceSymbol.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbol.curry
@@ -7,20 +7,34 @@ import JSON.Pretty
 import LSP.Protocol.Support
 import LSP.Protocol.Types.Location
 import LSP.Protocol.Types.LocationUriOnly
+import LSP.Protocol.Types.SymbolKind
+import LSP.Protocol.Types.SymbolTag
 import LSP.Utils.JSON
 
 instance FromJSON WorkspaceSymbol where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedLocation <- lookupFromJSON "location" vs
+        do parsedName <- lookupFromJSON "name" vs
+           parsedKind <- lookupFromJSON "kind" vs
+           parsedTags <- lookupMaybeFromJSON "tags" vs
+           parsedContainerName <- lookupMaybeFromJSON "containerName" vs
+           parsedLocation <- lookupFromJSON "location" vs
            parsedData <- lookupMaybeFromJSON "data" vs
            return
-            WorkspaceSymbol { workspaceSymbolLocation = parsedLocation
+            WorkspaceSymbol { workspaceSymbolName = parsedName
+                            , workspaceSymbolKind = parsedKind
+                            , workspaceSymbolTags = parsedTags
+                            , workspaceSymbolContainerName = parsedContainerName
+                            , workspaceSymbolLocation = parsedLocation
                             , workspaceSymbolData = parsedData }
       _ -> Left ("Unrecognized WorkspaceSymbol value: " ++ ppJSON j)
 
-data WorkspaceSymbol = WorkspaceSymbol { workspaceSymbolLocation :: Either Location LocationUriOnly
+data WorkspaceSymbol = WorkspaceSymbol { workspaceSymbolName :: String
+                                       , workspaceSymbolKind :: SymbolKind
+                                       , workspaceSymbolTags :: Maybe [SymbolTag]
+                                       , workspaceSymbolContainerName :: Maybe String
+                                       , workspaceSymbolLocation :: Either Location LocationUriOnly
                                        , workspaceSymbolData :: Maybe LSPAny }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceSymbolOptions.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolOptions.curry
@@ -10,11 +10,14 @@ instance FromJSON WorkspaceSymbolOptions where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
            return
-            WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider = parsedResolveProvider }
+            WorkspaceSymbolOptions { workspaceSymbolOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                   , workspaceSymbolOptionsResolveProvider = parsedResolveProvider }
       _ -> Left ("Unrecognized WorkspaceSymbolOptions value: " ++ ppJSON j)
 
-data WorkspaceSymbolOptions = WorkspaceSymbolOptions { workspaceSymbolOptionsResolveProvider :: Maybe Bool }
+data WorkspaceSymbolOptions = WorkspaceSymbolOptions { workspaceSymbolOptionsWorkDoneProgress :: Maybe Bool
+                                                     , workspaceSymbolOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceSymbolParams.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolParams.curry
@@ -4,17 +4,26 @@ module LSP.Protocol.Types.WorkspaceSymbolParams where
 
 import JSON.Data
 import JSON.Pretty
+import LSP.Protocol.Types.ProgressToken
 import LSP.Utils.JSON
 
 instance FromJSON WorkspaceSymbolParams where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedQuery <- lookupFromJSON "query" vs
+        do parsedWorkDoneToken <- lookupMaybeFromJSON "workDoneToken" vs
+           parsedPartialResultToken <- lookupMaybeFromJSON
+                                        "partialResultToken"
+                                        vs
+           parsedQuery <- lookupFromJSON "query" vs
            return
-            WorkspaceSymbolParams { workspaceSymbolParamsQuery = parsedQuery }
+            WorkspaceSymbolParams { workspaceSymbolParamsWorkDoneToken = parsedWorkDoneToken
+                                  , workspaceSymbolParamsPartialResultToken = parsedPartialResultToken
+                                  , workspaceSymbolParamsQuery = parsedQuery }
       _ -> Left ("Unrecognized WorkspaceSymbolParams value: " ++ ppJSON j)
 
-data WorkspaceSymbolParams = WorkspaceSymbolParams { workspaceSymbolParamsQuery :: String }
+data WorkspaceSymbolParams = WorkspaceSymbolParams { workspaceSymbolParamsWorkDoneToken :: Maybe ProgressToken
+                                                   , workspaceSymbolParamsPartialResultToken :: Maybe ProgressToken
+                                                   , workspaceSymbolParamsQuery :: String }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceSymbolRegistrationOptions.curry
+++ b/src/LSP/Protocol/Types/WorkspaceSymbolRegistrationOptions.curry
@@ -9,12 +9,18 @@ import LSP.Utils.JSON
 instance FromJSON WorkspaceSymbolRegistrationOptions where
   fromJSON j =
     case j of
-      JObject vs -> do return WorkspaceSymbolRegistrationOptions {  }
+      JObject vs ->
+        do parsedWorkDoneProgress <- lookupMaybeFromJSON "workDoneProgress" vs
+           parsedResolveProvider <- lookupMaybeFromJSON "resolveProvider" vs
+           return
+            WorkspaceSymbolRegistrationOptions { workspaceSymbolRegistrationOptionsWorkDoneProgress = parsedWorkDoneProgress
+                                               , workspaceSymbolRegistrationOptionsResolveProvider = parsedResolveProvider }
       _ ->
         Left
          ("Unrecognized WorkspaceSymbolRegistrationOptions value: "
            ++ ppJSON j)
 
-data WorkspaceSymbolRegistrationOptions = WorkspaceSymbolRegistrationOptions {  }
+data WorkspaceSymbolRegistrationOptions = WorkspaceSymbolRegistrationOptions { workspaceSymbolRegistrationOptionsWorkDoneProgress :: Maybe Bool
+                                                                             , workspaceSymbolRegistrationOptionsResolveProvider :: Maybe Bool }
  deriving (Show,Eq)
 

--- a/src/LSP/Protocol/Types/WorkspaceUnchangedDocumentDiagnosticReport.curry
+++ b/src/LSP/Protocol/Types/WorkspaceUnchangedDocumentDiagnosticReport.curry
@@ -11,17 +11,23 @@ instance FromJSON WorkspaceUnchangedDocumentDiagnosticReport where
   fromJSON j =
     case j of
       JObject vs ->
-        do parsedUri <- lookupFromJSON "uri" vs
+        do parsedKind <- lookupFromJSON "kind" vs
+           parsedResultId <- lookupFromJSON "resultId" vs
+           parsedUri <- lookupFromJSON "uri" vs
            parsedVersion <- lookupFromJSON "version" vs
            return
-            WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri = parsedUri
+            WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportKind = parsedKind
+                                                       , workspaceUnchangedDocumentDiagnosticReportResultId = parsedResultId
+                                                       , workspaceUnchangedDocumentDiagnosticReportUri = parsedUri
                                                        , workspaceUnchangedDocumentDiagnosticReportVersion = parsedVersion }
       _ ->
         Left
          ("Unrecognized WorkspaceUnchangedDocumentDiagnosticReport value: "
            ++ ppJSON j)
 
-data WorkspaceUnchangedDocumentDiagnosticReport = WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportUri :: DocumentUri
+data WorkspaceUnchangedDocumentDiagnosticReport = WorkspaceUnchangedDocumentDiagnosticReport { workspaceUnchangedDocumentDiagnosticReportKind :: String
+                                                                                             , workspaceUnchangedDocumentDiagnosticReportResultId :: String
+                                                                                             , workspaceUnchangedDocumentDiagnosticReportUri :: DocumentUri
                                                                                              , workspaceUnchangedDocumentDiagnosticReportVersion :: Either Int () }
  deriving (Show,Eq)
 

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -5,7 +5,7 @@ module LSP.Utils.General
   , capitalize, uncapitalize
   , replace, replaceSingle
   , unions, unionMap
-  , (<.$>), (<$.>)
+  , (<.$>), (<$.>), (<<$>>)
   , keyBy
   ) where
 
@@ -79,6 +79,10 @@ unionMap f = unions . map f
 -- | Maps over the second element of a tuple.
 (<$.>) :: Functor f => (b -> c) -> f (a, b) -> f (a, c)
 (<$.>) f = ((\(x, y) -> (x, f y)) <$>)
+
+-- | Map over nested functors. Alias for `fmap . fmap` (or `fmap fmap fmap`).
+(<<$>>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
+(<<$>>) = fmap . fmap
 
 -- | Associates the given value with the given key.
 keyBy :: (a -> k) -> a -> (k, a)

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -6,7 +6,7 @@ module LSP.Utils.General
   , replace, replaceSingle
   , unions, unionMap
   , (<.$>), (<$.>), (<<$>>)
-  , keyBy, nubOrdOn
+  , keyOn, nubOrdOn
   ) where
 
 import Data.Char ( toUpper, toLower )
@@ -85,8 +85,8 @@ unionMap f = unions . map f
 (<<$>>) = fmap . fmap
 
 -- | Associates the given value with the given key.
-keyBy :: (a -> k) -> a -> (k, a)
-keyBy f x = (f x, x)
+keyOn :: (a -> k) -> a -> (k, a)
+keyOn f x = (f x, x)
 
 -- Source: https://hackage.haskell.org/package/containers-0.7/docs/src/Data.Containers.ListUtils.html#nubOrdOn
 -- License: BSD-style ((c) Gershom Bazerman 2018)

--- a/src/LSP/Utils/General.curry
+++ b/src/LSP/Utils/General.curry
@@ -6,7 +6,7 @@ module LSP.Utils.General
   , replace, replaceSingle
   , unions, unionMap
   , (<.$>), (<$.>), (<<$>>)
-  , keyBy
+  , keyBy, nubOrdOn
   ) where
 
 import Data.Char ( toUpper, toLower )
@@ -87,3 +87,19 @@ unionMap f = unions . map f
 -- | Associates the given value with the given key.
 keyBy :: (a -> k) -> a -> (k, a)
 keyBy f x = (f x, x)
+
+-- Source: https://hackage.haskell.org/package/containers-0.7/docs/src/Data.Containers.ListUtils.html#nubOrdOn
+-- License: BSD-style ((c) Gershom Bazerman 2018)
+
+-- | Removes duplicates from the given list by comparing the values after the given projection.
+nubOrdOn :: Ord k => (a -> k) -> [a] -> [a]
+nubOrdOn f xs = nubOrdOnExcluding f S.empty xs
+
+nubOrdOnExcluding :: Ord k => (a -> k) -> S.Set k -> [a] -> [a]
+nubOrdOnExcluding f = go
+  where
+    go _ [] = []
+    go s (x:xs)
+      | fx `S.member` s = go s xs
+      | otherwise = x : go (S.insert fx s) xs
+      where fx = f x


### PR DESCRIPTION
### Fixes #7 

This updates the generator to flatten meta structures before generating Curry types from them.