### PR TITLE
Generate `ToJSON` instances

### DIFF
--- a/src/LSP/Generation/Generator.curry
+++ b/src/LSP/Generation/Generator.curry
@@ -131,7 +131,7 @@ metaEnumerationToProg e = do
       imps = requiredImports mname $ S.union (typeDeclModuleDeps ty) (unionMap instanceDeclModuleDeps insts)
   return $ AC.CurryProg mname [] imps Nothing [] insts [ty] [] []
 
--- | Converts a meta structure to a FromJSON instance.
+-- | Converts a flattened meta structure to a FromJSON instance.
 flatMetaStructureToFromJSONInstance :: String -> String -> MetaStructure -> GM AC.CInstanceDecl
 flatMetaStructureToFromJSONInstance mname prefix s' = do
   let name = escapeName $ msName s'
@@ -164,6 +164,11 @@ flatMetaStructureToFromJSONInstance mname prefix s' = do
       fdecl = AC.CFunc fromJSONQName 1 vis sig [rule]
       fdecls = [fdecl]
   return $ AC.CInstance fromJSONClassQName ctx texp fdecls
+
+-- | Converts a flattened meta structure to a ToJSON instance.
+flatMetaStructureToToJSONInstance :: String -> String -> MetaStructure -> GM AC.CInstanceDecl
+flatMetaStructureToToJSONInstance mname prefix s' = do
+  -- TODO
 
 -- | Picks the correct lookupFromJSON method for the given property.
 lookupFromJSONForMetaProperty :: MetaProperty -> AC.QName

--- a/src/LSP/Utils/JSON.curry
+++ b/src/LSP/Utils/JSON.curry
@@ -4,6 +4,7 @@ module LSP.Utils.JSON
   , stringFromJSON, arrayFromJSON, objectFromJSON, maybeFromJSON, boolFromJSON, integralFromJSON, fractionalFromJSON
   , lookupFromJSON, lookupObjectFromJSON, lookupMaybeFromJSON
   , lookupPathFromJSON
+  , (.=), (.?=), (<#>)
   ) where
 
 import qualified Data.Map as M
@@ -198,3 +199,19 @@ lookupMaybeFromJSON :: FromJSON a => String -> [(String, JValue)] -> Either Stri
 lookupMaybeFromJSON k vs = case lookup k vs of
   Just x  -> fromJSON x
   Nothing -> Right Nothing
+
+-- Constructs a JSON object with a single key-value pair.
+(.=) :: ToJSON a => String -> a -> JValue
+(.=) k v = JObject [(k, toJSON v)]
+
+-- Constructs a JSON object with a single optional key-value pair.
+(.?=) :: ToJSON a => String -> Maybe a -> JValue
+(.?=) k v = JObject $ case v of
+  Just v' -> [(k, toJSON v')]
+  Nothing -> []
+
+-- Combines JSON objects.
+(<#>) :: JValue -> JValue -> JValue
+(<#>) v1 v2 = case (v1, v2) of
+  (JObject kvs1, JObject kvs2) -> JObject (kvs1 ++ kvs2)
+  _ -> error $ "(<#>) requires two JObjects, but got " ++ show v1 ++ ", " ++ show v2

--- a/src/LSP/Utils/JSON.curry
+++ b/src/LSP/Utils/JSON.curry
@@ -44,11 +44,20 @@ class ToJSON a where
 instance FromJSON Bool where
   fromJSON = boolFromJSON
 
+instance ToJSON Bool where
+  toJSON = boolToJSON
+
 instance FromJSON Int where
   fromJSON = integralFromJSON
 
+instance ToJSON Int where
+  toJSON = integralToJSON
+
 instance FromJSON Float where
   fromJSON = fractionalFromJSON
+
+instance ToJSON Float where
+  toJSON = realToJSON
 
 instance FromJSON a => FromJSON [a] where
   fromJSON = listFromJSON
@@ -117,17 +126,31 @@ boolFromJSON j = case j of
   JFalse -> Right False
   _ -> Left $ "Expected boolean but was: " ++ ppJSON j
 
+-- Converts a boolean value to JSON.
+boolToJSON :: Bool -> JValue
+boolToJSON b = case b of
+  False -> JFalse
+  True -> JTrue
+
 -- Parses an integral value from JSON.
 integralFromJSON :: Integral a => JValue -> Either String a
 integralFromJSON j = case j of
   JNumber f -> Right $ round f
   _ -> Left $ "Expected integral but was: " ++ ppJSON j
 
+-- Converts an integral value to JSON.
+integralToJSON :: Integral a => a -> JValue
+integralToJSON x = JNumber (toFloat x)
+
 -- Parses a fractional value from JSON.
 fractionalFromJSON :: Fractional a => JValue -> Either String a
 fractionalFromJSON j = case j of
   JNumber f -> Right $ fromFloat f
   _ -> Left $ "Expected fractional but was: " ++ ppJSON j
+
+-- Converts a real value to JSON.
+realToJSON :: Real a => a -> JValue
+realToJSON x = JNumber (toFloat x)
 
 -- Parses a string from JSON.
 stringFromJSON :: JValue -> Either String String
@@ -199,6 +222,9 @@ lookupMaybeFromJSON :: FromJSON a => String -> [(String, JValue)] -> Either Stri
 lookupMaybeFromJSON k vs = case lookup k vs of
   Just x  -> fromJSON x
   Nothing -> Right Nothing
+
+infixr 8 .=, .?=
+infixr 4 <#>
 
 -- Constructs a JSON object with a single key-value pair.
 (.=) :: ToJSON a => String -> a -> JValue

--- a/src/LSP/Utils/JSON.curry
+++ b/src/LSP/Utils/JSON.curry
@@ -244,5 +244,6 @@ infixr 4 <#>
   _ -> error $ "(<#>) requires two JObjects, but got " ++ show v1 ++ ", " ++ show v2
 
 -- Flattens a list of objects (e.g. key value pairs created with (.=)).
+-- Discards any values that are not objects.
 object :: [JValue] -> JValue
 object vs = JObject [kv | JObject kvs <- vs, kv <- kvs]

--- a/src/LSP/Utils/JSON.curry
+++ b/src/LSP/Utils/JSON.curry
@@ -5,6 +5,7 @@ module LSP.Utils.JSON
   , lookupFromJSON, lookupObjectFromJSON, lookupMaybeFromJSON
   , lookupPathFromJSON
   , (.=), (.?=), (<#>)
+  , object
   ) where
 
 import qualified Data.Map as M
@@ -241,3 +242,7 @@ infixr 4 <#>
 (<#>) v1 v2 = case (v1, v2) of
   (JObject kvs1, JObject kvs2) -> JObject (kvs1 ++ kvs2)
   _ -> error $ "(<#>) requires two JObjects, but got " ++ show v1 ++ ", " ++ show v2
+
+-- Flattens a list of objects (e.g. key value pairs created with (.=)).
+object :: [JValue] -> JValue
+object vs = JObject [kv | JObject kvs <- vs, kv <- kvs]


### PR DESCRIPTION
This implements the generation of `ToJSON` instances for the LSP types, enabling them to be serialized back to JSON, e.g. for creating responses.